### PR TITLE
[TRK-116] CI hygiene: rename workflow, run optional-extra tests, add …

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,13 @@
-name: Test and Build (no publish)
+name: CI
 
 on:
   pull_request:
   workflow_dispatch:
+
+# To make this a required check on PRs, go to
+# Settings → Branches → Branch protection rules → main and add the
+# "Python tests" and "JavaScript tests" status checks below
+# "Require status checks to pass before merging".
 
 jobs:
   test-python:
@@ -24,6 +29,9 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r python/requirements.txt
           pip install pytest
+          # Install optional extras so tests covering them actually run
+          # in CI instead of skipping silently.
+          pip install "omf>=1.0,<2.0" "lasio>=0.31"
 
       - name: Run tests
         run: python -m pytest test -q

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,9 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r python/requirements.txt
           pip install pytest
+          # Install optional extras so tests covering them actually run
+          # in CI instead of skipping silently.
+          pip install "omf>=1.0,<2.0" "lasio>=0.31"
 
       - name: Run tests
         run: python -m pytest test -q

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Baselode
 
+[![CI](https://github.com/darkmine-oss/baselode/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/darkmine-oss/baselode/actions/workflows/ci.yml)
+[![PyPI](https://img.shields.io/pypi/v/baselode.svg)](https://pypi.org/project/baselode/)
+[![npm](https://img.shields.io/npm/v/baselode.svg)](https://www.npmjs.com/package/baselode)
+[![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
+
 [-> Interactive Demo Here<-](demo.baselode.net)
 
 <img src="docs/assets/baselode_logo.png" style="max-width:100px;">

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -27,6 +27,18 @@ Required secrets / configurations:
 | `NPM_TOKEN` | Repository secret | Authenticate `npm publish` |
 | PyPI trusted publisher | PyPI project settings | OIDC publish from Actions |
 
+### Recommended branch protection
+
+To make sure merges to `main` only happen once tests pass on the PR
+branch, configure branch protection for `main`:
+
+1. *Settings → Branches → Branch protection rules → Add rule.*
+2. Branch name pattern: `main`.
+3. Enable **Require status checks to pass before merging** and add
+   the `Python tests` and `JavaScript tests` checks (provided by the
+   `CI` workflow in `.github/workflows/ci.yml`).
+4. Enable **Require branches to be up to date before merging**.
+
 ---
 
 ## Manual releases


### PR DESCRIPTION
…badges

The CI workflow was named "Test and Build (no publish)" which is easy to miss in the PR checks panel — the test runs are happening and going green, but the label hides them. Renamed the file and `name:` field to plain "CI".

Separately, the `omf` and `lasio` optional extras weren't being installed in CI, so any tests gated on those (15 OMF, a handful in test_geophysics) were silently skipping in PR runs and on push to main. Added `pip install "omf>=1.0,<2.0" "lasio>=0.31"` to both ci.yml and release.yml test-install steps so those tests actually exercise their code paths in CI.

Other:
- README.md: added CI, PyPI, npm, and license status badges so the green/red state is visible from the repo home, PyPI, and npm pages.
- RELEASING.md: documented the recommended branch-protection setting to require the CI status checks before merging. The actual enable step is a repo-admin UI action and can't be done from a workflow.
- ci.yml: inline comment pointing at the same branch-protection instructions so anyone editing the workflow knows.

Workflow renames break any existing badge URLs that referenced `test-build.yml`; no such badges existed (this PR introduces the first one), so no callers to update.