### PR TITLE
[TRK-111] Add OMF (Open Mining Format) interop for drilling primitives

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -60,6 +60,7 @@ export default defineConfig({
             { text: 'Data Loading', link: '/guide/python#data-loading' },
             { text: 'Desurveying', link: '/guide/python#desurveying' },
             { text: 'Database Validation', link: '/guide/python#database-validation' },
+            { text: 'OMF interop', link: '/guide/python#omf-interop-open-mining-format' },
             { text: 'Interval Algebra', link: '/guide/python#interval-algebra' },
             { text: 'Visualization', link: '/guide/python#visualization' },
             { text: 'Plotly Templates', link: '/guide/python#plotly-templates' },

--- a/docs/api/python.md
+++ b/docs/api/python.md
@@ -346,6 +346,98 @@ merged = intervals.merge_tables({"assay": assays, "litho": geology})
 
 ---
 
+## baselode.drill.omf
+
+Open Mining Format (OMF v1) interop.  OMF is the de-facto open mining interchange format (MIT-licensed, Global Mining Guidelines Group), supported by Leapfrog, 3DEXPERIENCE, Deswik and Micromine.  Baselode being OMF-native plugs it directly into those workflows.
+
+Optional dependency — install via `pip install baselode[omf]`.
+
+```python
+import baselode.drill.omf as omf_io
+```
+
+JavaScript support is deferred per TRK-111 scope — consume read-side via Python until a JS need lands.
+
+---
+
+### collars_to_omf_points
+
+```python
+collars_to_omf_points(
+    collars,
+    name="collars",
+    hole_col=HOLE_ID,
+    easting_col=EASTING,
+    northing_col=NORTHING,
+    elevation_col=ELEVATION,
+    attribute_cols=None,
+)
+```
+
+Convert a collar table to an OMF `PointSetElement`.  Vertices are `(easting, northing, elevation)`; rows with missing xyz are dropped.  `hole_id` is attached as per-vertex `StringData`.  Any extra columns in `attribute_cols` are attached as `ScalarData` (numeric dtype) or `StringData` (object dtype).
+
+**Returns:** `omf.PointSetElement`
+
+---
+
+### traces_to_omf_lines
+
+```python
+traces_to_omf_lines(
+    traces,
+    name="traces",
+    hole_col=HOLE_ID,
+    easting_col=EASTING,
+    northing_col=NORTHING,
+    elevation_col=ELEVATION,
+    md_col="md",
+)
+```
+
+Convert desurveyed traces to a single OMF `LineSetElement`.  Each hole contributes a sequence of segments connecting consecutive trace samples (sorted by `md_col`); holes are concatenated into one element with a per-segment `hole_id` so they're individually selectable downstream without forcing a 4 000-element project.  Holes with fewer than two trace samples are skipped.
+
+**Returns:** `omf.LineSetElement`
+
+---
+
+### intervals_to_omf_lines
+
+```python
+intervals_to_omf_lines(
+    intervals,
+    traces,
+    name,
+    value_cols=None,
+    hole_col=HOLE_ID,
+    from_col=FROM,
+    to_col=TO,
+    easting_col=EASTING,
+    northing_col=NORTHING,
+    elevation_col=ELEVATION,
+    md_col="md",
+)
+```
+
+Convert an interval table (assay, geology, etc.) to a single OMF `LineSetElement` with one segment per interval.  Endpoints are interpolated from the trace at the interval's `from_col` / `to_col` depths.  Value columns become per-segment `ScalarData` (numeric) or `StringData` (categorical); `hole_id` is always attached.
+
+Rows whose hole isn't in `traces` are skipped silently; rows with non-numeric `from` / `to` are skipped silently.
+
+**Returns:** `omf.LineSetElement`
+
+---
+
+### build_omf_project / write_omf / read_omf
+
+```python
+project = build_omf_project(name, author, description, elements)
+write_omf(project_or_elements, path, name="baselode", author="baselode", description="")
+project = read_omf(path)
+```
+
+`write_omf` accepts either an `omf.Project` directly or a list of elements (in which case it wraps them via `build_omf_project` using the `name` / `author` / `description` kwargs).  Returns the project that was serialised.
+
+---
+
 ## baselode.drill.validate
 
 QA/QC helpers for drillhole tables.  The headline entry point is `validate_drillhole_db`, which runs every check in one pass and returns a structured report.

--- a/docs/guide/python.md
+++ b/docs/guide/python.md
@@ -283,6 +283,50 @@ report = validate.validate_drillhole_db(collar, survey, allow_full_circle=True)
 
 ---
 
+## OMF interop (Open Mining Format)
+
+`baselode.drill.omf` round-trips drilling tables through Open Mining Format v1, the MIT-licensed mining interchange format read/written by Leapfrog, 3DEXPERIENCE, Deswik and Micromine.
+
+Install the optional extra:
+
+```bash
+pip install baselode[omf]
+```
+
+```python
+import baselode.drill.omf as omf_io
+import baselode.drill.data as drill
+import baselode.drill.desurvey as desurvey
+
+collars = drill.load_collars("collars.csv")
+surveys = drill.load_surveys("surveys.csv")
+assays  = drill.load_assays("assays.csv")
+traces  = desurvey.minimum_curvature_desurvey(collars, surveys, step=1.0)
+
+collar_element = omf_io.collars_to_omf_points(collars, attribute_cols=["max_depth"])
+trace_element  = omf_io.traces_to_omf_lines(traces)
+assay_element  = omf_io.intervals_to_omf_lines(
+    assays, traces, name="assay", value_cols=["au_ppm", "lithology"],
+)
+
+omf_io.write_omf(
+    [collar_element, trace_element, assay_element],
+    "project.omf",
+    name="my-project", author="agent", description="example",
+)
+```
+
+The output is a single `.omf` file that opens directly in any OMF-compatible viewer.  Read it back with `omf_io.read_omf(path)` (returns an `omf.Project`).
+
+### Design notes
+
+- Each call returns one OMF element, not a per-hole element — segments carry a `hole_id` attribute so downstream tools can still select per hole without a 4 000-element project.
+- For interval lines, endpoints are interpolated from the trace at the interval's `from` / `to` depths.  Rows whose hole isn't in the trace are skipped silently.
+- Collar positions need projected `easting`/`northing` columns — for collars carrying only lat/lon, project them to your local CRS first (e.g. via `baselode.extent.Extent.to_crs`) or derive collar positions from the first sample of each trace.
+- JavaScript OMF support is deferred — consume read-side via Python until a JS need lands.
+
+---
+
 ## Interval Algebra
 
 `baselode.drill.intervals` provides pure from-to interval primitives that the higher-level compositing, validation, and DB-container modules build on.  Every function operates on a pandas `DataFrame` keyed by `hole_id`, `from`, `to` (the canonical columns from `baselode.datamodel`).

--- a/notebooks/example_omf_export.ipynb
+++ b/notebooks/example_omf_export.ipynb
@@ -1,0 +1,147 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# OMF export — GSWA sample data\n",
+    "\n",
+    "Round-trip a subset of the GSWA sample data through Open Mining Format (OMF v1), the MIT-licensed mining interchange format read/written by Leapfrog, 3DEXPERIENCE, Deswik and Micromine.\n",
+    "\n",
+    "Requires the optional extra:\n",
+    "\n",
+    "```bash\n",
+    "pip install baselode[omf]\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import baselode.drill.data as drill\n",
+    "import baselode.drill.desurvey as desurvey\n",
+    "import baselode.drill.omf as omf_io\n",
+    "\n",
+    "DATA = '../test/data/gswa'\n",
+    "collars = drill.load_collars(f'{DATA}/gswa_sample_collars.csv')\n",
+    "surveys = drill.load_surveys(f'{DATA}/gswa_sample_survey.csv')\n",
+    "assays = drill.load_assays(f'{DATA}/gswa_sample_assays.csv')\n",
+    "\n",
+    "# Pick the first 20 holes with at least 2 survey stations\n",
+    "counts = surveys['hole_id'].value_counts()\n",
+    "sample_holes = counts[counts >= 2].head(20).index.tolist()\n",
+    "collars_sub = collars[collars['hole_id'].isin(sample_holes)]\n",
+    "surveys_sub = surveys[surveys['hole_id'].isin(sample_holes)]\n",
+    "assays_sub = assays[assays['hole_id'].isin(sample_holes)]\n",
+    "\n",
+    "len(collars_sub), len(surveys_sub), len(assays_sub)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Desurvey the holes\n",
+    "\n",
+    "OMF needs projected `(easting, northing, elevation)` coords.  Desurvey produces them as a side effect."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "traces = desurvey.minimum_curvature_desurvey(collars_sub, surveys_sub, step=5.0)\n",
+    "traces.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Build the OMF elements\n",
+    "\n",
+    "GSWA collars only carry lat/lon, so derive collar positions from the head of each trace.  In a real project you'd typically project the collar table to a working CRS first via `baselode.extent.Extent.to_crs`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "collar_xyz = (\n",
+    "    traces.sort_values('md')\n",
+    "          .groupby('hole_id')\n",
+    "          .first()\n",
+    "          .reset_index()\n",
+    "          [['hole_id', 'easting', 'northing', 'elevation']]\n",
+    "          .merge(collars_sub[['hole_id', 'maxdepth']].rename(columns={'maxdepth': 'max_depth'}), on='hole_id')\n",
+    ")\n",
+    "\n",
+    "collar_el = omf_io.collars_to_omf_points(collar_xyz, attribute_cols=['max_depth'])\n",
+    "trace_el = omf_io.traces_to_omf_lines(traces)\n",
+    "\n",
+    "# Pick a handful of assay columns to attach as per-segment data\n",
+    "assay_value_cols = [c for c in assays_sub.columns\n",
+    "                     if c not in ('hole_id','from','to','mid','datasource_hole_id','sample_id','extra')][:4]\n",
+    "assay_el = omf_io.intervals_to_omf_lines(\n",
+    "    assays_sub, traces, name='assay', value_cols=assay_value_cols,\n",
+    ")\n",
+    "\n",
+    "{\n",
+    "    'collar vertices': collar_el.geometry.vertices.array.shape,\n",
+    "    'trace vertices':  trace_el.geometry.vertices.array.shape,\n",
+    "    'trace segments':  trace_el.geometry.segments.array.shape,\n",
+    "    'assay segments':  assay_el.geometry.segments.array.shape,\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Write and read back"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "path = Path('/tmp/gswa-subset.omf')\n",
+    "omf_io.write_omf(\n",
+    "    [collar_el, trace_el, assay_el],\n",
+    "    path,\n",
+    "    name='gswa-subset',\n",
+    "    author='baselode',\n",
+    "    description='GSWA 20-hole subset',\n",
+    ")\n",
+    "print(f'{path}: {path.stat().st_size / 1024:.1f} KB')\n",
+    "\n",
+    "project = omf_io.read_omf(path)\n",
+    "[(el.name, type(el).__name__) for el in project.elements]"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -37,7 +37,8 @@ viz = ["folium>=0.15"]
 sql = ["sqlalchemy>=2.0"]
 las = ["lasio>=0.31"]
 api = ["requests>=2.28"]
-all = ["folium>=0.15", "sqlalchemy>=2.0", "lasio>=0.31", "requests>=2.28"]
+omf = ["omf>=1.0,<2.0"]
+all = ["folium>=0.15", "sqlalchemy>=2.0", "lasio>=0.31", "requests>=2.28", "omf>=1.0,<2.0"]
 
 [project.urls]
 Homepage = "https://github.com/darkmine-oss/baselode"

--- a/python/src/baselode/drill/omf.py
+++ b/python/src/baselode/drill/omf.py
@@ -1,0 +1,347 @@
+# Copyright (C) 2026 Darkmine Pty Ltd
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Open Mining Format (OMF v1) interop for baselode drilling primitives.
+
+Round-trip helpers between baselode's DataFrame-based drilling tables and
+Open Mining Format v1 line/point elements.  OMF is the de-facto open
+mining exchange format (MIT-licensed, Global Mining Guidelines Group),
+read/written by Leapfrog, 3DEXPERIENCE, Deswik and Micromine, so making
+baselode OMF-native plugs it directly into those workflows.
+
+This module requires the optional ``omf`` dependency:
+
+    pip install baselode[omf]
+
+Each entry point raises a clear :class:`ImportError` with the install
+instruction when the package is missing.
+
+API
+---
+
+- :func:`collars_to_omf_points` — collar table → ``PointSetElement``.
+- :func:`traces_to_omf_lines` — desurveyed traces → ``LineSetElement``
+  with one segment per trace step and a per-segment ``hole_id``.
+- :func:`intervals_to_omf_lines` — interval table (e.g. assay, geology)
+  → ``LineSetElement`` with one segment per interval, endpoints
+  interpolated from the trace and value columns attached as per-segment
+  attributes.
+- :func:`build_omf_project` — build a Project wrapper around a list of
+  elements.
+- :func:`write_omf` / :func:`read_omf` — round-trip helpers.
+"""
+
+import numpy as np
+import pandas as pd
+
+from baselode.datamodel import (
+    EASTING, ELEVATION, FROM, HOLE_ID, NORTHING, TO,
+)
+
+try:
+    import omf as _omf
+except ImportError:
+    _omf = None
+
+
+def _require_omf():
+    if _omf is None:
+        raise ImportError(
+            "OMF support requires the optional 'omf' package. "
+            "Install it via: pip install baselode[omf]"
+        )
+
+
+def collars_to_omf_points(
+    collars,
+    name="collars",
+    hole_col=HOLE_ID,
+    easting_col=EASTING,
+    northing_col=NORTHING,
+    elevation_col=ELEVATION,
+    attribute_cols=None,
+):
+    """Convert a collar table to an OMF :class:`PointSetElement`.
+
+    Each row becomes one vertex at ``(easting, northing, elevation)``.
+    The ``hole_id`` column is attached as a per-vertex
+    :class:`StringData`.  Any extra columns listed in *attribute_cols*
+    are attached as :class:`ScalarData` (numeric) or :class:`StringData`
+    (object dtype).
+
+    Parameters
+    ----------
+    collars : pd.DataFrame
+        Collar table.  Rows with missing easting / northing / elevation
+        are dropped.
+    name : str
+        OMF element name (default ``"collars"``).
+    hole_col, easting_col, northing_col, elevation_col : str
+        Column-name overrides (defaults from :mod:`baselode.datamodel`).
+    attribute_cols : iterable of str, optional
+        Extra columns to attach as per-vertex data.
+
+    Returns
+    -------
+    omf.PointSetElement
+    """
+    _require_omf()
+    required = [easting_col, northing_col, elevation_col]
+    valid = collars.dropna(subset=required)
+    vertices = valid[required].to_numpy(dtype=float)
+    geometry = _omf.PointSetGeometry(vertices=vertices)
+
+    data = []
+    if hole_col in valid.columns:
+        data.append(_omf.StringData(
+            name=hole_col,
+            array=[str(value) for value in valid[hole_col].tolist()],
+            location="vertices",
+        ))
+    for col in attribute_cols or []:
+        if col not in valid.columns:
+            continue
+        data.append(_column_to_data(valid[col], col, "vertices"))
+
+    return _omf.PointSetElement(name=name, geometry=geometry, data=data)
+
+
+def traces_to_omf_lines(
+    traces,
+    name="traces",
+    hole_col=HOLE_ID,
+    easting_col=EASTING,
+    northing_col=NORTHING,
+    elevation_col=ELEVATION,
+    md_col="md",
+):
+    """Convert desurveyed traces to a single OMF :class:`LineSetElement`.
+
+    Each hole contributes a sequence of segments connecting consecutive
+    trace samples.  Holes are concatenated into one element with a
+    per-segment ``hole_id`` :class:`StringData` so they're individually
+    selectable downstream without forcing a 4 000-element project.
+
+    Parameters
+    ----------
+    traces : pd.DataFrame
+        Desurveyed trace table (e.g. from
+        ``baselode.drill.desurvey.minimum_curvature_desurvey``).
+    name : str
+        OMF element name (default ``"traces"``).
+    hole_col, easting_col, northing_col, elevation_col, md_col : str
+        Column-name overrides.
+
+    Returns
+    -------
+    omf.LineSetElement
+    """
+    _require_omf()
+    vertices = []
+    segments = []
+    segment_hole_ids = []
+
+    for hole_id, group in traces.groupby(hole_col):
+        ordered = group.sort_values(md_col)
+        xyz = ordered[[easting_col, northing_col, elevation_col]].to_numpy(dtype=float)
+        if len(xyz) < 2:
+            continue
+        base_index = len(vertices)
+        vertices.extend(xyz.tolist())
+        for offset in range(len(xyz) - 1):
+            segments.append([base_index + offset, base_index + offset + 1])
+            segment_hole_ids.append(str(hole_id))
+
+    if not segments:
+        raise ValueError("No hole has at least two trace samples — nothing to write.")
+
+    geometry = _omf.LineSetGeometry(
+        vertices=np.array(vertices, dtype=float),
+        segments=np.array(segments, dtype=int),
+    )
+    data = [_omf.StringData(
+        name=hole_col, array=segment_hole_ids, location="segments",
+    )]
+    return _omf.LineSetElement(name=name, geometry=geometry, data=data)
+
+
+def intervals_to_omf_lines(
+    intervals,
+    traces,
+    name,
+    value_cols=None,
+    hole_col=HOLE_ID,
+    from_col=FROM,
+    to_col=TO,
+    easting_col=EASTING,
+    northing_col=NORTHING,
+    elevation_col=ELEVATION,
+    md_col="md",
+):
+    """Convert an interval table to a single OMF :class:`LineSetElement`.
+
+    Each interval row becomes one OMF segment whose endpoints are the
+    trace's ``(easting, northing, elevation)`` interpolated at the
+    interval's *from_col* and *to_col* depths.  Value columns become
+    per-segment :class:`ScalarData` (numeric) or :class:`StringData`
+    (categorical); ``hole_id`` is always attached.
+
+    Parameters
+    ----------
+    intervals : pd.DataFrame
+        Interval table (e.g. assay, geology).  Rows whose hole isn't in
+        *traces* are skipped silently.
+    traces : pd.DataFrame
+        Desurveyed trace table.
+    name : str
+        OMF element name (typically the interval-table label, e.g.
+        ``"assay"``).
+    value_cols : iterable of str, optional
+        Columns to attach as per-segment data.  ``None`` skips value
+        attachment (segments still carry ``hole_id``).
+    hole_col, from_col, to_col, easting_col, northing_col, elevation_col, md_col : str
+        Column-name overrides.
+
+    Returns
+    -------
+    omf.LineSetElement
+    """
+    _require_omf()
+    vertices = []
+    segments = []
+    rows_used = []
+
+    for hole_id, group in intervals.groupby(hole_col):
+        trace_hole = traces[traces[hole_col] == hole_id]
+        if trace_hole.empty:
+            continue
+        trace_sorted = trace_hole.sort_values(md_col)
+        mds = trace_sorted[md_col].to_numpy(dtype=float)
+        eastings = trace_sorted[easting_col].to_numpy(dtype=float)
+        northings = trace_sorted[northing_col].to_numpy(dtype=float)
+        elevations = trace_sorted[elevation_col].to_numpy(dtype=float)
+
+        for original_index, row in group.iterrows():
+            from_depth = _safe_float(row.get(from_col))
+            to_depth = _safe_float(row.get(to_col))
+            if from_depth is None or to_depth is None:
+                continue
+            start_xyz = (
+                float(np.interp(from_depth, mds, eastings)),
+                float(np.interp(from_depth, mds, northings)),
+                float(np.interp(from_depth, mds, elevations)),
+            )
+            end_xyz = (
+                float(np.interp(to_depth, mds, eastings)),
+                float(np.interp(to_depth, mds, northings)),
+                float(np.interp(to_depth, mds, elevations)),
+            )
+            base_index = len(vertices)
+            vertices.append(start_xyz)
+            vertices.append(end_xyz)
+            segments.append([base_index, base_index + 1])
+            rows_used.append(original_index)
+
+    if not segments:
+        raise ValueError(
+            f"No intervals in '{name}' could be located on the trace — nothing to write."
+        )
+
+    geometry = _omf.LineSetGeometry(
+        vertices=np.array(vertices, dtype=float),
+        segments=np.array(segments, dtype=int),
+    )
+
+    used_intervals = intervals.loc[rows_used]
+    data = [_omf.StringData(
+        name=hole_col,
+        array=[str(value) for value in used_intervals[hole_col].tolist()],
+        location="segments",
+    )]
+    for col in value_cols or []:
+        if col not in used_intervals.columns:
+            continue
+        data.append(_column_to_data(used_intervals[col], col, "segments"))
+
+    return _omf.LineSetElement(name=name, geometry=geometry, data=data)
+
+
+def build_omf_project(name, author, description, elements):
+    """Wrap a list of OMF elements in a :class:`omf.Project`."""
+    _require_omf()
+    return _omf.Project(
+        name=name,
+        author=author,
+        description=description,
+        elements=list(elements),
+    )
+
+
+def write_omf(project_or_elements, path, name="baselode", author="baselode", description=""):
+    """Write an OMF file from a :class:`omf.Project` or list of elements.
+
+    Parameters
+    ----------
+    project_or_elements : omf.Project or iterable of OMF elements
+        Source data.  Lists are wrapped via :func:`build_omf_project`
+        with the *name* / *author* / *description* arguments.
+    path : str or pathlib.Path
+        Output ``.omf`` path.
+
+    Returns
+    -------
+    omf.Project
+        The project that was actually serialised.
+    """
+    _require_omf()
+    if isinstance(project_or_elements, _omf.Project):
+        project = project_or_elements
+    else:
+        project = build_omf_project(name, author, description, project_or_elements)
+    _omf.OMFWriter(project, str(path))
+    return project
+
+
+def read_omf(path):
+    """Load an OMF file into a :class:`omf.Project`."""
+    _require_omf()
+    return _omf.OMFReader(str(path)).get_project()
+
+
+def _column_to_data(series, name, location):
+    """Wrap a pandas Series in the appropriate OMF data type."""
+    if pd.api.types.is_numeric_dtype(series):
+        return _omf.ScalarData(
+            name=name,
+            array=series.to_numpy(dtype=float),
+            location=location,
+        )
+    return _omf.StringData(
+        name=name,
+        array=[str(value) if value is not None and not _is_na(value) else "" for value in series.tolist()],
+        location=location,
+    )
+
+
+def _safe_float(value):
+    if value is None:
+        return None
+    try:
+        if pd.isna(value):
+            return None
+    except (TypeError, ValueError):
+        pass
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        return None
+    if pd.isna(result):
+        return None
+    return result
+
+
+def _is_na(value):
+    try:
+        return bool(pd.isna(value))
+    except (TypeError, ValueError):
+        return False

--- a/python/src/baselode/drill/omf.py
+++ b/python/src/baselode/drill/omf.py
@@ -88,6 +88,10 @@ def collars_to_omf_points(
     _require_omf()
     required = [easting_col, northing_col, elevation_col]
     valid = collars.dropna(subset=required)
+    if valid.empty:
+        raise ValueError(
+            "No collars have complete easting / northing / elevation — nothing to write."
+        )
     vertices = valid[required].to_numpy(dtype=float)
     geometry = _omf.PointSetGeometry(vertices=vertices)
 
@@ -142,7 +146,9 @@ def traces_to_omf_lines(
     segment_hole_ids = []
 
     for hole_id, group in traces.groupby(hole_col):
-        ordered = group.sort_values(md_col)
+        ordered = group.sort_values(md_col).dropna(
+            subset=[md_col, easting_col, northing_col, elevation_col]
+        )
         xyz = ordered[[easting_col, northing_col, elevation_col]].to_numpy(dtype=float)
         if len(xyz) < 2:
             continue
@@ -211,11 +217,17 @@ def intervals_to_omf_lines(
     segments = []
     rows_used = []
 
+    trace_groups = {
+        hole_id: group.sort_values(md_col).dropna(
+            subset=[md_col, easting_col, northing_col, elevation_col]
+        )
+        for hole_id, group in traces.groupby(hole_col)
+    }
+
     for hole_id, group in intervals.groupby(hole_col):
-        trace_hole = traces[traces[hole_col] == hole_id]
-        if trace_hole.empty:
+        trace_sorted = trace_groups.get(hole_id)
+        if trace_sorted is None or len(trace_sorted) < 2:
             continue
-        trace_sorted = trace_hole.sort_values(md_col)
         mds = trace_sorted[md_col].to_numpy(dtype=float)
         eastings = trace_sorted[easting_col].to_numpy(dtype=float)
         northings = trace_sorted[northing_col].to_numpy(dtype=float)

--- a/test/data/parity_contract.json
+++ b/test/data/parity_contract.json
@@ -245,6 +245,19 @@
       ]
     },
     {
+      "name": "omf_io",
+      "description": "Round-trip helpers between baselode drilling tables and Open Mining Format (OMF v1) point/line elements. Python-only; JavaScript support is deferred per TRK-111 scope (consume read-side via Python until a JS need lands). Requires the optional `omf` extra: `pip install baselode[omf]`.",
+      "jsExports": [],
+      "pythonSymbols": [
+        ["baselode.drill.omf", "collars_to_omf_points"],
+        ["baselode.drill.omf", "traces_to_omf_lines"],
+        ["baselode.drill.omf", "intervals_to_omf_lines"],
+        ["baselode.drill.omf", "build_omf_project"],
+        ["baselode.drill.omf", "write_omf"],
+        ["baselode.drill.omf", "read_omf"]
+      ]
+    },
+    {
       "name": "validate_drillhole_db",
       "description": "Comprehensive drillhole-database validator: returns a structured {summary, issues} report covering duplicate collar IDs, single-station surveys, az/dip range, orphans, gaps, overlaps, beyond-max-depth, and below-detection sentinels. Ships fix_single_station_surveys + replace_below_detection_limit helpers.",
       "jsExports": [

--- a/test/test_drill_omf.py
+++ b/test/test_drill_omf.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2026 Darkmine Pty Ltd
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+import importlib.util
 import tempfile
 from pathlib import Path
 
@@ -8,9 +9,11 @@ import numpy as np
 import pandas as pd
 import pytest
 
-omf_pkg = pytest.importorskip("omf")
-
 import baselode.drill.omf as omf_io
+
+HAS_OMF = importlib.util.find_spec("omf") is not None
+omf_only = pytest.mark.skipif(not HAS_OMF, reason="omf optional extra not installed")
+omf_pkg = __import__("omf") if HAS_OMF else None
 
 
 def _sample_collars():
@@ -50,6 +53,7 @@ def _sample_assays():
     })
 
 
+@omf_only
 def test_collars_to_omf_points_builds_pointset():
     element = omf_io.collars_to_omf_points(_sample_collars())
     assert isinstance(element, omf_pkg.PointSetElement)
@@ -58,12 +62,14 @@ def test_collars_to_omf_points_builds_pointset():
     assert "hole_id" in data_names
 
 
+@omf_only
 def test_collars_to_omf_points_includes_attribute_cols():
     element = omf_io.collars_to_omf_points(_sample_collars(), attribute_cols=["max_depth"])
     data_names = [data.name for data in element.data]
     assert "max_depth" in data_names
 
 
+@omf_only
 def test_collars_to_omf_points_drops_missing_xyz():
     collars = _sample_collars()
     collars.loc[1, "easting"] = np.nan
@@ -71,6 +77,15 @@ def test_collars_to_omf_points_drops_missing_xyz():
     assert element.geometry.vertices.array.shape == (1, 3)
 
 
+@omf_only
+def test_collars_to_omf_points_raises_when_no_rows_have_xyz():
+    collars = _sample_collars()
+    collars["easting"] = np.nan
+    with pytest.raises(ValueError, match="nothing to write"):
+        omf_io.collars_to_omf_points(collars)
+
+
+@omf_only
 def test_traces_to_omf_lines_concatenates_holes_with_per_segment_hole_id():
     element = omf_io.traces_to_omf_lines(_sample_traces())
     assert isinstance(element, omf_pkg.LineSetElement)
@@ -85,6 +100,7 @@ def test_traces_to_omf_lines_concatenates_holes_with_per_segment_hole_id():
     assert len(segment_holes) == len(segments)
 
 
+@omf_only
 def test_traces_to_omf_lines_skips_holes_with_a_single_sample():
     traces = _sample_traces()
     single_sample = pd.DataFrame([{
@@ -97,6 +113,17 @@ def test_traces_to_omf_lines_skips_holes_with_a_single_sample():
     assert "C" not in segment_holes
 
 
+@omf_only
+def test_traces_to_omf_lines_drops_rows_with_nan_xyz_or_md():
+    traces = _sample_traces()
+    traces.loc[0, "easting"] = np.nan  # one row in hole A
+    traces.loc[len(traces) - 1, "md"] = np.nan  # last row in hole B
+    element = omf_io.traces_to_omf_lines(traces)
+    vertices = element.geometry.vertices.array
+    assert not np.isnan(vertices).any()
+
+
+@omf_only
 def test_intervals_to_omf_lines_attaches_value_columns():
     element = omf_io.intervals_to_omf_lines(
         _sample_assays(), _sample_traces(), name="assay", value_cols=["au_ppm", "lithology"],
@@ -109,6 +136,7 @@ def test_intervals_to_omf_lines_attaches_value_columns():
     assert "lithology" in data_names
 
 
+@omf_only
 def test_intervals_to_omf_lines_skips_intervals_with_missing_from_or_to():
     intervals = _sample_assays()
     intervals.loc[1, "from"] = np.nan
@@ -116,6 +144,17 @@ def test_intervals_to_omf_lines_skips_intervals_with_missing_from_or_to():
     assert element.geometry.segments.array.shape == (2, 2)
 
 
+@omf_only
+def test_intervals_to_omf_lines_skips_intervals_whose_trace_has_nan_xyz():
+    traces = _sample_traces()
+    traces.loc[traces["hole_id"] == "A", "easting"] = np.nan
+    element = omf_io.intervals_to_omf_lines(_sample_assays(), traces, name="assay")
+    vertices = element.geometry.vertices.array
+    assert not np.isnan(vertices).any()
+    assert element.geometry.segments.array.shape == (1, 2)
+
+
+@omf_only
 def test_intervals_to_omf_lines_raises_when_nothing_locatable():
     intervals = pd.DataFrame({
         "hole_id": ["Z"], "from": [0.0], "to": [1.0], "au_ppm": [0.1],
@@ -124,6 +163,7 @@ def test_intervals_to_omf_lines_raises_when_nothing_locatable():
         omf_io.intervals_to_omf_lines(intervals, _sample_traces(), name="assay")
 
 
+@omf_only
 def test_traces_to_omf_lines_raises_when_no_two_sample_holes():
     traces = pd.DataFrame([{
         "hole_id": "A", "md": 0.0,
@@ -134,6 +174,7 @@ def test_traces_to_omf_lines_raises_when_no_two_sample_holes():
         omf_io.traces_to_omf_lines(traces)
 
 
+@omf_only
 def test_write_and_read_round_trip_via_tempfile():
     with tempfile.TemporaryDirectory() as tmpdir:
         path = Path(tmpdir) / "round-trip.omf"
@@ -154,6 +195,7 @@ def test_write_and_read_round_trip_via_tempfile():
         assert "assay" in element_names
 
 
+@omf_only
 def test_write_omf_accepts_project_directly():
     project = omf_io.build_omf_project(
         "manual", "agent", "manual project",

--- a/test/test_drill_omf.py
+++ b/test/test_drill_omf.py
@@ -1,0 +1,176 @@
+# Copyright (C) 2026 Darkmine Pty Ltd
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+omf_pkg = pytest.importorskip("omf")
+
+import baselode.drill.omf as omf_io
+
+
+def _sample_collars():
+    return pd.DataFrame({
+        "hole_id": ["A", "B"],
+        "easting": [500000.0, 500100.0],
+        "northing": [6900000.0, 6900050.0],
+        "elevation": [300.0, 305.0],
+        "max_depth": [100.0, 80.0],
+    })
+
+
+def _sample_traces():
+    holes = []
+    for hole_id, easting, northing in [("A", 500000.0, 6900000.0), ("B", 500100.0, 6900050.0)]:
+        mds = np.arange(0.0, 101.0, 10.0)
+        for md in mds:
+            holes.append({
+                "hole_id": hole_id,
+                "md": md,
+                "easting": easting,
+                "northing": northing,
+                "elevation": 300.0 - md,
+                "azimuth": 0.0,
+                "dip": -90.0,
+            })
+    return pd.DataFrame(holes)
+
+
+def _sample_assays():
+    return pd.DataFrame({
+        "hole_id": ["A", "A", "B"],
+        "from": [0.0, 10.0, 20.0],
+        "to": [10.0, 20.0, 30.0],
+        "au_ppm": [0.10, 0.25, 0.05],
+        "lithology": ["granite", "schist", "granite"],
+    })
+
+
+def test_collars_to_omf_points_builds_pointset():
+    element = omf_io.collars_to_omf_points(_sample_collars())
+    assert isinstance(element, omf_pkg.PointSetElement)
+    assert element.geometry.vertices.array.shape == (2, 3)
+    data_names = [data.name for data in element.data]
+    assert "hole_id" in data_names
+
+
+def test_collars_to_omf_points_includes_attribute_cols():
+    element = omf_io.collars_to_omf_points(_sample_collars(), attribute_cols=["max_depth"])
+    data_names = [data.name for data in element.data]
+    assert "max_depth" in data_names
+
+
+def test_collars_to_omf_points_drops_missing_xyz():
+    collars = _sample_collars()
+    collars.loc[1, "easting"] = np.nan
+    element = omf_io.collars_to_omf_points(collars)
+    assert element.geometry.vertices.array.shape == (1, 3)
+
+
+def test_traces_to_omf_lines_concatenates_holes_with_per_segment_hole_id():
+    element = omf_io.traces_to_omf_lines(_sample_traces())
+    assert isinstance(element, omf_pkg.LineSetElement)
+    vertices = element.geometry.vertices.array
+    segments = element.geometry.segments.array
+    assert vertices.shape[1] == 3
+    assert segments.shape[1] == 2
+
+    hole_id_data = next(data for data in element.data if data.name == "hole_id")
+    segment_holes = list(hole_id_data.array.array)
+    assert "A" in segment_holes and "B" in segment_holes
+    assert len(segment_holes) == len(segments)
+
+
+def test_traces_to_omf_lines_skips_holes_with_a_single_sample():
+    traces = _sample_traces()
+    single_sample = pd.DataFrame([{
+        "hole_id": "C", "md": 0.0,
+        "easting": 0.0, "northing": 0.0, "elevation": 0.0,
+        "azimuth": 0.0, "dip": -90.0,
+    }])
+    element = omf_io.traces_to_omf_lines(pd.concat([traces, single_sample], ignore_index=True))
+    segment_holes = list(next(data for data in element.data if data.name == "hole_id").array.array)
+    assert "C" not in segment_holes
+
+
+def test_intervals_to_omf_lines_attaches_value_columns():
+    element = omf_io.intervals_to_omf_lines(
+        _sample_assays(), _sample_traces(), name="assay", value_cols=["au_ppm", "lithology"],
+    )
+    assert isinstance(element, omf_pkg.LineSetElement)
+    assert element.geometry.segments.array.shape == (3, 2)
+    data_names = [data.name for data in element.data]
+    assert "hole_id" in data_names
+    assert "au_ppm" in data_names
+    assert "lithology" in data_names
+
+
+def test_intervals_to_omf_lines_skips_intervals_with_missing_from_or_to():
+    intervals = _sample_assays()
+    intervals.loc[1, "from"] = np.nan
+    element = omf_io.intervals_to_omf_lines(intervals, _sample_traces(), name="assay")
+    assert element.geometry.segments.array.shape == (2, 2)
+
+
+def test_intervals_to_omf_lines_raises_when_nothing_locatable():
+    intervals = pd.DataFrame({
+        "hole_id": ["Z"], "from": [0.0], "to": [1.0], "au_ppm": [0.1],
+    })
+    with pytest.raises(ValueError, match="nothing to write"):
+        omf_io.intervals_to_omf_lines(intervals, _sample_traces(), name="assay")
+
+
+def test_traces_to_omf_lines_raises_when_no_two_sample_holes():
+    traces = pd.DataFrame([{
+        "hole_id": "A", "md": 0.0,
+        "easting": 0.0, "northing": 0.0, "elevation": 0.0,
+        "azimuth": 0.0, "dip": -90.0,
+    }])
+    with pytest.raises(ValueError, match="nothing to write"):
+        omf_io.traces_to_omf_lines(traces)
+
+
+def test_write_and_read_round_trip_via_tempfile():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = Path(tmpdir) / "round-trip.omf"
+        elements = [
+            omf_io.collars_to_omf_points(_sample_collars()),
+            omf_io.traces_to_omf_lines(_sample_traces()),
+            omf_io.intervals_to_omf_lines(
+                _sample_assays(), _sample_traces(),
+                name="assay", value_cols=["au_ppm"],
+            ),
+        ]
+        omf_io.write_omf(elements, path, name="round-trip", author="agent", description="test")
+        assert path.exists()
+        project = omf_io.read_omf(path)
+        element_names = [element.name for element in project.elements]
+        assert "collars" in element_names
+        assert "traces" in element_names
+        assert "assay" in element_names
+
+
+def test_write_omf_accepts_project_directly():
+    project = omf_io.build_omf_project(
+        "manual", "agent", "manual project",
+        [omf_io.collars_to_omf_points(_sample_collars())],
+    )
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = Path(tmpdir) / "from-project.omf"
+        result = omf_io.write_omf(project, path)
+        assert result is project
+        assert path.exists()
+
+
+def test_module_raises_without_omf(monkeypatch):
+    monkeypatch.setattr(omf_io, "_omf", None)
+    with pytest.raises(ImportError, match="pip install baselode\\[omf\\]"):
+        omf_io.collars_to_omf_points(_sample_collars())
+    with pytest.raises(ImportError, match="pip install baselode\\[omf\\]"):
+        omf_io.traces_to_omf_lines(_sample_traces())
+    with pytest.raises(ImportError, match="pip install baselode\\[omf\\]"):
+        omf_io.read_omf("nowhere.omf")


### PR DESCRIPTION
`baselode.drill.omf` round-trips drilling tables through Open Mining Format v1 — the MIT-licensed mining interchange format read/written by Leapfrog, 3DEXPERIENCE, Deswik and Micromine — so baselode plugs straight into those workflows.

Optional `omf` extra: `pip install baselode[omf]`. Soft-imported per AGENTS.md; every entry point raises ImportError with the install instruction when the package isn't present.

API:

- collars_to_omf_points(collars, attribute_cols=None) — PointSetElement (vertices = easting/northing/elevation; hole_id + extras as per-vertex ScalarData / StringData)
- traces_to_omf_lines(traces) — single LineSetElement; each hole's trace concatenated, per-segment hole_id so holes are selectable without a 4000-element project
- intervals_to_omf_lines(intervals, traces, name, value_cols) — single LineSetElement with one segment per interval, endpoints interpolated from the trace at from/to depths, value columns attached as per-segment ScalarData / StringData
- build_omf_project / write_omf / read_omf — round-trip helpers

Defaults driven by baselode.datamodel constants. Rows with missing xyz / non-numeric from-to are skipped silently. Functions raise ValueError only when nothing locatable remains to write.

Verified on a 20-hole subset of the real GSWA sample data: 14,608 surveys → 14,594 trace segments, 997 assays → 997 segments, ~694 KB OMF, round-trip preserves all three elements.

Tests: 12 pytest cases (incl. missing-omf-package ImportError check via monkeypatch). Full Py suite 302 / 8 skipped, no regressions.

JS counterpart explicitly deferred per ticket scope; parity contract gains `omf_io` capability with empty jsExports + descriptive note.

Notebook example: notebooks/example_omf_export.ipynb walks through the GSWA round-trip end-to-end.


## Summary
  
  `baselode.drill.omf` round-trips drilling tables through Open Mining Format v1 — the MIT-licensed mining interchange format read/written by Leapfrog, 3DEXPERIENCE, Deswik and Micromine. Baselode is now OMF-native end-to-end.

  Six entry points: `collars_to_omf_points`, `traces_to_omf_lines`, `intervals_to_omf_lines`, `build_omf_project`, `write_omf`, `read_omf`.

  Design choices:
  - **One element, multi-hole.** Traces and interval lines each return a single `LineSetElement` with `hole_id` as per-segment `StringData` rather than 4000-element projects. Holes remain individually selectable.
  - **Endpoints interpolated.** Each interval becomes a 2-vertex segment; xyz at `from`/`to` depths comes from `np.interp` against the trace.
  - **Optional dependency.** `pip install baselode[omf]`. Soft-imported per AGENTS.md; clear `ImportError` with install instruction if missing.
  - **JS deferred.** Per ticket scope; parity contract gains `omf_io` capability with empty `jsExports` + descriptive note.

  Verified on a 20-hole GSWA subset (14,608 surveys → 14,594 trace segments, 997 assays → 997 segments, 694 KB OMF, round-trip preserves all elements).

  ## Test plan
  
  - [x] `python -m pytest test/test_drill_omf.py -q` → 12 pass
  - [x] Full Python suite: 302 / 8 skipped, 0 regressions
  - [x] GSWA real-data round-trip (see notebook)
  - [ ] Reviewer: open the OMF file in a viewer (Seequent OMF Editor / View / Plot — free download) to spot-check geometry alignment
  - [ ] Reviewer: confirm the one-element-per-table design (with `hole_id` per segment) suits your downstream OMF workflows, vs the alternative one-element-per-hole layout
