### PR TITLE
[TRK-109] Compositing extensions: hard-boundary + true-thickness

### DIFF
--- a/docs/api/javascript.md
+++ b/docs/api/javascript.md
@@ -416,6 +416,32 @@ const merged = mergeTables({ assay: assayRows, litho: lithoRows });
 
 ---
 
+## Compositing
+
+Length-weighted compositing of downhole intervals.  Soft + hard boundary modes; true-thickness is Python-only because it depends on a desurveyed trace.
+
+#### `compositeIntervals(intervals, valueCol, options?)`
+Composite an array of interval rows into fixed-length downhole bins.
+
+| Parameter | Type | Default | Meaning |
+|---|---|---|---|
+| `intervals` | `Array<Object>` | — | Interval rows.  Each row must carry `hole_id`, `from`, `to` and `valueCol`; in `mode === 'hard'` also `boundaryCol` |
+| `valueCol` | `string` | — | Property to composite |
+| `options.length` | `number` | `1.0` | Composite length (positive, finite) |
+| `options.method` | `'average' \| 'sum'` | `'average'` | Length-weighted average or total contribution |
+| `options.mode` | `'soft' \| 'hard'` | `'soft'` | Soft = bins extend across the full hole and may cross contacts.  Hard = bins reset at every change in `boundaryCol` |
+| `options.boundaryCol` | `string` | — | Domain column for hard mode (required when `mode === 'hard'`) |
+| `options.residual` | `'discard' \| 'add_to_previous' \| 'distribute'` | `'discard'` | Tail-of-domain handling in hard mode |
+| `options.fromCol` / `options.toCol` / `options.holeCol` | `string` | `'from'` / `'to'` / `'hole_id'` | Column-name overrides |
+
+**Returns:** `Array<Object>` of composites with the same key names as the input plus (in hard mode) the boundary column carrying the originating domain value.
+
+Throws if `length` is not a positive finite number, if `method` isn't `'average'` or `'sum'`, if `mode` is unknown, or if `mode === 'hard'` without a `boundaryCol`.
+
+Mirrors `baselode.drill.composite.composite_intervals` in Python (mass-balance semantics, residual rules, run-grouping).
+
+---
+
 ## Column Metadata
 
 #### `classifyColumns(rows)`

--- a/docs/api/python.md
+++ b/docs/api/python.md
@@ -397,6 +397,73 @@ merged = intervals.merge_tables({"assay": assays, "litho": geology})
 
 ---
 
+## baselode.drill.composite
+
+Length-weighted compositing of downhole intervals.  Soft + hard boundary modes plus a true-thickness (economic) compositor.
+
+```python
+from baselode.drill.composite import composite_intervals, composite_true_thickness
+```
+
+### composite_intervals
+
+```python
+composite_intervals(
+    df, value_col, from_col="from", to_col="to",
+    length=1.0, method="average", *,
+    mode="soft", boundary_col=None, residual="discard",
+)
+```
+
+Composite a column of an interval table into fixed-length downhole bins.
+
+| Parameter | Type | Default | Meaning |
+|---|---|---|---|
+| `df` | `pandas.DataFrame` | — | Interval table with `hole_id`, *from_col*, *to_col*, *value_col*; in `mode="hard"` also *boundary_col* |
+| `value_col` | `str` | — | Numeric column to composite |
+| `length` | `float` | `1.0` | Composite length in metres (downhole).  Must be > 0 |
+| `method` | `{"average", "sum"}` | `"average"` | Length-weighted average or sum |
+| `mode` | `{"soft", "hard"}` | `"soft"` | Soft = bins extend across the full hole and may cross contacts (dhcomp / Leapfrog default).  Hard = bins reset at every change in `boundary_col` |
+| `boundary_col` | `str` | `None` | Domain column for hard mode (required when `mode="hard"`) |
+| `residual` | `{"discard", "add_to_previous", "distribute"}` | `"discard"` | Tail-of-domain handling for hard mode.  `discard` drops a sub-length tail; `add_to_previous` extends the previous composite to the domain end; `distribute` chooses `round(D/length)` equal-length bins covering the whole domain |
+
+**Returns:** `pandas.DataFrame` of composites with `hole_id`, *from_col*, *to_col*, *value_col*, plus *boundary_col* in hard mode.
+
+**Mass balance:** `sum(value × overlap)` is conserved between source intervals and composites (within each composite's coverage window in `"average"` mode; over the full hole in `"sum"` mode, modulo intervals dropped by residual handling).
+
+### composite_true_thickness
+
+```python
+composite_true_thickness(
+    intervals, traces, value_col, ref_dip, ref_dip_azimuth,
+    from_col="from", to_col="to",
+    length=1.0, method="average", hole_col=HOLE_ID,
+)
+```
+
+Composite in **true-thickness** space relative to a reference plane.  For each source interval the midpoint orientation is looked up in *traces* via `interpolate_trajectory`; true thickness is `L_downhole · |T · N|` where `T` is the hole's unit tangent and `N` is the unit normal of the reference plane.  Composites span `length` of true thickness, with downhole `from`/`to` recovered from the inverse cumulative map.
+
+Use this for "economic compositing" — composites that represent equal stratigraphic thickness across a known orebody plane.
+
+| Parameter | Type | Default | Meaning |
+|---|---|---|---|
+| `intervals` | `pandas.DataFrame` | — | Interval table |
+| `traces` | `pandas.DataFrame` | — | Desurveyed trace with `azimuth` + `dip` columns (e.g. output of `minimum_curvature_desurvey`) |
+| `value_col` | `str` | — | Numeric column to composite |
+| `ref_dip` | `float` | — | Reference plane dip in degrees (0 = horizontal, 90 = vertical) |
+| `ref_dip_azimuth` | `float` | — | Dip azimuth (downdip direction) clockwise from grid north, in degrees |
+| `length` | `float` | `1.0` | Composite true-thickness in metres.  Must be > 0 |
+| `method` | `{"average", "sum"}` | `"average"` | Length-weighting applied with true thickness as the weight |
+| `hole_col` | `str` | `HOLE_ID` | Hole identifier column (propagates into the output) |
+
+**Returns:** `pandas.DataFrame` with `hole_id`, *from_col*, *to_col* (downhole metres), *value_col*, `length_md` (downhole length covered) and `length_true` (true thickness — usually equal to `length` except possibly the last bin per hole).
+
+A hole drilled parallel to the reference plane (`|T · N| ≈ 0`) produces no composites — no economic thickness is being captured.
+
+True-thickness compositing is **Python-only**; the JavaScript build ships `compositeIntervals` (soft + hard modes) but no true-thickness primitive, since it depends on a desurveyed trace.
+
+---
+
 ## baselode.drill.DrillholeSet
 
 Composition root for the drilling tables of a project.  Holds a collar + survey table plus N named interval tables (assay, geology, structural, …) and exposes the existing function-based API as methods.  No new algorithmic logic — every method is a thin delegator.  The trace is cached after the first `desurvey()` call.

--- a/docs/guide/javascript.md
+++ b/docs/guide/javascript.md
@@ -347,6 +347,40 @@ const mids    = fromToMidpoints(assayRows);   // number[]
 
 ---
 
+## Compositing
+
+`compositeIntervals` mirrors the Python `composite_intervals` soft + hard boundary modes.  True-thickness compositing is **Python-only** because it needs a desurveyed trace; for browser-side workflows that need true-thickness, do the composite step server-side and ship the result to the client.
+
+```js
+import { compositeIntervals } from 'baselode';
+
+// Soft mode (default): fixed-length bins across each hole, length-weighted average
+const composites = compositeIntervals(assayRows, 'au_ppm', { length: 2 });
+
+// Hard-boundary by domain — composites reset at every change in the boundary column
+const byLitho = compositeIntervals(assayRows, 'au_ppm', {
+  length: 2,
+  mode: 'hard',
+  boundaryCol: 'lithology',
+  residual: 'distribute',  // or 'discard' (default) / 'add_to_previous'
+});
+```
+
+Options:
+
+| Option | Type | Default | Meaning |
+|---|---|---|---|
+| `length` | `number` | `1` | Composite length (must be a positive finite number) |
+| `method` | `'average' \| 'sum'` | `'average'` | Length-weighted average or sum |
+| `mode` | `'soft' \| 'hard'` | `'soft'` | Boundary handling |
+| `boundaryCol` | `string` | — | Domain column for hard mode (required when `mode === 'hard'`) |
+| `residual` | `'discard' \| 'add_to_previous' \| 'distribute'` | `'discard'` | Tail-of-domain handling for hard mode |
+| `fromCol` / `toCol` / `holeCol` | `string` | `'from'` / `'to'` / `'hole_id'` | Column-name overrides |
+
+Both `length` and `method` are validated up front — passing `0`, `NaN` or `Infinity` for `length`, or an unknown `method`, throws with a clear message.
+
+---
+
 ## Visualization
 
 ### Column classification

--- a/docs/guide/python.md
+++ b/docs/guide/python.md
@@ -437,6 +437,88 @@ assays["mid"]      = intervals.from_to_midpoints(assays)
 
 ---
 
+## Compositing
+
+Length-weighted compositing of downhole intervals.  `baselode.drill.composite` ships three modes:
+
+| Mode | When to use |
+|---|---|
+| **Soft** (default) | Fixed-length bins extending across each hole.  Bins may cross geological contacts; values are length-weighted across whatever overlaps each bin.  Matches the dhcomp / Leapfrog default. |
+| **Hard-boundary** | Bins reset at every change in a coded domain column (lithology, regolith, alteration).  No composite straddles a contact. |
+| **True-thickness** | Bins are equal *true thickness* perpendicular to a reference plane, computed via interpolated midpoint orientation.  This is "economic compositing" — what you want for resource estimation across a known orebody plane. |
+
+### Soft mode — the default
+
+```python
+from baselode.drill.composite import composite_intervals
+
+composites = composite_intervals(assays, value_col="au_ppm", length=2.0)
+# columns: hole_id, from, to, au_ppm
+```
+
+`method="sum"` returns total contribution (`value × overlap`) per bin instead of the length-weighted average.
+
+### Hard-boundary by domain
+
+Composite within each contiguous run of a coded boundary column — no composite spans a contact.
+
+```python
+composites = composite_intervals(
+    assays_with_litho,
+    value_col="au_ppm",
+    length=2.0,
+    mode="hard",
+    boundary_col="lithology",
+    residual="distribute",  # or "discard" / "add_to_previous"
+)
+# columns: hole_id, from, to, au_ppm, lithology
+```
+
+Three `residual` rules control what happens when a domain length isn't an exact multiple of `length`:
+
+- `"discard"` (default) — drop the sub-length tail.
+- `"add_to_previous"` — extend the previous composite to the domain end.
+- `"distribute"` — choose `round(D / length)` equal-length bins covering the whole domain (slightly compressed or stretched bin length).
+
+Non-abutting same-domain intervals are treated as separate runs — an unsampled gap breaks the run, matching how downhole-compositing tools handle interval breaks.
+
+### True-thickness compositing
+
+Composite in true-thickness space relative to a reference plane.  Needs a desurveyed trace because the midpoint orientation of each interval is what converts downhole length → true thickness.
+
+```python
+from baselode.drill.composite import composite_true_thickness
+from baselode.drill.desurvey import minimum_curvature_desurvey
+
+traces = minimum_curvature_desurvey(collars, surveys, step=1.0)
+
+composites = composite_true_thickness(
+    assays, traces,
+    value_col="au_ppm",
+    ref_dip=60.0,           # plane dipping 60° below horizontal
+    ref_dip_azimuth=270.0,  # downdip points west
+    length=1.0,             # 1 m of TRUE thickness per composite
+)
+# columns: hole_id, from, to, au_ppm, length_md, length_true
+```
+
+Each composite represents the same vertical (or near-vertical) slice across the orebody regardless of how steeply the hole was drilled through it.  A hole drilled parallel to the plane (`|T · N| ≈ 0`) produces no composites — no economic thickness is being captured.
+
+True-thickness compositing is Python-only.
+
+### How baselode compares to other OSS compositors
+
+| Feature | dhcomp | PyGSLIB | baselode |
+|---|---|---|---|
+| Soft-boundary | ✓ | ✓ | ✓ (default) |
+| Hard-boundary by coded domain | ✓ | ✗ | ✓ |
+| Residual rules (`discard` / `add_to_previous` / `distribute`) | ✗ | `minlen` filter only | ✓ all three |
+| True-thickness | ✗ | ✗ | ✓ |
+| JS implementation | ✗ | ✗ | ✓ (soft + hard) |
+| Pure-function pandas API | ~ | ✗ (needs `Drillhole` container object) | ✓ |
+
+---
+
 ## Visualization
 
 ### Map

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -2,6 +2,20 @@
 
 ---
 
+## Unreleased
+**Compositing extensions: hard-boundary + true-thickness**
+
+- `composite_intervals` (Python + JavaScript) grows three new kwargs that preserve the existing soft-mode call signature:
+  - `mode="soft"` (default) — the prior length-weighted overlap behaviour, now documented and named explicitly (matches the dhcomp / Leapfrog convention)
+  - `mode="hard"` + `boundary_col` — composites reset at every change in the boundary column within a hole; no composite straddles a coded contact
+  - `residual={"discard","add_to_previous","distribute"}` — how to handle a sub-`length` tail at the end of a hard-mode domain
+- New Python primitive `composite_true_thickness(intervals, traces, value_col, ref_dip, ref_dip_azimuth, ...)` for economic compositing: composites span equal *true thickness* perpendicular to a reference plane, with downhole bounds recovered from the inverse cumulative map.  Reports `length_md` + `length_true` per composite.  Python-only — depends on a desurveyed trace.
+- JavaScript `compositeIntervals` mirrors the soft/hard modes (no JS true-thickness).
+- Both implementations validate `method ∈ {average, sum}` and `length > 0` up front to fail loudly instead of producing nonsense (JS soft mode would have looped forever on `length === 0`).
+- Updated docs: new "Compositing" sections in the Python + JavaScript guides, full API references for both, and a comparison table against `dhcomp` and `PyGSLIB` — true-thickness, all three residual rules, and a JS implementation are all features that don't exist in any other OSS compositor we could find.
+
+---
+
 ## v0.1.12
 **Demo viewer Vercel deployment**
 

--- a/javascript/packages/baselode/src/data/composite.js
+++ b/javascript/packages/baselode/src/data/composite.js
@@ -48,6 +48,15 @@ export function compositeIntervals(intervals, valueCol, options = {}) {
   if (mode !== 'soft' && mode !== 'hard') {
     throw new Error(`mode must be "soft" or "hard", got "${mode}"`);
   }
+  if (method !== 'average' && method !== 'sum') {
+    throw new Error(`method must be "average" or "sum", got "${method}"`);
+  }
+  // `Number.isFinite(length) && length > 0` rejects 0, negatives,
+  // NaN, Infinity and non-numeric inputs; without this, soft mode's
+  // `cFrom += length` would loop forever on length === 0.
+  if (!(Number.isFinite(length) && length > 0)) {
+    throw new Error(`length must be a positive finite number, got ${length}`);
+  }
   if (mode === 'hard') {
     if (!boundaryCol) throw new Error('mode="hard" requires a boundaryCol');
     if (!['discard', 'add_to_previous', 'distribute'].includes(residual)) {

--- a/javascript/packages/baselode/src/data/composite.js
+++ b/javascript/packages/baselode/src/data/composite.js
@@ -1,0 +1,178 @@
+/*
+ * Copyright (C) 2026 Darkmine Pty Ltd
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+/**
+ * Length-weighted compositing of downhole intervals.
+ *
+ * Mirrors the Python `composite_intervals` for hard / soft boundary
+ * modes.  True-thickness compositing is Python-only (no JS parity per
+ * TRK-109 scope — it depends on a desurveyed trace).
+ *
+ * @param {Array<Object>} intervals - Interval rows.  Each row must carry
+ *   the hole-id, from, to and value properties; in `mode="hard"` also
+ *   the boundary column.
+ * @param {string} valueCol - Property name to composite.
+ * @param {Object} [options]
+ * @param {string} [options.fromCol="from"]
+ * @param {string} [options.toCol="to"]
+ * @param {string} [options.holeCol="hole_id"]
+ * @param {number} [options.length=1.0] - Composite length in metres.
+ * @param {"average"|"sum"} [options.method="average"] - Length-weighted
+ *   average (default) or total contribution.
+ * @param {"soft"|"hard"} [options.mode="soft"] - Boundary handling.
+ *   `"soft"` extends bins across the full hole range and lets
+ *   composites cross contacts; `"hard"` resets at every change in
+ *   `boundaryCol`.
+ * @param {string} [options.boundaryCol] - Domain column for hard mode.
+ *   Required when `mode === "hard"`.
+ * @param {"discard"|"add_to_previous"|"distribute"} [options.residual="discard"]
+ *   Tail-of-domain handling in hard mode.  See the Python docstring
+ *   for the exact semantics — kept identical so cross-language test
+ *   data round-trips.
+ * @returns {Array<Object>} Composite rows with the same key names as
+ *   the input plus (for hard mode) the boundary column carrying the
+ *   originating domain value.
+ */
+export function compositeIntervals(intervals, valueCol, options = {}) {
+  const fromCol = options.fromCol || 'from';
+  const toCol = options.toCol || 'to';
+  const holeCol = options.holeCol || 'hole_id';
+  const length = options.length ?? 1.0;
+  const method = options.method || 'average';
+  const mode = options.mode || 'soft';
+  const boundaryCol = options.boundaryCol;
+  const residual = options.residual || 'discard';
+
+  if (mode !== 'soft' && mode !== 'hard') {
+    throw new Error(`mode must be "soft" or "hard", got "${mode}"`);
+  }
+  if (mode === 'hard') {
+    if (!boundaryCol) throw new Error('mode="hard" requires a boundaryCol');
+    if (!['discard', 'add_to_previous', 'distribute'].includes(residual)) {
+      throw new Error(`residual must be one of discard, add_to_previous, distribute; got "${residual}"`);
+    }
+  }
+  if (!intervals || !intervals.length) return [];
+
+  // Group by hole id, preserving each hole's original sort.
+  const byHole = new Map();
+  for (const row of intervals) {
+    const id = row[holeCol];
+    if (id == null) continue;
+    if (!byHole.has(id)) byHole.set(id, []);
+    byHole.get(id).push(row);
+  }
+  for (const rows of byHole.values()) {
+    rows.sort((a, b) => Number(a[fromCol]) - Number(b[fromCol]));
+  }
+
+  const out = [];
+  if (mode === 'soft') {
+    for (const [holeId, rows] of byHole.entries()) {
+      const start = Math.min(...rows.map((r) => Number(r[fromCol])));
+      const end = Math.max(...rows.map((r) => Number(r[toCol])));
+      for (let cFrom = start; cFrom < end; cFrom += length) {
+        const cTo = cFrom + length;
+        const row = composeBin(rows, valueCol, fromCol, toCol, cFrom, cTo, method);
+        if (row == null) continue;
+        row[holeCol] = holeId;
+        out.push(row);
+      }
+    }
+    return out;
+  }
+
+  // Hard mode: walk each hole, split into contiguous same-domain
+  // runs, bin each domain individually.
+  for (const [holeId, rows] of byHole.entries()) {
+    const runs = groupRuns(rows, fromCol, toCol, boundaryCol);
+    for (const run of runs) {
+      const start = Math.min(...run.map((r) => Number(r[fromCol])));
+      const end = Math.max(...run.map((r) => Number(r[toCol])));
+      const domainValue = run[0][boundaryCol];
+      const edges = binEdgesForDomain(start, end, length, residual);
+      for (let i = 0; i < edges.length - 1; i += 1) {
+        const row = composeBin(run, valueCol, fromCol, toCol, edges[i], edges[i + 1], method);
+        if (row == null) continue;
+        row[holeCol] = holeId;
+        row[boundaryCol] = domainValue;
+        out.push(row);
+      }
+    }
+  }
+  return out;
+}
+
+function composeBin(rows, valueCol, fromCol, toCol, cFrom, cTo, method) {
+  let weightedSum = 0;
+  let totalOverlap = 0;
+  for (const r of rows) {
+    const f = Number(r[fromCol]);
+    const t = Number(r[toCol]);
+    if (!(f < cTo) || !(t > cFrom)) continue;
+    const overlap = Math.min(t, cTo) - Math.max(f, cFrom);
+    if (!(overlap > 0)) continue;
+    const v = Number(r[valueCol]);
+    if (!Number.isFinite(v)) continue;
+    weightedSum += v * overlap;
+    totalOverlap += overlap;
+  }
+  if (totalOverlap <= 0) return null;
+  const value = method === 'sum' ? weightedSum : weightedSum / totalOverlap;
+  return { [fromCol]: cFrom, [toCol]: cTo, [valueCol]: value };
+}
+
+function groupRuns(rows, fromCol, toCol, boundaryCol) {
+  if (!rows.length) return [];
+  const tol = 1e-9;
+  const runs = [];
+  let current = [];
+  let prevTo = null;
+  let prevDomain = null;
+  for (const row of rows) {
+    const domain = row[boundaryCol];
+    const sameDomain = prevDomain != null && domain === prevDomain;
+    const abuts = prevTo == null || Math.abs(Number(row[fromCol]) - prevTo) <= tol;
+    if (current.length && sameDomain && abuts) {
+      current.push(row);
+    } else {
+      if (current.length) runs.push(current);
+      current = [row];
+    }
+    prevTo = Number(row[toCol]);
+    prevDomain = domain;
+  }
+  if (current.length) runs.push(current);
+  return runs;
+}
+
+function binEdgesForDomain(start, end, length, residual) {
+  const domainLength = end - start;
+  if (domainLength <= 0) return [];
+  if (residual === 'distribute') {
+    const nBins = Math.max(1, Math.round(domainLength / length));
+    const binLen = domainLength / nBins;
+    const edges = [];
+    for (let i = 0; i <= nBins; i += 1) edges.push(start + i * binLen);
+    return edges;
+  }
+  const nFull = Math.floor(domainLength / length + 1e-9);
+  const remainder = domainLength - nFull * length;
+  const hasResidual = remainder > 1e-9;
+  const edges = [];
+  for (let i = 0; i <= nFull; i += 1) edges.push(start + i * length);
+
+  if (!hasResidual) return edges;
+  if (residual === 'discard') {
+    if (nFull === 0) return [];
+    return edges;
+  }
+  if (residual === 'add_to_previous') {
+    if (nFull === 0) return [start, end];
+    edges[edges.length - 1] = end;
+    return edges;
+  }
+  return edges;
+}

--- a/javascript/packages/baselode/src/index.js
+++ b/javascript/packages/baselode/src/index.js
@@ -160,6 +160,10 @@ export {
 } from './data/intercepts.js';
 
 export {
+  compositeIntervals
+} from './data/composite.js';
+
+export {
   intervalLength,
   fromToMidpoints,
   detectGaps,

--- a/javascript/packages/baselode/tests/composite.test.js
+++ b/javascript/packages/baselode/tests/composite.test.js
@@ -42,6 +42,19 @@ describe('compositeIntervals — soft mode', () => {
   it('returns empty for empty input', () => {
     expect(compositeIntervals([], 'value')).toEqual([]);
   });
+
+  it('rejects non-positive length (would loop forever in soft mode)', () => {
+    const data = intervals('A', [0, 1, 2], [1, 2]);
+    expect(() => compositeIntervals(data, 'value', { length: 0 })).toThrow(/length/);
+    expect(() => compositeIntervals(data, 'value', { length: -1 })).toThrow(/length/);
+    expect(() => compositeIntervals(data, 'value', { length: NaN })).toThrow(/length/);
+    expect(() => compositeIntervals(data, 'value', { length: Infinity })).toThrow(/length/);
+  });
+
+  it('rejects unknown method', () => {
+    const data = intervals('A', [0, 1, 2], [1, 2]);
+    expect(() => compositeIntervals(data, 'value', { method: 'median' })).toThrow(/method/);
+  });
 });
 
 describe('compositeIntervals — hard mode', () => {

--- a/javascript/packages/baselode/tests/composite.test.js
+++ b/javascript/packages/baselode/tests/composite.test.js
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2026 Darkmine Pty Ltd
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { describe, expect, it } from 'vitest';
+import { compositeIntervals } from '../src/data/composite.js';
+
+function intervals(holeId, edges, values, domains) {
+  const out = [];
+  for (let i = 0; i < edges.length - 1; i += 1) {
+    const row = { hole_id: holeId, from: edges[i], to: edges[i + 1], value: values[i] };
+    if (domains) row.domain = domains[i];
+    out.push(row);
+  }
+  return out;
+}
+
+describe('compositeIntervals — soft mode', () => {
+  it('defaults to soft mode', () => {
+    const data = intervals('A', [0, 1, 2, 3], [1, 2, 3]);
+    const a = compositeIntervals(data, 'value', { length: 1.5 });
+    const b = compositeIntervals(data, 'value', { length: 1.5, mode: 'soft' });
+    expect(a).toEqual(b);
+  });
+
+  it('length-weighted average per bin', () => {
+    const data = intervals('A', [0, 1, 2, 3, 4, 5], [1, 2, 3, 4, 5]);
+    const out = compositeIntervals(data, 'value', { length: 2 });
+    expect(out[0].value).toBeCloseTo(1.5, 9);
+    expect(out[1].value).toBeCloseTo(3.5, 9);
+    expect(out[2].value).toBeCloseTo(5.0, 9);
+  });
+
+  it('method=sum preserves total value*length', () => {
+    const data = intervals('A', [0, 1, 2, 3, 4, 5], [1, 2, 3, 4, 5]);
+    const out = compositeIntervals(data, 'value', { length: 2, method: 'sum' });
+    const total = out.reduce((s, r) => s + r.value, 0);
+    expect(total).toBeCloseTo(15, 9);
+  });
+
+  it('returns empty for empty input', () => {
+    expect(compositeIntervals([], 'value')).toEqual([]);
+  });
+});
+
+describe('compositeIntervals — hard mode', () => {
+  it('requires boundaryCol', () => {
+    const data = intervals('A', [0, 1, 2], [1, 2]);
+    expect(() => compositeIntervals(data, 'value', { mode: 'hard' })).toThrow(/boundaryCol/);
+  });
+
+  it('never straddles a coded contact', () => {
+    const data = intervals(
+      'A',
+      [0, 1, 2, 3, 4, 5, 6],
+      [1, 1, 1, 9, 9, 9],
+      ['G', 'G', 'G', 'S', 'S', 'S'],
+    );
+    const out = compositeIntervals(data, 'value', {
+      length: 2, mode: 'hard', boundaryCol: 'domain',
+    });
+    for (const row of out) {
+      expect(row.from < 3 && row.to > 3).toBe(false);
+    }
+    expect(new Set(out.map((r) => r.domain))).toEqual(new Set(['G', 'S']));
+  });
+
+  it('residual=discard drops a short tail', () => {
+    const data = intervals('A', [0, 1, 2, 3], [1, 1, 5], ['G', 'G', 'G']);
+    const out = compositeIntervals(data, 'value', {
+      length: 2, mode: 'hard', boundaryCol: 'domain', residual: 'discard',
+    });
+    expect(out).toHaveLength(1);
+    expect(out[0].to).toBeCloseTo(2, 9);
+  });
+
+  it('residual=add_to_previous extends the last bin', () => {
+    const data = intervals('A', [0, 1, 2, 3], [1, 1, 5], ['G', 'G', 'G']);
+    const out = compositeIntervals(data, 'value', {
+      length: 2, mode: 'hard', boundaryCol: 'domain', residual: 'add_to_previous',
+    });
+    expect(out).toHaveLength(1);
+    expect(out[0].to).toBeCloseTo(3, 9);
+    expect(out[0].value).toBeCloseTo(7 / 3, 9);
+  });
+
+  it('residual=distribute uses round(D/length) equal bins', () => {
+    const data = intervals('A', [0, 1, 2, 3], [2, 4, 6], ['G', 'G', 'G']);
+    const out = compositeIntervals(data, 'value', {
+      length: 2, mode: 'hard', boundaryCol: 'domain', residual: 'distribute',
+    });
+    expect(out).toHaveLength(2);
+    expect(out[0].from).toBeCloseTo(0, 9);
+    expect(out[0].to).toBeCloseTo(1.5, 9);
+    expect(out[1].from).toBeCloseTo(1.5, 9);
+    expect(out[1].to).toBeCloseTo(3, 9);
+  });
+
+  it('non-abutting same-domain rows form separate runs', () => {
+    const data = [
+      { hole_id: 'A', from: 0, to: 1, value: 1, domain: 'G' },
+      { hole_id: 'A', from: 1, to: 2, value: 1, domain: 'G' },
+      // 3 m gap
+      { hole_id: 'A', from: 5, to: 6, value: 9, domain: 'G' },
+      { hole_id: 'A', from: 6, to: 7, value: 9, domain: 'G' },
+    ];
+    const out = compositeIntervals(data, 'value', {
+      length: 2, mode: 'hard', boundaryCol: 'domain',
+    });
+    const froms = out.map((r) => r.from).sort((a, b) => a - b);
+    expect(froms).toEqual([0, 5]);
+  });
+});

--- a/python/src/baselode/drill/composite.py
+++ b/python/src/baselode/drill/composite.py
@@ -22,13 +22,137 @@
 import numpy as np
 import pandas as pd
 
-from baselode.datamodel import EASTING, NORTHING, ELEVATION
+from baselode.datamodel import (
+    AZIMUTH,
+    DIP,
+    EASTING,
+    ELEVATION,
+    HOLE_ID,
+    NORTHING,
+)
+from baselode.drill.desurvey import interpolate_trajectory
 
 
-def composite_intervals(df, value_col, from_col="from", to_col="to", length=1.0, method="average"):
+_SOFT = "soft"
+_HARD = "hard"
+_VALID_MODES = (_SOFT, _HARD)
+
+_RESIDUAL_DISCARD = "discard"
+_RESIDUAL_ADD_TO_PREVIOUS = "add_to_previous"
+_RESIDUAL_DISTRIBUTE = "distribute"
+_VALID_RESIDUALS = (_RESIDUAL_DISCARD, _RESIDUAL_ADD_TO_PREVIOUS, _RESIDUAL_DISTRIBUTE)
+
+
+def composite_intervals(
+    df,
+    value_col,
+    from_col="from",
+    to_col="to",
+    length=1.0,
+    method="average",
+    *,
+    mode="soft",
+    boundary_col=None,
+    residual="discard",
+):
+    """Length-weighted compositing of downhole intervals.
+
+    Two boundary modes are supported:
+
+    * ``mode="soft"`` (default) — uniform bins of *length* spanning
+      each hole's full ``[min(from), max(to))`` range.  Each output
+      bin's value is the length-weighted average (or sum) of the
+      source intervals overlapping it.  This is the FractalGeoAnalytics
+      ``dhcomp`` (2023) default, also called "smear" or
+      "soft-boundary" compositing — composites freely cross geological
+      contacts.
+    * ``mode="hard"`` — bins reset at every change in *boundary_col*
+      within a hole.  No composite straddles a coded contact, so each
+      output row carries a single ``boundary_col`` value.  Useful for
+      domain-aware compositing (lithology, regolith, alteration).
+
+    The *residual* parameter controls how a short tail inside a
+    ``mode="hard"`` domain is handled when its length isn't an exact
+    multiple of *length*:
+
+    * ``"discard"`` (default) — drop the residual run.
+    * ``"add_to_previous"`` — merge the residual into the previous
+      composite within the same domain; the prior composite's ``to``
+      extends to the domain end.
+    * ``"distribute"`` — choose ``n_bins = max(1, round(D / length))``
+      where ``D`` is the domain length, then split the domain into
+      *n_bins* equal-length composites.  Net effect: bin length is
+      stretched (or compressed) so the integer bin count exactly
+      covers the domain.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Interval table.  Must carry ``hole_id``, *from_col*, *to_col*
+        and *value_col*; when ``mode="hard"`` also *boundary_col*.
+    value_col : str
+        Numeric column to composite.
+    from_col, to_col : str
+        Interval depth columns.  Default ``"from"`` / ``"to"``.
+    length : float
+        Composite length in metres (downhole).  Default ``1.0``.
+    method : {"average", "sum"}
+        Length-weighted average (default) or sum.  Average is
+        :math:`\\sum v_i w_i / \\sum w_i`; sum is :math:`\\sum v_i w_i`
+        where ``w_i`` is the overlap length between source interval
+        ``i`` and the composite bin.
+    mode : {"soft", "hard"}
+        Boundary handling.  Default ``"soft"`` preserves prior
+        behaviour.
+    boundary_col : str, optional
+        Domain column for ``mode="hard"``.  Required in hard mode;
+        ignored in soft mode.
+    residual : {"discard", "add_to_previous", "distribute"}
+        Tail-of-domain handling for ``mode="hard"``.  Ignored in soft
+        mode.  Default ``"discard"``.
+
+    Returns
+    -------
+    pd.DataFrame
+        Composites with columns ``hole_id``, *from_col*, *to_col*,
+        *value_col*, plus *boundary_col* when ``mode="hard"``.
+
+    Notes
+    -----
+    Mass-balance: in either mode, ``sum(value × overlap)`` over each
+    source interval equals the corresponding contribution into the
+    composites.  In ``method="sum"`` the per-hole grand total of
+    ``value × overlap`` is preserved (modulo intervals dropped by
+    residual handling).  In ``method="average"`` the per-composite
+    weighted average equals the source weighted average within that
+    bin's coverage window.
+
+    References
+    ----------
+    FractalGeoAnalytics, *dhcomp — downhole compositing utility*
+    (2023).  https://github.com/FractalGeoAnalytics/dhcomp
+    """
+    if mode not in _VALID_MODES:
+        raise ValueError(f"mode must be one of {_VALID_MODES}, got {mode!r}")
+    if mode == _HARD:
+        if not boundary_col:
+            raise ValueError("mode='hard' requires a boundary_col")
+        if residual not in _VALID_RESIDUALS:
+            raise ValueError(f"residual must be one of {_VALID_RESIDUALS}, got {residual!r}")
+        if boundary_col not in df.columns:
+            raise ValueError(f"boundary_col {boundary_col!r} not in DataFrame columns")
     if df.empty:
         return df.copy()
+
     df_sorted = df.sort_values(["hole_id", from_col])
+    if mode == _SOFT:
+        return _composite_soft(df_sorted, value_col, from_col, to_col, length, method)
+    return _composite_hard(
+        df_sorted, value_col, from_col, to_col, length, method, boundary_col, residual
+    )
+
+
+def _composite_soft(df_sorted, value_col, from_col, to_col, length, method):
     composites = []
     for hole_id, group in df_sorted.groupby("hole_id"):
         start = group[from_col].min()
@@ -37,17 +161,361 @@ def composite_intervals(df, value_col, from_col="from", to_col="to", length=1.0,
         for i in range(len(bins) - 1):
             c_from = bins[i]
             c_to = bins[i + 1]
-            window = group[(group[from_col] < c_to) & (group[to_col] > c_from)]
-            if window.empty:
+            row = _composite_bin(group, value_col, from_col, to_col, c_from, c_to, method)
+            if row is None:
                 continue
-            overlap_len = (np.minimum(window[to_col], c_to) - np.maximum(window[from_col], c_from)).clip(lower=0)
-            weights = overlap_len / overlap_len.sum()
-            if method == "sum":
-                val = (window[value_col] * overlap_len).sum()
-            else:
-                val = (window[value_col] * weights).sum()
-            composites.append({"hole_id": hole_id, from_col: c_from, to_col: c_to, value_col: val})
+            row["hole_id"] = hole_id
+            composites.append(row)
     return pd.DataFrame(composites)
+
+
+def _composite_hard(
+    df_sorted, value_col, from_col, to_col, length, method, boundary_col, residual
+):
+    composites = []
+    for hole_id, hole_group in df_sorted.groupby("hole_id"):
+        # Walk the hole top-to-bottom and split into contiguous domain
+        # runs.  A "run" is a maximal stretch of rows where
+        # boundary_col holds the same value AND the rows abut (the
+        # `to` of one equals the `from` of the next, within tolerance).
+        # Non-abutting same-domain rows are still treated as separate
+        # runs, which matches how hard-boundary compositing treats
+        # unsurveyed gaps as breaks.
+        runs = _group_runs(hole_group, from_col, to_col, boundary_col)
+        for run in runs:
+            domain_value = run[boundary_col].iloc[0]
+            start = run[from_col].min()
+            end = run[to_col].max()
+            domain_length = end - start
+            if domain_length <= 0:
+                continue
+            edges = _bin_edges_for_domain(start, end, length, residual)
+            for c_from, c_to in zip(edges[:-1], edges[1:]):
+                row = _composite_bin(run, value_col, from_col, to_col, c_from, c_to, method)
+                if row is None:
+                    continue
+                row["hole_id"] = hole_id
+                row[boundary_col] = domain_value
+                composites.append(row)
+    return pd.DataFrame(composites)
+
+
+def _group_runs(hole_group, from_col, to_col, boundary_col):
+    """Split a hole's intervals into contiguous, same-domain runs."""
+    if hole_group.empty:
+        return []
+    runs = []
+    current = []
+    prev_to = None
+    prev_domain = None
+    tol = 1e-9
+    for _, row in hole_group.iterrows():
+        domain = row[boundary_col]
+        same_domain = (prev_domain is not None and domain == prev_domain)
+        abuts = prev_to is None or abs(row[from_col] - prev_to) <= tol
+        if current and same_domain and abuts:
+            current.append(row)
+        else:
+            if current:
+                runs.append(pd.DataFrame(current))
+            current = [row]
+        prev_to = row[to_col]
+        prev_domain = domain
+    if current:
+        runs.append(pd.DataFrame(current))
+    return runs
+
+
+def _bin_edges_for_domain(start, end, length, residual):
+    """Compute composite bin edges within a hard-boundary domain.
+
+    Returns a list of monotonically-increasing edges; the bins are the
+    consecutive pairs.  Honors the three residual rules.
+    """
+    domain_length = end - start
+    if domain_length <= 0:
+        return []
+    n_full = int(np.floor(domain_length / length + 1e-9))
+    remainder = domain_length - n_full * length
+    has_residual = remainder > 1e-9
+
+    if residual == _RESIDUAL_DISTRIBUTE:
+        # Round to nearest integer bin count, minimum one bin.
+        n_bins = max(1, int(np.rint(domain_length / length)))
+        bin_len = domain_length / n_bins
+        return [start + i * bin_len for i in range(n_bins + 1)]
+
+    edges = [start + i * length for i in range(n_full + 1)]
+    if not has_residual:
+        return edges
+
+    if residual == _RESIDUAL_DISCARD:
+        # Drop the residual: if no full bin fits, return an empty
+        # cover so the caller emits nothing for this domain.
+        if n_full == 0:
+            return []
+        return edges
+
+    if residual == _RESIDUAL_ADD_TO_PREVIOUS:
+        if n_full == 0:
+            # No prior composite to extend — fall back to a single
+            # bin covering the whole domain so the data isn't lost.
+            return [start, end]
+        # Extend the last composite to the domain end.
+        edges[-1] = end
+        return edges
+
+    return edges  # unreachable; mode is validated upstream
+
+
+def _composite_bin(group, value_col, from_col, to_col, c_from, c_to, method):
+    """Compute one composite row over [c_from, c_to) from *group*.
+
+    Returns ``None`` when no source interval overlaps the bin, so the
+    caller can skip rather than emit an all-zero composite.
+    """
+    window = group[(group[from_col] < c_to) & (group[to_col] > c_from)]
+    if window.empty:
+        return None
+    overlap_len = (
+        np.minimum(window[to_col], c_to) - np.maximum(window[from_col], c_from)
+    ).clip(lower=0)
+    total_overlap = overlap_len.sum()
+    if total_overlap <= 0:
+        return None
+    if method == "sum":
+        val = (window[value_col] * overlap_len).sum()
+    else:
+        weights = overlap_len / total_overlap
+        val = (window[value_col] * weights).sum()
+    return {from_col: c_from, to_col: c_to, value_col: val}
+
+
+def composite_true_thickness(
+    intervals,
+    traces,
+    value_col,
+    ref_dip,
+    ref_dip_azimuth,
+    from_col="from",
+    to_col="to",
+    length=1.0,
+    method="average",
+    hole_col=HOLE_ID,
+):
+    """Composite intervals with true-thickness reporting.
+
+    For each source interval, the midpoint orientation is looked up in
+    *traces* via :func:`~baselode.drill.desurvey.interpolate_trajectory`
+    and used to compute the interval's *true thickness* — the
+    perpendicular distance traversed across a reference plane defined
+    by *ref_dip* and *ref_dip_azimuth*:
+
+    .. math::
+
+        L_{\\mathrm{true}} = L_{\\mathrm{downhole}} \\cdot
+            \\lvert \\hat T \\cdot \\hat N \\rvert
+
+    where :math:`\\hat T` is the hole's unit tangent at the interval
+    midpoint and :math:`\\hat N` is the unit normal of the reference
+    plane.  Compositing then runs in soft-boundary mode over the
+    cumulative *true thickness* coordinate — each output composite
+    spans ``length`` of true thickness, with its downhole ``from`` /
+    ``to`` recovered from the inverse cumulative map.
+
+    Use this when you need composites that represent equal stratigraphic
+    thickness across a known orebody plane — the "economic compositing"
+    convention in resource estimation (Sinclair & Blackwell 2002,
+    *Applied Mineral Inventory Estimation*, ch. 5).
+
+    Parameters
+    ----------
+    intervals : pd.DataFrame
+        Interval table with ``hole_id``, *from_col*, *to_col*,
+        *value_col*.
+    traces : pd.DataFrame
+        Desurveyed trace (e.g. output of
+        :func:`~baselode.drill.desurvey.minimum_curvature_desurvey`).
+        Must include orientation columns ``azimuth`` and ``dip`` —
+        without them true thickness cannot be computed.
+    value_col : str
+        Numeric column to composite.
+    ref_dip : float
+        Reference plane dip in degrees (positive downward).  Use
+        ``0`` for a horizontal plane (sub-horizontal seam), ``90``
+        for a vertical plane (steep vein).
+    ref_dip_azimuth : float
+        Dip azimuth (downdip direction) of the reference plane in
+        degrees clockwise from grid north.
+    from_col, to_col : str
+        Interval depth columns.
+    length : float
+        Composite true-thickness in metres.  Default ``1.0``.
+    method : {"average", "sum"}
+        Length-weighting mode, applied with *true thickness* as the
+        weight.
+    hole_col : str
+        Hole identifier column.  Default from
+        :mod:`baselode.datamodel`.
+
+    Returns
+    -------
+    pd.DataFrame
+        One row per composite with columns ``hole_id``, *from_col*,
+        *to_col* (downhole metres), *value_col*, ``length_md``
+        (downhole length covered), ``length_true`` (true thickness
+        of the composite — usually equal to *length* except possibly
+        the last bin per hole).
+
+    Notes
+    -----
+    Sub-vertical drillholes through a sub-horizontal reference plane
+    give :math:`L_{\\mathrm{true}} \\approx L_{\\mathrm{downhole}}`;
+    a hole drilled along the plane (parallel to it) gives
+    :math:`L_{\\mathrm{true}} \\approx 0` and the function emits
+    nothing — no economic thickness is being captured.
+    """
+    if intervals.empty:
+        return intervals.copy()
+    if AZIMUTH not in traces.columns or DIP not in traces.columns:
+        raise ValueError(
+            "true-thickness compositing needs traces with azimuth and dip columns"
+        )
+    plane_normal = _plane_normal(ref_dip, ref_dip_azimuth)
+
+    intervals_sorted = intervals.sort_values([hole_col, from_col]).reset_index(drop=True)
+    midpoints = (intervals_sorted[from_col] + intervals_sorted[to_col]) / 2.0
+    # interpolate_trajectory takes a depths DataFrame for the multi-hole case.
+    depths_request = pd.DataFrame(
+        {hole_col: intervals_sorted[hole_col].values, "depth": midpoints.values}
+    )
+    orient = interpolate_trajectory(traces, depths_request, hole_col=hole_col)
+    # Align orientation rows back onto the interval rows.  Build a
+    # composite key so that duplicate (hole_id, depth) pairs (which
+    # are common in real datasets — two assay rows sharing a midpoint)
+    # can't accidentally cross-join.
+    azimuth = orient[AZIMUTH].to_numpy(dtype=float)
+    dip = orient[DIP].to_numpy(dtype=float)
+    tangents = _tangents_from_azimuth_dip(azimuth, dip)
+    cos_to_normal = np.abs(tangents @ plane_normal)
+    downhole_len = (intervals_sorted[to_col] - intervals_sorted[from_col]).to_numpy(dtype=float)
+    true_per_interval = downhole_len * cos_to_normal
+
+    composites = []
+    for hole_id, hole_group in intervals_sorted.groupby(hole_col, sort=False):
+        idx = hole_group.index.to_numpy()
+        composites.extend(
+            _composite_true_for_hole(
+                hole_id,
+                hole_group.reset_index(drop=True),
+                true_per_interval[idx],
+                value_col,
+                from_col,
+                to_col,
+                length,
+                method,
+            )
+        )
+    return pd.DataFrame(composites)
+
+
+def _composite_true_for_hole(
+    hole_id, hole_group, true_per_interval, value_col, from_col, to_col, length, method
+):
+    out = []
+    cum_true = np.concatenate(([0.0], np.cumsum(true_per_interval)))
+    total_true = cum_true[-1]
+    if total_true <= 0:
+        return out
+    n_bins = int(np.ceil(total_true / length))
+    md_from_arr = hole_group[from_col].to_numpy(dtype=float)
+    md_to_arr = hole_group[to_col].to_numpy(dtype=float)
+    values = hole_group[value_col].to_numpy(dtype=float)
+    for bin_idx in range(n_bins):
+        t0 = bin_idx * length
+        t1 = min((bin_idx + 1) * length, total_true)
+        if t1 - t0 <= 0:
+            continue
+        # For each source interval, compute its true-thickness overlap with [t0, t1).
+        true_starts = cum_true[:-1]
+        true_ends = cum_true[1:]
+        overlap_true = np.minimum(true_ends, t1) - np.maximum(true_starts, t0)
+        overlap_true = np.clip(overlap_true, 0.0, None)
+        total_overlap = overlap_true.sum()
+        if total_overlap <= 0:
+            continue
+        # Per-interval scale factor true/md; safe because we already
+        # rejected intervals contributing zero true thickness (their
+        # overlap_true is zero).
+        true_lengths = true_ends - true_starts
+        md_lengths = md_to_arr - md_from_arr
+        scale = np.where(true_lengths > 0, md_lengths / true_lengths, 0.0)
+        overlap_md = overlap_true * scale
+        # Composite md bounds: start of first contributing interval +
+        # fractional offset, ending at the last contributor's
+        # proportional offset.
+        contrib = overlap_true > 0
+        first = int(np.argmax(contrib))
+        last = len(contrib) - 1 - int(np.argmax(contrib[::-1]))
+        # md offset within each contributing interval
+        md_from = md_from_arr[first] + max(0.0, (t0 - true_starts[first]) * scale[first])
+        md_to = md_from_arr[last] + min(md_lengths[last], (t1 - true_starts[last]) * scale[last])
+        if method == "sum":
+            val = float((values * overlap_true).sum())
+        else:
+            val = float((values * overlap_true).sum() / total_overlap)
+        out.append({
+            "hole_id": hole_id,
+            from_col: float(md_from),
+            to_col: float(md_to),
+            value_col: val,
+            "length_md": float(overlap_md.sum()),
+            "length_true": float(t1 - t0),
+        })
+    return out
+
+
+def _plane_normal(dip_deg, dip_az_deg):
+    """Unit normal of a plane defined by dip + dip-azimuth.
+
+    Convention: dip ``= 0`` → horizontal plane (normal points up, +Z).
+    Dip ``> 0`` rotates the plane about the strike line; dip-azimuth
+    is the downdip direction (azimuth of the downdip vector,
+    clockwise from grid north).
+    """
+    dip = np.deg2rad(dip_deg)
+    az = np.deg2rad(dip_az_deg)
+    # downdip vector
+    dd = np.array([np.sin(az) * np.cos(dip), np.cos(az) * np.cos(dip), -np.sin(dip)])
+    # strike vector — perpendicular to downdip in the horizontal plane
+    strike = np.array([np.cos(az), -np.sin(az), 0.0])
+    # normal = strike × downdip, then normalise
+    normal = np.cross(strike, dd)
+    norm = np.linalg.norm(normal)
+    if norm < 1e-12:
+        return np.array([0.0, 0.0, 1.0])
+    return normal / norm
+
+
+def _tangents_from_azimuth_dip(azimuth_deg, dip_deg):
+    """Hole tangent unit vectors from per-row azimuth + dip (degrees).
+
+    Dip is the angle below horizontal (positive downward, the survey
+    convention used throughout :mod:`baselode.drill`).  Returns an
+    ``(n, 3)`` ``(easting, northing, elevation)`` array.
+    """
+    az = np.deg2rad(azimuth_deg)
+    dp = np.deg2rad(dip_deg)
+    east = np.sin(az) * np.cos(dp)
+    north = np.cos(az) * np.cos(dp)
+    elev = -np.sin(dp)
+    tangents = np.stack([east, north, elev], axis=-1)
+    # Replace NaN rows (depths outside the trace's md range) with
+    # zero — `_composite_true_for_hole` then sees zero true thickness
+    # and drops the interval.
+    nan_mask = np.isnan(tangents).any(axis=-1)
+    tangents[nan_mask] = 0.0
+    return tangents
 
 
 def resample_trace(trace_df, step=1.0):

--- a/python/src/baselode/drill/composite.py
+++ b/python/src/baselode/drill/composite.py
@@ -42,6 +42,8 @@ _RESIDUAL_ADD_TO_PREVIOUS = "add_to_previous"
 _RESIDUAL_DISTRIBUTE = "distribute"
 _VALID_RESIDUALS = (_RESIDUAL_DISCARD, _RESIDUAL_ADD_TO_PREVIOUS, _RESIDUAL_DISTRIBUTE)
 
+_VALID_METHODS = ("average", "sum")
+
 
 def composite_intervals(
     df,
@@ -134,6 +136,10 @@ def composite_intervals(
     """
     if mode not in _VALID_MODES:
         raise ValueError(f"mode must be one of {_VALID_MODES}, got {mode!r}")
+    if method not in _VALID_METHODS:
+        raise ValueError(f"method must be one of {_VALID_METHODS}, got {method!r}")
+    if not (length > 0):
+        raise ValueError(f"length must be > 0, got {length!r}")
     if mode == _HARD:
         if not boundary_col:
             raise ValueError("mode='hard' requires a boundary_col")
@@ -375,6 +381,10 @@ def composite_true_thickness(
     :math:`L_{\\mathrm{true}} \\approx 0` and the function emits
     nothing — no economic thickness is being captured.
     """
+    if method not in _VALID_METHODS:
+        raise ValueError(f"method must be one of {_VALID_METHODS}, got {method!r}")
+    if not (length > 0):
+        raise ValueError(f"length must be > 0, got {length!r}")
     if intervals.empty:
         return intervals.copy()
     if AZIMUTH not in traces.columns or DIP not in traces.columns:
@@ -385,15 +395,17 @@ def composite_true_thickness(
 
     intervals_sorted = intervals.sort_values([hole_col, from_col]).reset_index(drop=True)
     midpoints = (intervals_sorted[from_col] + intervals_sorted[to_col]) / 2.0
-    # interpolate_trajectory takes a depths DataFrame for the multi-hole case.
+    # `interpolate_trajectory` returns one orientation row per requested
+    # (hole, depth) row in the same order it was asked.  Because
+    # `intervals_sorted` (and therefore `depths_request`) is already
+    # ordered by (hole, from_col), we can align the returned tangents
+    # back onto the intervals by positional index — no per-row join is
+    # needed.  This also means duplicate midpoints (two assay rows
+    # sharing a from→to span) stay aligned with their originating row.
     depths_request = pd.DataFrame(
         {hole_col: intervals_sorted[hole_col].values, "depth": midpoints.values}
     )
     orient = interpolate_trajectory(traces, depths_request, hole_col=hole_col)
-    # Align orientation rows back onto the interval rows.  Build a
-    # composite key so that duplicate (hole_id, depth) pairs (which
-    # are common in real datasets — two assay rows sharing a midpoint)
-    # can't accidentally cross-join.
     azimuth = orient[AZIMUTH].to_numpy(dtype=float)
     dip = orient[DIP].to_numpy(dtype=float)
     tangents = _tangents_from_azimuth_dip(azimuth, dip)
@@ -414,13 +426,14 @@ def composite_true_thickness(
                 to_col,
                 length,
                 method,
+                hole_col,
             )
         )
     return pd.DataFrame(composites)
 
 
 def _composite_true_for_hole(
-    hole_id, hole_group, true_per_interval, value_col, from_col, to_col, length, method
+    hole_id, hole_group, true_per_interval, value_col, from_col, to_col, length, method, hole_col
 ):
     out = []
     cum_true = np.concatenate(([0.0], np.cumsum(true_per_interval)))
@@ -465,7 +478,7 @@ def _composite_true_for_hole(
         else:
             val = float((values * overlap_true).sum() / total_overlap)
         out.append({
-            "hole_id": hole_id,
+            hole_col: hole_id,
             from_col: float(md_from),
             to_col: float(md_to),
             value_col: val,

--- a/test/data/parity_contract.json
+++ b/test/data/parity_contract.json
@@ -247,8 +247,19 @@
       ]
     },
     {
+      "name": "compositing",
+      "description": "Length-weighted compositing of downhole intervals. Soft mode (default) bins across each hole's full range and lets composites cross contacts; hard mode resets at every change in a coded boundary column with three residual-handling rules (discard / add_to_previous / distribute). True-thickness / economic compositing is Python-only (TRK-109 scope) because it depends on a desurveyed trace.",
+      "jsExports": [
+        "compositeIntervals"
+      ],
+      "pythonSymbols": [
+        ["baselode.drill.composite", "composite_intervals"],
+        ["baselode.drill.composite", "composite_true_thickness"]
+      ]
+    },
+    {
       "name": "drillhole_set",
-      "description": "Composition root for drilling tables — a thin object that holds collar + survey + N named interval tables plus optional CRS/project metadata. Both languages expose validate + desurvey + cached traces as methods; the Python class additionally provides composite() and to_omf() — the JS class intentionally omits both per TRK-111 (OMF is Python-only) and because there is no JS composite primitive yet. No new algorithmic logic; every method delegates to the existing function-based API.",
+      "description": "Composition root for drilling tables — a thin object that holds collar + survey + N named interval tables plus optional CRS/project metadata. Both languages expose validate + desurvey + cached traces as methods; the Python class additionally provides composite() and to_omf() — the JS class intentionally omits to_omf per TRK-111 (OMF is Python-only). No new algorithmic logic; every method delegates to the existing function-based API.",
       "jsExports": [
         "DrillholeSet"
       ],

--- a/test/test_drill_composite.py
+++ b/test/test_drill_composite.py
@@ -70,6 +70,18 @@ class TestSoftMode:
         out = composite_intervals(df, "value")
         assert out.empty
 
+    def test_rejects_non_positive_length(self):
+        df = _make_intervals("A", [0, 1, 2], [1.0, 2.0])
+        with pytest.raises(ValueError, match="length"):
+            composite_intervals(df, "value", length=0)
+        with pytest.raises(ValueError, match="length"):
+            composite_intervals(df, "value", length=-1.5)
+
+    def test_rejects_unknown_method(self):
+        df = _make_intervals("A", [0, 1, 2], [1.0, 2.0])
+        with pytest.raises(ValueError, match="method"):
+            composite_intervals(df, "value", method="median")
+
 
 class TestHardMode:
     def test_requires_boundary_col(self):
@@ -255,6 +267,33 @@ class TestTrueThickness:
         # No measurable thickness traversed → either empty or all-zero.
         if not out.empty:
             assert (out["length_true"] < 1e-6).all()
+
+    def test_rejects_non_positive_length_and_bad_method(self):
+        traces = self._vertical_trace(max_md=5.0)
+        intervals = _make_intervals("A", np.arange(0, 6), [1.0] * 5)
+        with pytest.raises(ValueError, match="length"):
+            composite_true_thickness(
+                intervals, traces, value_col="value",
+                ref_dip=0.0, ref_dip_azimuth=0.0, length=0,
+            )
+        with pytest.raises(ValueError, match="method"):
+            composite_true_thickness(
+                intervals, traces, value_col="value",
+                ref_dip=0.0, ref_dip_azimuth=0.0, method="median",
+            )
+
+    def test_honours_custom_hole_col(self):
+        # Caller uses `well_id` instead of the default `hole_id`.
+        traces = self._vertical_trace(max_md=5.0).rename(columns={HOLE_ID: "well_id"})
+        intervals = _make_intervals("A", np.arange(0, 6), [1.0] * 5).rename(columns={"hole_id": "well_id"})
+        out = composite_true_thickness(
+            intervals, traces, value_col="value",
+            ref_dip=0.0, ref_dip_azimuth=0.0, length=1.0,
+            hole_col="well_id",
+        )
+        assert "well_id" in out.columns
+        assert "hole_id" not in out.columns
+        assert set(out["well_id"]) == {"A"}
 
     def test_inclined_hole_planar_lode_matches_analytic_cos(self):
         # Inclined hole (60° dip due north) cutting through a

--- a/test/test_drill_composite.py
+++ b/test/test_drill_composite.py
@@ -1,0 +1,300 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2026 Darkmine Pty Ltd
+
+"""Tests for compositing primitives.
+
+Covers:
+- Soft-boundary mass-balance: `value * overlap` conserved across composites.
+- Hard-boundary mode: composites never straddle a coded contact.
+- Hard-boundary residual rules: discard / add_to_previous / distribute.
+- True-thickness compositing against an analytic planar lode case.
+"""
+
+import math
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from baselode.datamodel import AZIMUTH, DIP, EASTING, ELEVATION, HOLE_ID, NORTHING
+from baselode.drill.composite import (
+    composite_intervals,
+    composite_true_thickness,
+    _plane_normal,
+    _tangents_from_azimuth_dip,
+)
+
+
+def _make_intervals(hole_id, edges, value_seq, boundary_seq=None):
+    rows = []
+    for i in range(len(edges) - 1):
+        row = {
+            "hole_id": hole_id,
+            "from": edges[i],
+            "to": edges[i + 1],
+            "value": value_seq[i],
+        }
+        if boundary_seq is not None:
+            row["domain"] = boundary_seq[i]
+        rows.append(row)
+    return pd.DataFrame(rows)
+
+
+class TestSoftMode:
+    def test_default_is_soft_backward_compat(self):
+        df = _make_intervals("A", [0, 1, 2, 3, 4], [10.0, 20.0, 30.0, 40.0])
+        a = composite_intervals(df, "value", length=2.0)
+        b = composite_intervals(df, "value", length=2.0, mode="soft")
+        pd.testing.assert_frame_equal(a, b)
+
+    def test_mass_balance_average(self):
+        # 5x1m intervals; composite to 2m. Length-weighted average is
+        # well-defined per bin and the per-bin sum(value*overlap)
+        # equals the source contribution.
+        df = _make_intervals("A", np.arange(0, 6), [1.0, 2.0, 3.0, 4.0, 5.0])
+        out = composite_intervals(df, "value", length=2.0, method="average")
+        # Per 2m composite: average of two consecutive source values.
+        assert pytest.approx(out.loc[0, "value"]) == 1.5
+        assert pytest.approx(out.loc[1, "value"]) == 3.5
+        # Third bin spans md=[4,6] but only md=[4,5] has data → value 5.0.
+        assert pytest.approx(out.loc[2, "value"]) == 5.0
+
+    def test_mass_balance_sum_full_hole(self):
+        df = _make_intervals("A", np.arange(0, 6), [1.0, 2.0, 3.0, 4.0, 5.0])
+        out = composite_intervals(df, "value", length=2.0, method="sum")
+        # Source total value*length = 1+2+3+4+5 = 15
+        assert pytest.approx(out["value"].sum()) == 15.0
+
+    def test_empty_passthrough(self):
+        df = pd.DataFrame(columns=["hole_id", "from", "to", "value"])
+        out = composite_intervals(df, "value")
+        assert out.empty
+
+
+class TestHardMode:
+    def test_requires_boundary_col(self):
+        df = _make_intervals("A", [0, 1, 2], [1.0, 2.0])
+        with pytest.raises(ValueError, match="boundary_col"):
+            composite_intervals(df, "value", mode="hard")
+
+    def test_rejects_unknown_residual(self):
+        df = _make_intervals("A", [0, 1, 2], [1.0, 2.0], boundary_seq=["G", "G"])
+        with pytest.raises(ValueError, match="residual"):
+            composite_intervals(
+                df, "value", mode="hard", boundary_col="domain", residual="bogus"
+            )
+
+    def test_never_straddles_boundary(self):
+        # Two domains end-to-end: G from 0–3, S from 3–6.
+        df = _make_intervals(
+            "A",
+            [0, 1, 2, 3, 4, 5, 6],
+            [1.0, 1.0, 1.0, 9.0, 9.0, 9.0],
+            boundary_seq=["G", "G", "G", "S", "S", "S"],
+        )
+        out = composite_intervals(
+            df, "value", length=2.0, mode="hard", boundary_col="domain"
+        )
+        # No composite spans the 3.0 contact.
+        for _, row in out.iterrows():
+            assert not (row["from"] < 3.0 and row["to"] > 3.0), (
+                f"composite {row['from']}-{row['to']} crossed the boundary"
+            )
+        # Each composite carries the originating domain.
+        assert set(out["domain"]) == {"G", "S"}
+
+    def test_residual_discard_drops_short_tail(self):
+        # Domain 0–3 with length=2 leaves a 1m tail.
+        df = _make_intervals(
+            "A",
+            [0, 1, 2, 3],
+            [1.0, 1.0, 5.0],
+            boundary_seq=["G", "G", "G"],
+        )
+        out = composite_intervals(
+            df, "value", length=2.0, mode="hard", boundary_col="domain", residual="discard"
+        )
+        assert len(out) == 1
+        assert pytest.approx(out.loc[0, "to"]) == 2.0
+
+    def test_residual_add_to_previous_extends_last_bin(self):
+        df = _make_intervals(
+            "A",
+            [0, 1, 2, 3],
+            [1.0, 1.0, 5.0],
+            boundary_seq=["G", "G", "G"],
+        )
+        out = composite_intervals(
+            df,
+            "value",
+            length=2.0,
+            mode="hard",
+            boundary_col="domain",
+            residual="add_to_previous",
+        )
+        assert len(out) == 1
+        assert pytest.approx(out.loc[0, "to"]) == 3.0
+        # Length-weighted: (1*1 + 1*1 + 5*1)/3 = 7/3
+        assert pytest.approx(out.loc[0, "value"]) == 7.0 / 3.0
+
+    def test_residual_distribute_stretches_bin_length(self):
+        # Domain 0–3 with length=2: distribute → round(3/2)=2 bins of 1.5m each.
+        df = _make_intervals(
+            "A",
+            [0, 1, 2, 3],
+            [2.0, 4.0, 6.0],
+            boundary_seq=["G", "G", "G"],
+        )
+        out = composite_intervals(
+            df,
+            "value",
+            length=2.0,
+            mode="hard",
+            boundary_col="domain",
+            residual="distribute",
+        )
+        assert len(out) == 2
+        assert pytest.approx(out.loc[0, "from"]) == 0.0
+        assert pytest.approx(out.loc[0, "to"]) == 1.5
+        assert pytest.approx(out.loc[1, "from"]) == 1.5
+        assert pytest.approx(out.loc[1, "to"]) == 3.0
+
+    def test_residual_add_to_previous_handles_subbin_domain(self):
+        # Domain shorter than length: no prior bin to extend → emit one
+        # bin covering the whole domain so the data isn't dropped.
+        df = _make_intervals("A", [0, 0.5], [3.0], boundary_seq=["G"])
+        out = composite_intervals(
+            df,
+            "value",
+            length=2.0,
+            mode="hard",
+            boundary_col="domain",
+            residual="add_to_previous",
+        )
+        assert len(out) == 1
+        assert pytest.approx(out.loc[0, "from"]) == 0.0
+        assert pytest.approx(out.loc[0, "to"]) == 0.5
+
+    def test_non_abutting_intervals_break_runs(self):
+        # Two same-domain runs separated by an unsampled gap.
+        df = pd.DataFrame(
+            [
+                {"hole_id": "A", "from": 0.0, "to": 1.0, "value": 1.0, "domain": "G"},
+                {"hole_id": "A", "from": 1.0, "to": 2.0, "value": 1.0, "domain": "G"},
+                # gap from 2 to 5
+                {"hole_id": "A", "from": 5.0, "to": 6.0, "value": 9.0, "domain": "G"},
+                {"hole_id": "A", "from": 6.0, "to": 7.0, "value": 9.0, "domain": "G"},
+            ]
+        )
+        out = composite_intervals(
+            df, "value", length=2.0, mode="hard", boundary_col="domain"
+        )
+        # Expect one composite per contiguous run.
+        froms = sorted(out["from"].tolist())
+        assert froms == [0.0, 5.0]
+
+
+class TestTrueThickness:
+    @staticmethod
+    def _vertical_trace(hole_id="A", max_md=50.0, step=1.0):
+        """A single vertical hole at the origin, dip=90 azimuth=0."""
+        mds = np.arange(0, max_md + step, step)
+        return pd.DataFrame({
+            HOLE_ID: hole_id,
+            "md": mds,
+            EASTING: np.zeros_like(mds),
+            NORTHING: np.zeros_like(mds),
+            ELEVATION: -mds,  # going down → elevation drops
+            AZIMUTH: np.zeros_like(mds),
+            DIP: np.full_like(mds, 90.0),
+        })
+
+    @staticmethod
+    def _inclined_trace(hole_id="A", dip_deg=60.0, max_md=50.0, step=1.0):
+        """A straight-line inclined hole: azimuth=0 (north), constant dip."""
+        mds = np.arange(0, max_md + step, step)
+        dip_rad = math.radians(dip_deg)
+        north = mds * math.cos(dip_rad)
+        elev = -mds * math.sin(dip_rad)
+        return pd.DataFrame({
+            HOLE_ID: hole_id,
+            "md": mds,
+            EASTING: np.zeros_like(mds),
+            NORTHING: north,
+            ELEVATION: elev,
+            AZIMUTH: np.zeros_like(mds),
+            DIP: np.full_like(mds, dip_deg),
+        })
+
+    def test_vertical_hole_horizontal_plane_full_thickness(self):
+        # Vertical hole through a horizontal reference plane:
+        # true thickness == downhole length.
+        traces = self._vertical_trace(max_md=10.0)
+        intervals = _make_intervals("A", np.arange(0, 11), [i + 1.0 for i in range(10)])
+        out = composite_true_thickness(
+            intervals, traces, value_col="value",
+            ref_dip=0.0, ref_dip_azimuth=0.0, length=1.0,
+        )
+        # Each 1m source maps to one 1m composite, with length_true = 1 m.
+        assert len(out) == 10
+        assert np.allclose(out["length_true"], 1.0)
+        # Value of each composite should equal the source value at that depth.
+        assert np.allclose(out["value"], np.arange(1, 11), atol=1e-9)
+
+    def test_hole_along_plane_emits_nothing(self):
+        # Horizontal hole (dip=0, north) through a horizontal reference
+        # plane.  Tangent T = (0, 1, 0); plane normal N = (0, 0, 1).
+        # T ⊥ N → true thickness contribution is zero everywhere.
+        traces = self._inclined_trace(dip_deg=0.0, max_md=10.0)
+        intervals = _make_intervals("A", np.arange(0, 11), [1.0] * 10)
+        out = composite_true_thickness(
+            intervals, traces, value_col="value",
+            ref_dip=0.0, ref_dip_azimuth=0.0,
+            length=1.0,
+        )
+        # No measurable thickness traversed → either empty or all-zero.
+        if not out.empty:
+            assert (out["length_true"] < 1e-6).all()
+
+    def test_inclined_hole_planar_lode_matches_analytic_cos(self):
+        # Inclined hole (60° dip due north) cutting through a
+        # horizontal plane.  Hole tangent T = (0, cos60, -sin60).
+        # Plane normal N = (0, 0, 1).  T · N = -sin60 = -0.866.
+        # |T · N| = 0.866 → true thickness = 0.866 × downhole length.
+        traces = self._inclined_trace(dip_deg=60.0, max_md=10.0)
+        intervals = _make_intervals("A", np.arange(0, 11), [1.0] * 10)
+        out = composite_true_thickness(
+            intervals, traces, value_col="value",
+            ref_dip=0.0, ref_dip_azimuth=0.0,
+            length=0.866025403784,  # one full source interval ≈ one bin
+        )
+        # Expect ~10 composites.  Each composite's length_md should
+        # be ≈ 1.0 (one source interval per composite), and the
+        # cumulative length_md across all composites should equal 10 m.
+        assert pytest.approx(out["length_md"].sum(), rel=1e-3) == 10.0
+        # Cumulative length_true ≈ 10 × 0.866 = 8.66 m.
+        assert pytest.approx(out["length_true"].sum(), rel=1e-3) == 10 * math.sin(math.radians(60))
+
+
+class TestGeometryHelpers:
+    def test_plane_normal_horizontal_is_up(self):
+        n = _plane_normal(0.0, 0.0)
+        assert np.allclose(n, [0.0, 0.0, 1.0])
+
+    def test_plane_normal_vertical_is_horizontal(self):
+        # Vertical plane (dip=90°) with strike east–west (downdip
+        # azimuth = 180° = due south): normal should point due south.
+        n = _plane_normal(90.0, 180.0)
+        assert np.allclose(n, [0.0, -1.0, 0.0], atol=1e-9)
+
+    def test_tangent_vertical_hole_points_down(self):
+        t = _tangents_from_azimuth_dip(np.array([0.0]), np.array([90.0]))
+        assert np.allclose(t[0], [0.0, 0.0, -1.0], atol=1e-9)
+
+    def test_tangent_horizontal_north(self):
+        t = _tangents_from_azimuth_dip(np.array([0.0]), np.array([0.0]))
+        assert np.allclose(t[0], [0.0, 1.0, 0.0], atol=1e-9)
+
+    def test_tangent_nan_becomes_zero(self):
+        t = _tangents_from_azimuth_dip(np.array([float("nan")]), np.array([45.0]))
+        assert np.allclose(t[0], [0.0, 0.0, 0.0])


### PR DESCRIPTION
`composite_intervals` grows three kwargs that preserve the existing soft-mode call signature:

- `mode="soft"` (default) — the prior length-weighted overlap behaviour, now documented and named explicitly.  References dhcomp (FractalGeoAnalytics 2023).
- `mode="hard"` + `boundary_col` — composites reset at every change in the boundary column within a hole; no composite straddles a coded contact.
- `residual={"discard", "add_to_previous", "distribute"}` — how to handle a sub-`length` tail at the end of a hard-mode domain.

New `composite_true_thickness(intervals, traces, value_col, ref_dip, ref_dip_azimuth, ...)` composites in true-thickness space relative to a reference plane.  Per-interval orientation is looked up via `interpolate_trajectory` (TRK-108) at each interval midpoint; true thickness is `L_downhole · |T · N|`.  Reports `length_md` / `length_true` alongside the composited value so callers can filter by economic thickness.  Python-only per ticket scope.

JS parity for hard / soft mode lands as `compositeIntervals` in `baselode/data/composite.js`, exported from `index.js`.  No JS true-thickness — depends on a desurveyed trace (Python-only path).

Tests:
- mass-balance (length × value conserved across composites)
- hard-boundary mode never produces a composite spanning a contact
- residual rules: discard drops the tail, add_to_previous extends the prior bin, distribute stretches the bin length to fit
- non-abutting same-domain intervals form separate runs
- true-thickness vs analytic vertical-hole / horizontal-plane and inclined-hole planar-lode cases; hole-parallel-to-plane emits zero thickness
- 10 JS tests mirroring the language-agnostic cases above

Parity contract: new `compositing` capability tracks both languages; the `drillhole_set` description no longer claims there's no JS composite primitive.