### PR TITLE
[TRK-119] Interactive plot wrapper panels (BaselodeXPanel)

### DIFF
--- a/demo-viewer-react/app/src/components/Layout.jsx
+++ b/demo-viewer-react/app/src/components/Layout.jsx
@@ -6,19 +6,22 @@ import Sidebar from './Sidebar.jsx';
 import '../App.css';
 import { ZoomProvider } from '../context/ZoomContext.jsx';
 import { DemoDataProvider } from '../context/DemoDataContext.jsx';
+import { ThemeProvider } from '../context/ThemeContext.jsx';
 
 function Layout({ children }) {
   return (
-    <ZoomProvider>
-      <DemoDataProvider>
-        <div className="app-container">
-          <Sidebar />
-          <main className="main-content">
-            {children}
-          </main>
-        </div>
-      </DemoDataProvider>
-    </ZoomProvider>
+    <ThemeProvider>
+      <ZoomProvider>
+        <DemoDataProvider>
+          <div className="app-container">
+            <Sidebar />
+            <main className="main-content">
+              {children}
+            </main>
+          </div>
+        </DemoDataProvider>
+      </ZoomProvider>
+    </ThemeProvider>
   );
 }
 

--- a/demo-viewer-react/app/src/components/Sidebar.css
+++ b/demo-viewer-react/app/src/components/Sidebar.css
@@ -32,6 +32,61 @@
   margin-top: 4px;
 }
 
+.sidebar-theme-toggle {
+  margin-top: 10px;
+  appearance: none;
+  border: 1px solid rgba(0, 0, 0, 0.15);
+  background: transparent;
+  color: inherit;
+  font-size: 12px;
+  padding: 4px 10px;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background 120ms ease, color 120ms ease, border-color 120ms ease;
+}
+
+.sidebar-theme-toggle:hover {
+  background: rgba(0, 0, 0, 0.05);
+}
+
+:root.dark .sidebar-theme-toggle {
+  border-color: rgba(255, 255, 255, 0.2);
+}
+
+:root.dark .sidebar-theme-toggle:hover {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+/* ─── Dark-theme overrides for the sidebar shell ───────────── */
+:root.dark .sidebar {
+  background: rgba(28, 28, 32, 0.9);
+  border-right-color: rgba(255, 255, 255, 0.08);
+}
+
+:root.dark .sidebar-header {
+  border-bottom-color: rgba(255, 255, 255, 0.08);
+}
+
+:root.dark .sidebar-header h2 {
+  color: #e2e8f0;
+}
+
+:root.dark .sidebar-menu a {
+  color: #cbd5e1;
+}
+
+:root.dark .sidebar-menu a:hover {
+  background: rgba(255, 255, 255, 0.05);
+  color: #fff;
+}
+
+:root.dark .sidebar-footer,
+:root.dark .sidebar-slot,
+:root.dark .sidebar-source-link {
+  border-top-color: rgba(255, 255, 255, 0.08);
+  color: #cbd5e1;
+}
+
 .sidebar-header h2 {
   font-family: 'Lexend', sans-serif;
   font-size: 18px;

--- a/demo-viewer-react/app/src/components/Sidebar.jsx
+++ b/demo-viewer-react/app/src/components/Sidebar.jsx
@@ -5,11 +5,13 @@
 import { Link, useLocation } from 'react-router-dom';
 import './Sidebar.css';
 import { useZoomContext } from '../context/ZoomContext.jsx';
+import { useTheme } from '../context/ThemeContext.jsx';
 import { ViewHelper } from 'three/examples/jsm/Addons.js';
 
 function Sidebar() {
   const location = useLocation();
   const { zoomLevel } = useZoomContext();
+  const { theme, toggleTheme } = useTheme();
 
   const menuItems = [
     { path: '/', label: 'Map' },
@@ -29,6 +31,15 @@ function Sidebar() {
         <h2>Baselode</h2>
         <h2>Demo Viewer</h2>
         <span className="sidebar-version">v{__APP_VERSION__}</span>
+        <button
+          type="button"
+          className="sidebar-theme-toggle"
+          onClick={toggleTheme}
+          aria-label={theme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'}
+          title={theme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'}
+        >
+          {theme === 'dark' ? '☀ Light' : '☾ Dark'}
+        </button>
       </div>
       <ul className="sidebar-menu">
         {menuItems.map((item) => (

--- a/demo-viewer-react/app/src/context/ThemeContext.jsx
+++ b/demo-viewer-react/app/src/context/ThemeContext.jsx
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2026 Darkmine Pty Ltd
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+import { createContext, useCallback, useContext, useEffect, useState } from 'react';
+
+// App-wide light/dark theme.  Stores the user's pick in localStorage
+// so the choice survives reloads, and falls back to the OS preference
+// otherwise.  Toggles a `.light` / `.dark` class on `<html>` so any
+// page-level CSS (and the baselode wrapper components' custom
+// properties) can re-theme through a single switch.
+
+const STORAGE_KEY = 'baselode-demo-viewer-theme';
+const VALID = new Set(['dark', 'light']);
+
+const ThemeContext = createContext({
+  theme: 'light',
+  toggleTheme: () => {},
+  setTheme: () => {},
+});
+
+function readInitialTheme() {
+  if (typeof window === 'undefined') return 'light';
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored && VALID.has(stored)) return stored;
+  } catch (e) {
+    /* ignore */
+  }
+  if (typeof window.matchMedia === 'function') {
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  }
+  return 'light';
+}
+
+export function ThemeProvider({ children }) {
+  const [theme, setThemeState] = useState(readInitialTheme);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    root.classList.toggle('dark', theme === 'dark');
+    root.classList.toggle('light', theme === 'light');
+    try {
+      localStorage.setItem(STORAGE_KEY, theme);
+    } catch (e) {
+      /* ignore */
+    }
+  }, [theme]);
+
+  const setTheme = useCallback((next) => {
+    if (VALID.has(next)) setThemeState(next);
+  }, []);
+
+  const toggleTheme = useCallback(() => {
+    setThemeState((current) => (current === 'dark' ? 'light' : 'dark'));
+  }, []);
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  return useContext(ThemeContext);
+}

--- a/demo-viewer-react/app/src/index.css
+++ b/demo-viewer-react/app/src/index.css
@@ -21,6 +21,14 @@ body {
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  background: #fff;
+  color: #1e293b;
+  transition: background 120ms ease, color 120ms ease;
+}
+
+:root.dark body {
+  background: #1b1b1f;
+  color: #e2e8f0;
 }
 
 #root {

--- a/demo-viewer-react/app/src/pages/AnalyticsPlots.css
+++ b/demo-viewer-react/app/src/pages/AnalyticsPlots.css
@@ -36,20 +36,24 @@
 .analytics-page--dark {
   background-color: #1b1b1f;
   color: #e2e8f0;
+  /* Re-theme the BaselodeXPanel wrappers via the CSS custom
+     properties they expose.  The library's defaults assume a light
+     host page; overriding the vars here keeps the dark toggle in
+     sync with the Plotly dark template chosen in JS. */
+  --baselode-panel-bg: #24252a;
+  --baselode-panel-fg: #e2e8f0;
+  --baselode-panel-border: 1px solid #34353b;
+  --baselode-panel-muted: #94a3b8;
+  --baselode-panel-controls-bg: rgba(148, 163, 184, 0.08);
+  --baselode-control-bg: #24252a;
+  --baselode-control-border: #34353b;
 }
 
 .analytics-page--dark .analytics-page__header p,
-.analytics-page--dark .plot-panel__header p,
 .analytics-page--dark .analytics-rowcount {
   color: #94a3b8;
 }
 
-.analytics-page--dark .plot-panel {
-  background: #24252a;
-  border-color: #34353b;
-}
-
-.analytics-page--dark .prop-select select,
 .analytics-page--dark .analytics-rowcount {
   background: #24252a;
   color: #e2e8f0;

--- a/demo-viewer-react/app/src/pages/AnalyticsPlots.jsx
+++ b/demo-viewer-react/app/src/pages/AnalyticsPlots.jsx
@@ -114,7 +114,7 @@ function AnalyticsPlots() {
             description="Distribution per group overlaid; switch stack mode to compare absolute counts."
           />
 
-          <div className="analytics-grid">
+          <div className="analytics-grid baselode-analytics-grid">
             <BaselodeBoxPanel
               rows={assayRows}
               colourMap={colourMap}

--- a/demo-viewer-react/app/src/pages/AnalyticsPlots.jsx
+++ b/demo-viewer-react/app/src/pages/AnalyticsPlots.jsx
@@ -2,22 +2,20 @@
  * Copyright (C) 2026 Darkmine Pty Ltd
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
-import { useEffect, useMemo, useRef, useState } from 'react';
-import Plotly from 'plotly.js-dist-min';
+import { useMemo, useState } from 'react';
 import {
-  buildScatterPlotConfig,
-  buildHistogramPlotConfig,
-  buildBoxPlotConfig,
-  buildViolinPlotConfig,
-  buildTernaryPlotConfig,
+  BaselodeScatterPanel,
+  BaselodeHistogramPanel,
+  BaselodeBoxPanel,
+  BaselodeViolinPanel,
+  BaselodeTernaryPanel,
   BASELODE_TEMPLATE,
   BASELODE_DARK_TEMPLATE,
   LITHOLOGY_COLOURS,
+  detectCategoricalColumns,
 } from 'baselode';
 import { useDemoData } from '../context/DemoDataContext.jsx';
 import './AnalyticsPlots.css';
-
-const RESERVED = new Set(['hole_id', 'from', 'to', 'mid', 'depth', '_source']);
 
 function flattenAssayRows(combinedHoles) {
   const flattened = [];
@@ -36,227 +34,30 @@ function flattenAssayRows(combinedHoles) {
   return flattened;
 }
 
-function detectNumericColumns(rows) {
-  if (!rows.length) return [];
-  const counts = new Map();
-  for (const row of rows) {
-    for (const [key, value] of Object.entries(row)) {
-      if (RESERVED.has(key)) continue;
-      // Skip nullish + blanks explicitly: Number('') is 0, which would
-      // falsely classify blank-string columns as numeric.
-      if (value == null) continue;
-      if (typeof value === 'string' && value.trim() === '') continue;
-      const numeric = Number(value);
-      if (!Number.isFinite(numeric)) continue;
-      counts.set(key, (counts.get(key) || 0) + 1);
-    }
-  }
-  // Sort by frequency desc — most-populated analytes first.
-  return [...counts.entries()]
-    .sort((a, b) => b[1] - a[1])
-    .map(([key]) => key);
-}
-
-function detectCategoricalColumns(rows) {
-  if (!rows.length) return [];
-  const candidates = new Map();
-  for (const row of rows) {
-    for (const [key, value] of Object.entries(row)) {
-      if (RESERVED.has(key)) continue;
-      if (value == null || value === '') continue;
-      if (Number.isFinite(Number(value))) continue;
-      if (!candidates.has(key)) candidates.set(key, new Set());
-      candidates.get(key).add(String(value));
-    }
-  }
-  return [...candidates.entries()]
-    .filter(([, distinct]) => distinct.size > 1 && distinct.size <= 40)
-    .sort((a, b) => a[1].size - b[1].size)
-    .map(([key]) => key);
-}
-
-function PlotPanel({ title, description, controls, data, layout, height = 380 }) {
-  const containerRef = useRef(null);
-
-  useEffect(() => {
-    const container = containerRef.current;
-    if (!container) return undefined;
-    Plotly.react(container, data || [], { autosize: true, ...layout, height }, {
-      responsive: true,
-      displayModeBar: 'hover',
-    });
-    return () => {
-      try { Plotly.purge(container); } catch (_) { /* unmounted */ }
-    };
-  }, [data, layout, height]);
-
-  return (
-    <section className="plot-panel">
-      <header className="plot-panel__header">
-        <h2>{title}</h2>
-        {description && <p>{description}</p>}
-      </header>
-      {controls && <div className="plot-panel__controls">{controls}</div>}
-      <div ref={containerRef} className="plot-panel__chart" style={{ height: `${height}px` }} />
-    </section>
-  );
-}
-
-function LogToggle({ label, value, onChange }) {
-  return (
-    <label className="log-toggle">
-      <input
-        type="checkbox"
-        checked={Boolean(value)}
-        onChange={(event) => onChange(event.target.checked)}
-      />
-      <span>{label}</span>
-    </label>
-  );
-}
-
-function BarmodeSelect({ value, onChange }) {
-  return (
-    <label className="prop-select">
-      <span>stack</span>
-      <select value={value} onChange={(event) => onChange(event.target.value)}>
-        <option value="overlay">in z (overlay)</option>
-        <option value="stack">in y (stacked)</option>
-        <option value="group">side-by-side</option>
-      </select>
-    </label>
-  );
-}
-
-function PropertySelect({ label, value, onChange, options, includeBlank = false }) {
-  // Render the dropdown alphabetically (case-insensitive) so the list is
-  // scannable.  The unsorted ordering is preserved upstream for default
-  // picking via column frequency.
-  const sortedOptions = [...options].sort((a, b) =>
-    String(a).localeCompare(String(b), undefined, { sensitivity: 'base' })
-  );
-  return (
-    <label className="prop-select">
-      <span>{label}</span>
-      <select value={value} onChange={(event) => onChange(event.target.value)}>
-        {includeBlank && <option value="">(none)</option>}
-        {sortedOptions.map((option) => (
-          <option key={option} value={option}>{option}</option>
-        ))}
-      </select>
-    </label>
-  );
-}
-
 /**
- * Stable per-plot state — the user can configure each chart independently.
- * Defaults are derived from the discovered numeric / categorical columns
- * the first time they become available; later changes don't auto-reset.
+ * Demo of the new BaselodeXPanel wrappers from `baselode`.  Every
+ * picker is now bundled with its plot primitive — this page just
+ * passes `rows` + a `template`/`colourMap` and the panels render
+ * themselves, including X/Y/Group-by dropdowns, log toggles, and
+ * (for the histogram) the stack-mode picker.  Compare to the
+ * pre-TRK-119 incarnation of this file (~430 lines of inline
+ * pickers + per-plot state) to see what the wrappers absorb.
  */
-function useDefaultColumn(value, columns, fallbackIdx = 0) {
-  useEffect(() => {
-    if (value || !columns.length) return;
-    // Caller will hand back a setter via the returned function below.
-  }, [value, columns, fallbackIdx]);
-}
-
 function AnalyticsPlots() {
   const { loading, combinedHoles, errors } = useDemoData();
   const [useDarkTemplate, setUseDarkTemplate] = useState(false);
 
   const assayRows = useMemo(() => flattenAssayRows(combinedHoles), [combinedHoles]);
-  const numericColumns = useMemo(() => detectNumericColumns(assayRows), [assayRows]);
-  const categoricalColumns = useMemo(() => detectCategoricalColumns(assayRows), [assayRows]);
 
-  const defaultColorBy = useMemo(() => {
-    if (!categoricalColumns.length) return '';
-    return categoricalColumns.find((column) => column.toLowerCase().includes('litho'))
-      || categoricalColumns[0];
-  }, [categoricalColumns]);
-
-  // Per-plot state — scatter
-  const [scatterX, setScatterX] = useState('');
-  const [scatterY, setScatterY] = useState('');
-  const [scatterColorBy, setScatterColorBy] = useState('');
-  const [scatterLogX, setScatterLogX] = useState(true);
-  const [scatterLogY, setScatterLogY] = useState(true);
-
-  // Per-plot state — histogram (Y-only log; X is the binned analyte and
-  // a log X on a histogram isn't a useful default per the page brief).
-  const [histProp, setHistProp] = useState('');
-  const [histGroupBy, setHistGroupBy] = useState('');
-  const [histLogY, setHistLogY] = useState(true);
-  const [histBarmode, setHistBarmode] = useState('overlay');
-
-  // Per-plot state — box (value axis is Y; X is the categorical group)
-  const [boxProp, setBoxProp] = useState('');
-  const [boxGroupBy, setBoxGroupBy] = useState('');
-  const [boxLogY, setBoxLogY] = useState(true);
-
-  // Per-plot state — violin (value axis is Y; X is the categorical group)
-  const [violinProp, setViolinProp] = useState('');
-  const [violinGroupBy, setViolinGroupBy] = useState('');
-  const [violinLogY, setViolinLogY] = useState(true);
-
-  // Per-plot state — ternary (no log — components are percentages)
-  const [aProp, setAProp] = useState('');
-  const [bProp, setBProp] = useState('');
-  const [cProp, setCProp] = useState('');
-  const [ternaryColorBy, setTernaryColorBy] = useState('');
-
-  // Seed all the per-plot column selections from the discovered columns
-  // the first time they're available.  Subsequent column changes don't
-  // overwrite a user's explicit pick.
-  useEffect(() => {
-    if (!numericColumns.length) return;
-    const get = (idx) => numericColumns[Math.min(idx, numericColumns.length - 1)];
-    setScatterX((current) => current || get(0));
-    setScatterY((current) => current || get(1));
-    setHistProp((current) => current || get(0));
-    setBoxProp((current) => current || get(0));
-    setViolinProp((current) => current || get(0));
-    setAProp((current) => current || get(0));
-    setBProp((current) => current || get(1));
-    setCProp((current) => current || get(2));
-  }, [numericColumns]);
-
-  useEffect(() => {
-    if (!defaultColorBy) return;
-    setScatterColorBy((current) => current || defaultColorBy);
-    setHistGroupBy((current) => current || defaultColorBy);
-    setBoxGroupBy((current) => current || defaultColorBy);
-    setViolinGroupBy((current) => current || defaultColorBy);
-    setTernaryColorBy((current) => current || defaultColorBy);
-  }, [defaultColorBy]);
+  // Only swap to the lithology palette when the data actually carries
+  // a lithology categorical — otherwise the panel cycles the
+  // BASELODE_COLORWAY for whatever the user picked.
+  const colourMap = useMemo(() => {
+    const cats = detectCategoricalColumns(assayRows);
+    return cats.some((c) => c.toLowerCase().includes('litho')) ? LITHOLOGY_COLOURS : null;
+  }, [assayRows]);
 
   const template = useDarkTemplate ? BASELODE_DARK_TEMPLATE : BASELODE_TEMPLATE;
-  const colourMap = categoricalColumns.some((column) => column.toLowerCase().includes('litho'))
-    ? LITHOLOGY_COLOURS
-    : null;
-
-  const scatter = useMemo(() => buildScatterPlotConfig(assayRows, {
-    xProp: scatterX, yProp: scatterY, colorBy: scatterColorBy, colourMap,
-    log: { x: scatterLogX, y: scatterLogY }, template,
-  }), [assayRows, scatterX, scatterY, scatterColorBy, scatterLogX, scatterLogY, colourMap, template]);
-
-  const histogram = useMemo(() => buildHistogramPlotConfig(assayRows, {
-    prop: histProp, groupBy: histGroupBy, colourMap,
-    log: histLogY, barmode: histBarmode, template,
-  }), [assayRows, histProp, histGroupBy, histLogY, histBarmode, colourMap, template]);
-
-  const box = useMemo(() => buildBoxPlotConfig(assayRows, {
-    prop: boxProp, groupBy: boxGroupBy, colourMap, log: boxLogY, template,
-  }), [assayRows, boxProp, boxGroupBy, boxLogY, colourMap, template]);
-
-  const violin = useMemo(() => buildViolinPlotConfig(assayRows, {
-    prop: violinProp, groupBy: violinGroupBy, colourMap, log: violinLogY, template,
-  }), [assayRows, violinProp, violinGroupBy, violinLogY, colourMap, template]);
-
-  const ternary = useMemo(() => buildTernaryPlotConfig(assayRows, {
-    aProp, bProp, cProp, colorBy: ternaryColorBy, colourMap, template,
-  }), [assayRows, aProp, bProp, cProp, ternaryColorBy, colourMap, template]);
-
-  const hasCategoricals = categoricalColumns.length > 0;
 
   return (
     <div className={`analytics-page ${useDarkTemplate ? 'analytics-page--dark' : ''}`}>
@@ -264,12 +65,11 @@ function AnalyticsPlots() {
         <div>
           <h1>Analytics Plots</h1>
           <p>
-            Demos of the non-tool-UI plot primitives —{' '}
-            <code>buildScatterPlotConfig</code>, <code>buildHistogramPlotConfig</code>,{' '}
-            <code>buildBoxPlotConfig</code>, <code>buildViolinPlotConfig</code>, and{' '}
-            <code>buildTernaryPlotConfig</code> — each rendered straight into Plotly.
-            Lithology-coloured categoricals use the built-in <code>LITHOLOGY_COLOURS</code> map;
-            other categoricals cycle the <code>BASELODE_COLORWAY</code>.
+            Demo of the <code>Baselode*Panel</code> wrappers — each plot bundles its
+            own dropdowns + view toggles so the host page just passes <code>rows</code>{' '}
+            and a Plotly <code>template</code>.  Lithology-coloured categoricals use the
+            built-in <code>LITHOLOGY_COLOURS</code> map; other categoricals cycle the{' '}
+            <code>BASELODE_COLORWAY</code>.
           </p>
         </div>
         <div className="analytics-page__meta">
@@ -300,124 +100,40 @@ function AnalyticsPlots() {
 
       {!loading && assayRows.length > 0 && (
         <>
-          <PlotPanel
-            title="Scatter"
-            description="buildScatterPlotConfig — analyte vs analyte with optional categorical colour-by."
-            controls={(
-              <>
-                <PropertySelect label="X" value={scatterX} onChange={setScatterX} options={numericColumns} />
-                <PropertySelect label="Y" value={scatterY} onChange={setScatterY} options={numericColumns} />
-                {hasCategoricals && (
-                  <PropertySelect
-                    label="Colour by"
-                    value={scatterColorBy}
-                    onChange={setScatterColorBy}
-                    options={categoricalColumns}
-                    includeBlank
-                  />
-                )}
-                <LogToggle label="log X" value={scatterLogX} onChange={setScatterLogX} />
-                <LogToggle label="log Y" value={scatterLogY} onChange={setScatterLogY} />
-              </>
-            )}
-            data={scatter.data}
-            layout={scatter.layout}
+          <BaselodeScatterPanel
+            rows={assayRows}
+            colourMap={colourMap}
+            template={template}
+            description="Analyte vs analyte with optional categorical colour-by."
           />
 
-          <PlotPanel
-            title="Histogram"
-            description="buildHistogramPlotConfig — distribution per group overlaid."
-            controls={(
-              <>
-                <PropertySelect label="Property" value={histProp} onChange={setHistProp} options={numericColumns} />
-                {hasCategoricals && (
-                  <PropertySelect
-                    label="Group by"
-                    value={histGroupBy}
-                    onChange={setHistGroupBy}
-                    options={categoricalColumns}
-                    includeBlank
-                  />
-                )}
-                <LogToggle label="log Y" value={histLogY} onChange={setHistLogY} />
-                {histGroupBy && (
-                  <BarmodeSelect value={histBarmode} onChange={setHistBarmode} />
-                )}
-              </>
-            )}
-            data={histogram.data}
-            layout={histogram.layout}
+          <BaselodeHistogramPanel
+            rows={assayRows}
+            colourMap={colourMap}
+            template={template}
+            description="Distribution per group overlaid; switch stack mode to compare absolute counts."
           />
 
           <div className="analytics-grid">
-            <PlotPanel
-              title="Box"
-              description="buildBoxPlotConfig — quartiles per group, outliers shown."
-              controls={(
-                <>
-                  <PropertySelect label="Property" value={boxProp} onChange={setBoxProp} options={numericColumns} />
-                  {hasCategoricals && (
-                    <PropertySelect
-                      label="Group by"
-                      value={boxGroupBy}
-                      onChange={setBoxGroupBy}
-                      options={categoricalColumns}
-                      includeBlank
-                    />
-                  )}
-                  <LogToggle label="log Y" value={boxLogY} onChange={setBoxLogY} />
-                </>
-              )}
-              data={box.data}
-              layout={box.layout}
-              height={360}
+            <BaselodeBoxPanel
+              rows={assayRows}
+              colourMap={colourMap}
+              template={template}
+              description="Quartiles per group, outliers shown."
             />
-            <PlotPanel
-              title="Violin"
-              description="buildViolinPlotConfig — distribution shape per group, inner box + mean line."
-              controls={(
-                <>
-                  <PropertySelect label="Property" value={violinProp} onChange={setViolinProp} options={numericColumns} />
-                  {hasCategoricals && (
-                    <PropertySelect
-                      label="Group by"
-                      value={violinGroupBy}
-                      onChange={setViolinGroupBy}
-                      options={categoricalColumns}
-                      includeBlank
-                    />
-                  )}
-                  <LogToggle label="log Y" value={violinLogY} onChange={setViolinLogY} />
-                </>
-              )}
-              data={violin.data}
-              layout={violin.layout}
-              height={360}
+            <BaselodeViolinPanel
+              rows={assayRows}
+              colourMap={colourMap}
+              template={template}
+              description="Distribution shape per group, inner box + mean line."
             />
           </div>
 
-          <PlotPanel
-            title="Ternary"
-            description="buildTernaryPlotConfig — three-component composition, Plotly auto-normalises to 100."
-            controls={(
-              <>
-                <PropertySelect label="A" value={aProp} onChange={setAProp} options={numericColumns} />
-                <PropertySelect label="B" value={bProp} onChange={setBProp} options={numericColumns} />
-                <PropertySelect label="C" value={cProp} onChange={setCProp} options={numericColumns} />
-                {hasCategoricals && (
-                  <PropertySelect
-                    label="Colour by"
-                    value={ternaryColorBy}
-                    onChange={setTernaryColorBy}
-                    options={categoricalColumns}
-                    includeBlank
-                  />
-                )}
-              </>
-            )}
-            data={ternary.data}
-            layout={ternary.layout}
-            height={480}
+          <BaselodeTernaryPanel
+            rows={assayRows}
+            colourMap={colourMap}
+            template={template}
+            description="Three-component composition, Plotly auto-normalises to 100."
           />
         </>
       )}

--- a/demo-viewer-react/app/src/pages/AnalyticsPlots.jsx
+++ b/demo-viewer-react/app/src/pages/AnalyticsPlots.jsx
@@ -2,7 +2,7 @@
  * Copyright (C) 2026 Darkmine Pty Ltd
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
-import { useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import {
   BaselodeScatterPanel,
   BaselodeHistogramPanel,
@@ -15,6 +15,7 @@ import {
   detectCategoricalColumns,
 } from 'baselode';
 import { useDemoData } from '../context/DemoDataContext.jsx';
+import { useTheme } from '../context/ThemeContext.jsx';
 import './AnalyticsPlots.css';
 
 function flattenAssayRows(combinedHoles) {
@@ -45,7 +46,8 @@ function flattenAssayRows(combinedHoles) {
  */
 function AnalyticsPlots() {
   const { loading, combinedHoles, errors } = useDemoData();
-  const [useDarkTemplate, setUseDarkTemplate] = useState(false);
+  const { theme } = useTheme();
+  const useDarkTemplate = theme === 'dark';
 
   const assayRows = useMemo(() => flattenAssayRows(combinedHoles), [combinedHoles]);
 
@@ -73,14 +75,6 @@ function AnalyticsPlots() {
           </p>
         </div>
         <div className="analytics-page__meta">
-          <label className="dark-toggle">
-            <input
-              type="checkbox"
-              checked={useDarkTemplate}
-              onChange={(event) => setUseDarkTemplate(event.target.checked)}
-            />
-            <span>Dark template</span>
-          </label>
           {assayRows.length > 0 && (
             <span className="analytics-rowcount">{assayRows.length.toLocaleString()} assay rows</span>
           )}

--- a/demo-viewer-react/app/src/pages/Drillhole2D.css
+++ b/demo-viewer-react/app/src/pages/Drillhole2D.css
@@ -102,8 +102,16 @@
 .drillhole2d-grid {
   flex: 1;
   min-height: 0;
+  /* `min-width: 0` lets the flex item shrink below its content's
+     natural width — without it, a too-wide grid cell pushes this
+     flex item wider than its parent and `overflow-y: auto` below
+     ends up granting horizontal scroll too.  Explicit `overflow-x:
+     hidden` is the second belt to make sure long hole-id picker
+     contents can't break out of the 4-up layout. */
+  min-width: 0;
   padding: 12px 12px 16px 12px;
-  overflow: auto;
+  overflow-x: hidden;
+  overflow-y: auto;
 }
 
 :root.dark .drillhole2d-container {

--- a/demo-viewer-react/app/src/pages/Drillhole2D.css
+++ b/demo-viewer-react/app/src/pages/Drillhole2D.css
@@ -95,40 +95,49 @@
   font-size: 13px;
 }
 
-.template-toggle {
-  margin-left: auto;
-  padding: 6px 14px;
-  font-size: 12px;
-  font-weight: 600;
-  border: 1px solid #d0d0d0;
-  border-radius: 6px;
-  background: white;
-  color: #555;
-  cursor: pointer;
-  letter-spacing: 0.02em;
-  transition: background 0.15s, color 0.15s, border-color 0.15s;
-}
-
-.template-toggle:hover {
-  border-color: #888;
-  color: #222;
-}
-
-.template-toggle.active {
-  background: #1b1b1f;
-  color: #ffffbb;
-  border-color: #3a3a3f;
-}
-
-.plots-grid {
+/* The strip-log grid lives inside this page; the BaselodeStripLogGrid
+   wrapper supplies the grid-template-columns + gap rules.  We just
+   reserve the flex slot + padding so it fills the page below the
+   header. */
+.drillhole2d-grid {
   flex: 1;
   min-height: 0;
-  display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  grid-auto-rows: minmax(0, 1fr);
-  gap: 12px;
   padding: 12px 12px 16px 12px;
   overflow: auto;
+}
+
+:root.dark .drillhole2d-container {
+  background: #1b1b1f;
+}
+
+:root.dark .drillhole2d-header {
+  background: #24252a;
+  border-bottom-color: #34353b;
+  color: #e2e8f0;
+}
+
+:root.dark .drillhole2d-header h2 {
+  color: #e2e8f0;
+}
+
+/* Strip-log cards (lib `.plot-card`) carry no colours in the bundled
+   CSS — they're host-themable on purpose.  In light mode the rules
+   above this block apply; in dark mode re-theme the chrome to match
+   the rest of the page. */
+:root.dark .plot-card {
+  background: #24252a;
+  border-color: #34353b;
+}
+
+:root.dark .plot-select {
+  background: #24252a;
+  color: #e2e8f0;
+  border-color: #34353b;
+}
+
+:root.dark .plot-title,
+:root.dark .placeholder {
+  color: #cbd5e1;
 }
 
 .plot-card {

--- a/demo-viewer-react/app/src/pages/Drillhole2D.jsx
+++ b/demo-viewer-react/app/src/pages/Drillhole2D.jsx
@@ -2,17 +2,18 @@
  * Copyright (C) 2026 Darkmine Pty Ltd
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { useLocation } from 'react-router-dom';
 import {
-  TracePlot,
-  useDrillholeTraceGrid,
+  BaselodeStripLogGrid,
   BASELODE_DARK_TEMPLATE,
+  BASELODE_TEMPLATE,
 } from 'baselode';
 import 'baselode/style.css';
 import './Drillhole2D.css';
 import { createPortal } from 'react-dom';
 import { useDemoData } from '../context/DemoDataContext.jsx';
+import { useTheme } from '../context/ThemeContext.jsx';
 
 // The demo GSWA assay columns encode the unit as a trailing token, e.g.
 // "Au_PPM". Split that into a clean label + unit so the strip-log axes and
@@ -41,80 +42,50 @@ function metaForProperty(property) {
   return { label: tokens.slice(0, -1).map(titleCase).join(' '), unit };
 }
 
+/**
+ * Build a propertyMeta map by inspecting every row's keys.  Cheap
+ * enough to do once per render given the dataset is fixed for the
+ * demo; production code would use upstream `analysis_uom` instead.
+ */
+function buildPropertyMeta(combinedHoles) {
+  const map = {};
+  for (const hole of combinedHoles || []) {
+    const points = hole?.points || hole?.rows || [];
+    for (const row of points) {
+      for (const key of Object.keys(row || {})) {
+        if (key in map) continue;
+        const m = metaForProperty(key);
+        if (m) map[key] = m;
+      }
+    }
+  }
+  return map;
+}
+
 function Drillhole2D() {
   const location = useLocation();
   const { combinedHoles } = useDemoData();
-  const [useDarkTemplate, setUseDarkTemplate] = useState(false);
-  const activeTemplate = useDarkTemplate ? BASELODE_DARK_TEMPLATE : undefined;
+  const { theme } = useTheme();
+  const template = theme === 'dark' ? BASELODE_DARK_TEMPLATE : BASELODE_TEMPLATE;
+  const holeCount = (combinedHoles || []).length;
 
-  const {
-    error,
-    setError,
-    holeCount,
-    setFocusedHoleId,
-    labeledHoleOptions,
-    traceGraphs,
-    handleConfigChange,
-  } = useDrillholeTraceGrid({
-    initialFocusedHoleId: location.state?.holeId || '',
-    extraHoles: combinedHoles,
-    plotCount: 4,
-  });
-
-  // Per-property unit metadata keyed by the bare property name, derived once
-  // from every graph's available properties.
-  const propertyMeta = useMemo(() => {
-    const map = {};
-    traceGraphs.forEach((g) => {
-      (g?.propertyOptions || []).forEach((p) => {
-        if (p in map) return;
-        const m = metaForProperty(p);
-        if (m) map[p] = m;
-      });
-    });
-    return map;
-  }, [traceGraphs]);
-
-  useEffect(() => {
-    const holeIdFromNav = location.state?.holeId;
-    if (holeIdFromNav) {
-      setFocusedHoleId(holeIdFromNav);
-      if (!holeCount) {
-        setError((prev) => prev || `Loading data for hole ${holeIdFromNav}.`);
-      }
-    }
-  }, [location.state, holeCount, setError, setFocusedHoleId]);
+  const propertyMeta = useMemo(() => buildPropertyMeta(combinedHoles), [combinedHoles]);
 
   return (
     <div className="drillhole2d-container">
       <div className="drillhole2d-header">
         <h2>Drillhole Strip Logs</h2>
-        <div className="drillhole2d-controls">
-          {error && <span className="error-text">{error}</span>}
-          <button
-            className={`template-toggle${useDarkTemplate ? ' active' : ''}`}
-            onClick={() => setUseDarkTemplate((v) => !v)}
-            title={useDarkTemplate ? 'Switch to Baselode Light theme' : 'Switch to Baselode Dark theme'}
-          >
-            {useDarkTemplate ? 'Dark' : 'Light'}
-          </button>
-        </div>
       </div>
 
-      <div className="plots-grid">
-        {Array.from({ length: 4 }).map((_, idx) => (
-          <TracePlot
-            key={idx}
-            config={traceGraphs[idx]?.config || { holeId: '', property: '', chartType: 'markers+line' }}
-            graph={traceGraphs[idx]}
-            holeOptions={labeledHoleOptions}
-            propertyOptions={traceGraphs[idx]?.propertyOptions || []}
-            propertyMeta={propertyMeta}
-            onConfigChange={(patch) => handleConfigChange(idx, patch)}
-            template={activeTemplate}
-          />
-        ))}
-      </div>
+      <BaselodeStripLogGrid
+        holes={combinedHoles}
+        initialHoleId={location.state?.holeId || ''}
+        plotCount={4}
+        propertyMeta={propertyMeta}
+        template={template}
+        className="drillhole2d-grid"
+      />
+
       {(() => {
         const dataSourceTarget = typeof document !== 'undefined' ? document.getElementById('data-source-slot') : null;
         if (!dataSourceTarget) return null;

--- a/javascript/packages/baselode/src/index.js
+++ b/javascript/packages/baselode/src/index.js
@@ -168,6 +168,28 @@ export {
   getBaselodeSchema
 } from './data/schemas.js';
 
+// Interactive plot wrappers — bundles each viz primitive with its
+// own property pickers + view toggles so embedding apps don't have
+// to reinvent the dropdown plumbing.
+export { BaselodeScatterPanel } from './panels/BaselodeScatterPanel.jsx';
+export { BaselodeHistogramPanel } from './panels/BaselodeHistogramPanel.jsx';
+export { BaselodeBoxPanel } from './panels/BaselodeBoxPanel.jsx';
+export { BaselodeViolinPanel } from './panels/BaselodeViolinPanel.jsx';
+export { BaselodeTernaryPanel } from './panels/BaselodeTernaryPanel.jsx';
+export { BaselodeStripLogPanel } from './panels/BaselodeStripLogPanel.jsx';
+export {
+  PlotPanel,
+  PropertySelect,
+  LogToggle,
+  BarmodeSelect,
+} from './panels/PanelControls.jsx';
+export {
+  detectNumericColumns,
+  detectCategoricalColumns,
+  defaultColorByColumn,
+} from './panels/columnDetection.js';
+export { useControllable } from './panels/useControllable.js';
+
 export {
   intervalLength,
   fromToMidpoints,

--- a/javascript/packages/baselode/src/index.js
+++ b/javascript/packages/baselode/src/index.js
@@ -177,6 +177,7 @@ export { BaselodeBoxPanel } from './panels/BaselodeBoxPanel.jsx';
 export { BaselodeViolinPanel } from './panels/BaselodeViolinPanel.jsx';
 export { BaselodeTernaryPanel } from './panels/BaselodeTernaryPanel.jsx';
 export { BaselodeStripLogPanel } from './panels/BaselodeStripLogPanel.jsx';
+export { BaselodeStripLogGrid } from './panels/BaselodeStripLogGrid.jsx';
 export {
   PlotPanel,
   PropertySelect,

--- a/javascript/packages/baselode/src/panels/BaselodeBoxPanel.jsx
+++ b/javascript/packages/baselode/src/panels/BaselodeBoxPanel.jsx
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2026 Darkmine Pty Ltd
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { useEffect, useMemo } from 'react';
+import { buildBoxPlotConfig } from '../viz/boxPlotViz.js';
+import { LogToggle, PlotPanel, PropertySelect } from './PanelControls.jsx';
+import {
+  defaultColorByColumn,
+  detectCategoricalColumns,
+  detectNumericColumns,
+} from './columnDetection.js';
+import { useControllable } from './useControllable.js';
+
+/**
+ * Interactive box-plot panel: Property + Group-by selectors and a
+ * log-Y toggle.  Quartiles + outliers per group.
+ *
+ * State shape: `{ prop, groupBy, logY }`.
+ */
+export function BaselodeBoxPanel({
+  rows,
+  numericColumns,
+  categoricalColumns,
+  value,
+  onChange,
+  initialProp = '',
+  initialGroupBy = '',
+  initialLogY = true,
+  colourMap = null,
+  template,
+  title = 'Box',
+  description,
+  height = 360,
+}) {
+  const autoNumeric = useMemo(() => detectNumericColumns(rows), [rows]);
+  const autoCategorical = useMemo(() => detectCategoricalColumns(rows), [rows]);
+  const numerics = numericColumns ?? autoNumeric;
+  const categoricals = categoricalColumns ?? autoCategorical;
+
+  const [state, setState] = useControllable({
+    value,
+    onChange,
+    defaultValue: { prop: initialProp, groupBy: initialGroupBy, logY: initialLogY },
+  });
+
+  useEffect(() => {
+    if (!numerics.length) return;
+    setState((current) => (current.prop ? {} : { prop: numerics[0] }));
+  }, [numerics, setState]);
+
+  useEffect(() => {
+    if (!categoricals.length) return;
+    const defaultColor = defaultColorByColumn(categoricals);
+    if (!defaultColor) return;
+    setState((current) => (current.groupBy ? {} : { groupBy: defaultColor }));
+  }, [categoricals, setState]);
+
+  const config = useMemo(() => buildBoxPlotConfig(rows || [], {
+    prop: state.prop,
+    groupBy: state.groupBy,
+    colourMap,
+    log: state.logY,
+    template,
+  }), [rows, state, colourMap, template]);
+
+  return (
+    <PlotPanel
+      title={title}
+      description={description}
+      controls={(
+        <>
+          <PropertySelect
+            label="Property"
+            value={state.prop}
+            onChange={(prop) => setState({ prop })}
+            options={numerics}
+          />
+          <PropertySelect
+            label="Group by"
+            value={state.groupBy}
+            onChange={(groupBy) => setState({ groupBy })}
+            options={categoricals}
+            includeBlank
+          />
+          <LogToggle label="log Y" value={state.logY} onChange={(logY) => setState({ logY })} />
+        </>
+      )}
+      data={config.data}
+      layout={config.layout}
+      height={height}
+    />
+  );
+}

--- a/javascript/packages/baselode/src/panels/BaselodeHistogramPanel.jsx
+++ b/javascript/packages/baselode/src/panels/BaselodeHistogramPanel.jsx
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2026 Darkmine Pty Ltd
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { useEffect, useMemo } from 'react';
+import { buildHistogramPlotConfig } from '../viz/histogramViz.js';
+import {
+  BarmodeSelect,
+  LogToggle,
+  PlotPanel,
+  PropertySelect,
+} from './PanelControls.jsx';
+import {
+  defaultColorByColumn,
+  detectCategoricalColumns,
+  detectNumericColumns,
+} from './columnDetection.js';
+import { useControllable } from './useControllable.js';
+
+/**
+ * Interactive histogram panel.
+ *
+ * Property + Group-by selectors, log-Y toggle, and a 3-way stack
+ * mode picker (overlay / stack / side-by-side) that only renders
+ * when a group-by is selected.  Histogram X log is intentionally
+ * omitted — it would log-scale the binned analyte axis, which is
+ * almost never useful.
+ *
+ * Uncontrolled by default; controlled-mode via `{ value, onChange }`.
+ * State shape: `{ prop, groupBy, logY, barmode }`.
+ */
+export function BaselodeHistogramPanel({
+  rows,
+  numericColumns,
+  categoricalColumns,
+  value,
+  onChange,
+  initialProp = '',
+  initialGroupBy = '',
+  initialLogY = true,
+  initialBarmode = 'overlay',
+  colourMap = null,
+  template,
+  title = 'Histogram',
+  description,
+  height = 380,
+}) {
+  const autoNumeric = useMemo(() => detectNumericColumns(rows), [rows]);
+  const autoCategorical = useMemo(() => detectCategoricalColumns(rows), [rows]);
+  const numerics = numericColumns ?? autoNumeric;
+  const categoricals = categoricalColumns ?? autoCategorical;
+
+  const [state, setState] = useControllable({
+    value,
+    onChange,
+    defaultValue: {
+      prop: initialProp,
+      groupBy: initialGroupBy,
+      logY: initialLogY,
+      barmode: initialBarmode,
+    },
+  });
+
+  useEffect(() => {
+    if (!numerics.length) return;
+    setState((current) => (current.prop ? {} : { prop: numerics[0] }));
+  }, [numerics, setState]);
+
+  useEffect(() => {
+    if (!categoricals.length) return;
+    const defaultColor = defaultColorByColumn(categoricals);
+    if (!defaultColor) return;
+    setState((current) => (current.groupBy ? {} : { groupBy: defaultColor }));
+  }, [categoricals, setState]);
+
+  const config = useMemo(() => buildHistogramPlotConfig(rows || [], {
+    prop: state.prop,
+    groupBy: state.groupBy,
+    colourMap,
+    log: state.logY,
+    barmode: state.barmode,
+    template,
+  }), [rows, state, colourMap, template]);
+
+  return (
+    <PlotPanel
+      title={title}
+      description={description}
+      controls={(
+        <>
+          <PropertySelect
+            label="Property"
+            value={state.prop}
+            onChange={(prop) => setState({ prop })}
+            options={numerics}
+          />
+          <PropertySelect
+            label="Group by"
+            value={state.groupBy}
+            onChange={(groupBy) => setState({ groupBy })}
+            options={categoricals}
+            includeBlank
+          />
+          <LogToggle label="log Y" value={state.logY} onChange={(logY) => setState({ logY })} />
+          {state.groupBy && (
+            <BarmodeSelect
+              value={state.barmode}
+              onChange={(barmode) => setState({ barmode })}
+            />
+          )}
+        </>
+      )}
+      data={config.data}
+      layout={config.layout}
+      height={height}
+    />
+  );
+}

--- a/javascript/packages/baselode/src/panels/BaselodeScatterPanel.jsx
+++ b/javascript/packages/baselode/src/panels/BaselodeScatterPanel.jsx
@@ -1,0 +1,156 @@
+/*
+ * Copyright (C) 2026 Darkmine Pty Ltd
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { useEffect, useMemo } from 'react';
+import { buildScatterPlotConfig } from '../viz/scatterViz.js';
+import { PlotPanel, PropertySelect, LogToggle } from './PanelControls.jsx';
+import {
+  defaultColorByColumn,
+  detectCategoricalColumns,
+  detectNumericColumns,
+} from './columnDetection.js';
+import { useControllable } from './useControllable.js';
+
+/**
+ * Interactive scatter panel: data + dropdowns in one drop-in
+ * component.
+ *
+ * Wraps `buildScatterPlotConfig` with X / Y / Colour-by selectors
+ * and per-axis log toggles.  Auto-detects numeric + categorical
+ * columns from `rows` if the caller doesn't pass them.
+ *
+ * **Uncontrolled mode (default)**: state is held internally; the
+ * panel seeds picks the first time columns are known and otherwise
+ * leaves them alone.  Use `initialX` / `initialY` / `initialColorBy`
+ * / `initialLogX` / `initialLogY` to override the seed.
+ *
+ * **Controlled mode**: pass `value` (`{ x, y, colorBy, logX, logY }`)
+ * + `onChange(next)`.  The caller owns the state; the panel just
+ * renders and reports.
+ *
+ * @param {Object} props
+ * @param {Array<Object>} props.rows - Plot data; each row is an
+ *   object keyed by column name.
+ * @param {Array<string>} [props.numericColumns] - Override the
+ *   auto-detected numeric column list.
+ * @param {Array<string>} [props.categoricalColumns] - Override the
+ *   auto-detected categorical column list (for the Colour-by
+ *   dropdown).
+ * @param {Object} [props.value] - Controlled state object (see above).
+ * @param {Function} [props.onChange] - Controlled-mode setter.
+ * @param {string} [props.initialX]
+ * @param {string} [props.initialY]
+ * @param {string} [props.initialColorBy]
+ * @param {boolean} [props.initialLogX=true]
+ * @param {boolean} [props.initialLogY=true]
+ * @param {string|Object} [props.colourMap] - Passed straight to the
+ *   config builder.
+ * @param {Object} [props.template] - Plotly template.
+ * @param {string} [props.title='Scatter']
+ * @param {string} [props.description]
+ * @param {number} [props.height=380]
+ */
+export function BaselodeScatterPanel({
+  rows,
+  numericColumns,
+  categoricalColumns,
+  value,
+  onChange,
+  initialX = '',
+  initialY = '',
+  initialColorBy = '',
+  initialLogX = true,
+  initialLogY = true,
+  colourMap = null,
+  template,
+  title = 'Scatter',
+  description,
+  height = 380,
+}) {
+  // Auto-detect once when caller doesn't supply column lists.  The
+  // hooks always fire so we don't break the Rules of Hooks; the
+  // override is just a `??` away.
+  const autoNumeric = useMemo(() => detectNumericColumns(rows), [rows]);
+  const autoCategorical = useMemo(() => detectCategoricalColumns(rows), [rows]);
+  const numerics = numericColumns ?? autoNumeric;
+  const categoricals = categoricalColumns ?? autoCategorical;
+
+  const [state, setState] = useControllable({
+    value,
+    onChange,
+    defaultValue: {
+      x: initialX,
+      y: initialY,
+      colorBy: initialColorBy,
+      logX: initialLogX,
+      logY: initialLogY,
+    },
+  });
+
+  // Seed empty picks once columns are known.  Functional form means
+  // we never overwrite a user's explicit pick — even after a
+  // column-list change.
+  useEffect(() => {
+    if (!numerics.length) return;
+    const get = (idx) => numerics[Math.min(idx, numerics.length - 1)];
+    setState((current) => {
+      const patch = {};
+      if (!current.x) patch.x = get(0);
+      if (!current.y) patch.y = numerics.length > 1 ? get(1) : get(0);
+      return patch;
+    });
+  }, [numerics, setState]);
+
+  useEffect(() => {
+    if (!categoricals.length) return;
+    const defaultColor = defaultColorByColumn(categoricals);
+    if (!defaultColor) return;
+    setState((current) => (current.colorBy ? {} : { colorBy: defaultColor }));
+  }, [categoricals, setState]);
+
+  const config = useMemo(() => buildScatterPlotConfig(rows || [], {
+    xProp: state.x,
+    yProp: state.y,
+    colorBy: state.colorBy,
+    colourMap,
+    log: { x: state.logX, y: state.logY },
+    template,
+  }), [rows, state, colourMap, template]);
+
+  return (
+    <PlotPanel
+      title={title}
+      description={description}
+      controls={(
+        <>
+          <PropertySelect
+            label="X"
+            value={state.x}
+            onChange={(x) => setState({ x })}
+            options={numerics}
+          />
+          <PropertySelect
+            label="Y"
+            value={state.y}
+            onChange={(y) => setState({ y })}
+            options={numerics}
+          />
+          <PropertySelect
+            label="Colour by"
+            value={state.colorBy}
+            onChange={(colorBy) => setState({ colorBy })}
+            options={categoricals}
+            includeBlank
+          />
+          <LogToggle label="log X" value={state.logX} onChange={(logX) => setState({ logX })} />
+          <LogToggle label="log Y" value={state.logY} onChange={(logY) => setState({ logY })} />
+        </>
+      )}
+      data={config.data}
+      layout={config.layout}
+      height={height}
+    />
+  );
+}

--- a/javascript/packages/baselode/src/panels/BaselodeStripLogGrid.jsx
+++ b/javascript/packages/baselode/src/panels/BaselodeStripLogGrid.jsx
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2026 Darkmine Pty Ltd
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { useEffect } from 'react';
+import TracePlot from '../viz/TracePlot.jsx';
+import useDrillholeTraceGrid from '../viz/useDrillholeTraceGrid.jsx';
+import './panels.css';
+
+/**
+ * N-up grid of strip-log panels sharing a single `useDrillholeTraceGrid`
+ * hook instance.
+ *
+ * Unlike rendering N independent `BaselodeStripLogPanel`s, this
+ * grid keeps a single shared focused-hole + column-classification
+ * pass so the panels behave like one strip log split across tracks
+ * rather than N disconnected mini-charts.  This is the right primitive
+ * for the multi-track viewer pattern.
+ *
+ * For a single track (e.g. an embedded preview), use
+ * `BaselodeStripLogPanel` — it's simpler and doesn't fight with
+ * caller-owned layout.
+ *
+ * @param {Object} props
+ * @param {Array<Object>} props.holes - Pre-parsed hole data; each
+ *   hole carries `id` + `points`.
+ * @param {number} [props.plotCount=4] - Number of tracks in the
+ *   grid.  Capped 1..16 to match the hook's expectations.
+ * @param {string} [props.initialHoleId] - Hole to focus on first
+ *   render.
+ * @param {Object} [props.holeSelector] - Passed through to every
+ *   `TracePlot` in the grid for project / domain grouping.
+ * @param {Object} [props.propertyMeta] - Per-property metadata map
+ *   (`{ [property]: { label, unit, sourceAttribute } }`).  Passed
+ *   through to each `TracePlot` so the axis titles + tooltips can
+ *   render "Au (ppm)" instead of "Au_PPM".
+ * @param {Object} [props.template] - Plotly template.
+ * @param {number} [props.columns] - Override the grid column count.
+ *   Defaults to `plotCount` for a single row, capped at 4 so wider
+ *   layouts wrap.  Set explicitly for a 2x2 / 2x4 etc.
+ * @param {string} [props.className] - Extra class on the grid
+ *   container.
+ */
+export function BaselodeStripLogGrid({
+  holes,
+  plotCount = 4,
+  initialHoleId = '',
+  holeSelector,
+  propertyMeta,
+  template,
+  columns,
+  className = '',
+}) {
+  const {
+    setFocusedHoleId,
+    labeledHoleOptions,
+    traceGraphs,
+    handleConfigChange,
+  } = useDrillholeTraceGrid({
+    initialFocusedHoleId: initialHoleId,
+    extraHoles: holes || [],
+    plotCount,
+  });
+
+  // Push later initialHoleId changes (route nav, parent re-render)
+  // through to the hook.  Mirrors the demo viewer's existing pattern.
+  useEffect(() => {
+    if (initialHoleId) setFocusedHoleId(initialHoleId);
+  }, [initialHoleId, setFocusedHoleId]);
+
+  // Default to one row of `plotCount`, capped at 4 columns so wider
+  // grids wrap to a 4×(N/4) layout.
+  const effectiveColumns = columns ?? Math.min(plotCount, 4);
+  const gridStyle = {
+    gridTemplateColumns: `repeat(${effectiveColumns}, minmax(0, 1fr))`,
+  };
+
+  return (
+    <div className={`baselode-strip-log-grid ${className}`.trim()} style={gridStyle}>
+      {Array.from({ length: plotCount }).map((_, idx) => {
+        const graph = traceGraphs[idx];
+        return (
+          <TracePlot
+            key={idx}
+            config={graph?.config || { holeId: '', property: '', chartType: 'markers+line' }}
+            graph={graph}
+            holeOptions={labeledHoleOptions}
+            holeSelector={holeSelector}
+            propertyOptions={graph?.propertyOptions || []}
+            propertyMeta={propertyMeta}
+            onConfigChange={(patch) => handleConfigChange(idx, patch)}
+            template={template}
+          />
+        );
+      })}
+    </div>
+  );
+}

--- a/javascript/packages/baselode/src/panels/BaselodeStripLogPanel.jsx
+++ b/javascript/packages/baselode/src/panels/BaselodeStripLogPanel.jsx
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2026 Darkmine Pty Ltd
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import TracePlot from '../viz/TracePlot.jsx';
+import useDrillholeTraceGrid from '../viz/useDrillholeTraceGrid.jsx';
+import { useEffect } from 'react';
+
+/**
+ * Interactive strip-log panel for a single track.
+ *
+ * Wraps `useDrillholeTraceGrid` + `TracePlot` into one drop-in
+ * component so an embedding app doesn't have to wire the hook +
+ * picker plumbing itself.  `TracePlot` already ships interactive
+ * hole / property / chart-type dropdowns, so this panel's job is
+ * really just to spin up the hook with sensible defaults and pass
+ * its state into the existing picker UI.
+ *
+ * For a multi-panel grid, render the panel N times — each one owns
+ * its own hook instance with `plotCount=1`, which keeps the
+ * controlled-state story simple per panel.
+ *
+ * @param {Object} props
+ * @param {Array<Object>} props.holes - Pre-parsed hole data from a
+ *   baselode loader (each hole carries `id` + `points`).
+ * @param {string} [props.initialHoleId] - Hole to focus on first
+ *   render.  Defaults to the first hole in `holes`.
+ * @param {Object} [props.holeSelector] - Passed through to
+ *   `TracePlot` for project / domain grouping (`{ kind:
+ *   'group+hole', groupBy, groupLabel, ... }`).  When omitted, the
+ *   default flat hole dropdown renders.
+ * @param {Object} [props.template] - Plotly template.
+ * @param {number} [props.height=380] - Chart height in pixels.
+ */
+export function BaselodeStripLogPanel({
+  holes,
+  initialHoleId = '',
+  holeSelector,
+  template,
+  height = 380,
+}) {
+  const {
+    setFocusedHoleId,
+    labeledHoleOptions,
+    traceGraphs,
+    handleConfigChange,
+  } = useDrillholeTraceGrid({
+    initialFocusedHoleId: initialHoleId,
+    extraHoles: holes || [],
+    plotCount: 1,
+  });
+
+  // If the caller updates `initialHoleId` after mount (e.g. routes
+  // change), push it through.  Mirrors the existing Drillhole2D
+  // pattern.
+  useEffect(() => {
+    if (initialHoleId) setFocusedHoleId(initialHoleId);
+  }, [initialHoleId, setFocusedHoleId]);
+
+  const graph = traceGraphs[0];
+  return (
+    <TracePlot
+      config={graph?.config || { holeId: '', property: '', chartType: 'markers+line' }}
+      graph={graph}
+      holeOptions={labeledHoleOptions}
+      holeSelector={holeSelector}
+      propertyOptions={graph?.propertyOptions || []}
+      onConfigChange={(patch) => handleConfigChange(0, patch)}
+      template={template}
+      height={height}
+    />
+  );
+}

--- a/javascript/packages/baselode/src/panels/BaselodeStripLogPanel.jsx
+++ b/javascript/packages/baselode/src/panels/BaselodeStripLogPanel.jsx
@@ -37,6 +37,7 @@ export function BaselodeStripLogPanel({
   holes,
   initialHoleId = '',
   holeSelector,
+  propertyMeta,
   template,
   height = 380,
 }) {
@@ -66,6 +67,7 @@ export function BaselodeStripLogPanel({
       holeOptions={labeledHoleOptions}
       holeSelector={holeSelector}
       propertyOptions={graph?.propertyOptions || []}
+      propertyMeta={propertyMeta}
       onConfigChange={(patch) => handleConfigChange(0, patch)}
       template={template}
       height={height}

--- a/javascript/packages/baselode/src/panels/BaselodeTernaryPanel.jsx
+++ b/javascript/packages/baselode/src/panels/BaselodeTernaryPanel.jsx
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2026 Darkmine Pty Ltd
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { useEffect, useMemo } from 'react';
+import { buildTernaryPlotConfig } from '../viz/ternaryPlotViz.js';
+import { PlotPanel, PropertySelect } from './PanelControls.jsx';
+import {
+  defaultColorByColumn,
+  detectCategoricalColumns,
+  detectNumericColumns,
+} from './columnDetection.js';
+import { useControllable } from './useControllable.js';
+
+/**
+ * Interactive ternary-plot panel: A / B / C apex selectors and an
+ * optional Colour-by.  No log toggles — the apices are normalised
+ * to percentages.
+ *
+ * State shape: `{ a, b, c, colorBy }`.
+ */
+export function BaselodeTernaryPanel({
+  rows,
+  numericColumns,
+  categoricalColumns,
+  value,
+  onChange,
+  initialA = '',
+  initialB = '',
+  initialC = '',
+  initialColorBy = '',
+  colourMap = null,
+  template,
+  title = 'Ternary',
+  description,
+  height = 480,
+}) {
+  const autoNumeric = useMemo(() => detectNumericColumns(rows), [rows]);
+  const autoCategorical = useMemo(() => detectCategoricalColumns(rows), [rows]);
+  const numerics = numericColumns ?? autoNumeric;
+  const categoricals = categoricalColumns ?? autoCategorical;
+
+  const [state, setState] = useControllable({
+    value,
+    onChange,
+    defaultValue: {
+      a: initialA,
+      b: initialB,
+      c: initialC,
+      colorBy: initialColorBy,
+    },
+  });
+
+  useEffect(() => {
+    if (!numerics.length) return;
+    const get = (idx) => numerics[Math.min(idx, numerics.length - 1)];
+    setState((current) => {
+      const patch = {};
+      if (!current.a) patch.a = get(0);
+      if (!current.b) patch.b = get(1);
+      if (!current.c) patch.c = get(2);
+      return patch;
+    });
+  }, [numerics, setState]);
+
+  useEffect(() => {
+    if (!categoricals.length) return;
+    const defaultColor = defaultColorByColumn(categoricals);
+    if (!defaultColor) return;
+    setState((current) => (current.colorBy ? {} : { colorBy: defaultColor }));
+  }, [categoricals, setState]);
+
+  const config = useMemo(() => buildTernaryPlotConfig(rows || [], {
+    aProp: state.a,
+    bProp: state.b,
+    cProp: state.c,
+    colorBy: state.colorBy,
+    colourMap,
+    template,
+  }), [rows, state, colourMap, template]);
+
+  return (
+    <PlotPanel
+      title={title}
+      description={description}
+      controls={(
+        <>
+          <PropertySelect label="A" value={state.a} onChange={(a) => setState({ a })} options={numerics} />
+          <PropertySelect label="B" value={state.b} onChange={(b) => setState({ b })} options={numerics} />
+          <PropertySelect label="C" value={state.c} onChange={(c) => setState({ c })} options={numerics} />
+          <PropertySelect
+            label="Colour by"
+            value={state.colorBy}
+            onChange={(colorBy) => setState({ colorBy })}
+            options={categoricals}
+            includeBlank
+          />
+        </>
+      )}
+      data={config.data}
+      layout={config.layout}
+      height={height}
+    />
+  );
+}

--- a/javascript/packages/baselode/src/panels/BaselodeViolinPanel.jsx
+++ b/javascript/packages/baselode/src/panels/BaselodeViolinPanel.jsx
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2026 Darkmine Pty Ltd
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { useEffect, useMemo } from 'react';
+import { buildViolinPlotConfig } from '../viz/violinPlotViz.js';
+import { LogToggle, PlotPanel, PropertySelect } from './PanelControls.jsx';
+import {
+  defaultColorByColumn,
+  detectCategoricalColumns,
+  detectNumericColumns,
+} from './columnDetection.js';
+import { useControllable } from './useControllable.js';
+
+/**
+ * Interactive violin-plot panel: same control surface as
+ * `BaselodeBoxPanel` (Property + Group-by + log-Y).  Inner box +
+ * mean line are on by default per the underlying primitive.
+ *
+ * State shape: `{ prop, groupBy, logY }`.
+ */
+export function BaselodeViolinPanel({
+  rows,
+  numericColumns,
+  categoricalColumns,
+  value,
+  onChange,
+  initialProp = '',
+  initialGroupBy = '',
+  initialLogY = true,
+  colourMap = null,
+  template,
+  title = 'Violin',
+  description,
+  height = 360,
+}) {
+  const autoNumeric = useMemo(() => detectNumericColumns(rows), [rows]);
+  const autoCategorical = useMemo(() => detectCategoricalColumns(rows), [rows]);
+  const numerics = numericColumns ?? autoNumeric;
+  const categoricals = categoricalColumns ?? autoCategorical;
+
+  const [state, setState] = useControllable({
+    value,
+    onChange,
+    defaultValue: { prop: initialProp, groupBy: initialGroupBy, logY: initialLogY },
+  });
+
+  useEffect(() => {
+    if (!numerics.length) return;
+    setState((current) => (current.prop ? {} : { prop: numerics[0] }));
+  }, [numerics, setState]);
+
+  useEffect(() => {
+    if (!categoricals.length) return;
+    const defaultColor = defaultColorByColumn(categoricals);
+    if (!defaultColor) return;
+    setState((current) => (current.groupBy ? {} : { groupBy: defaultColor }));
+  }, [categoricals, setState]);
+
+  const config = useMemo(() => buildViolinPlotConfig(rows || [], {
+    prop: state.prop,
+    groupBy: state.groupBy,
+    colourMap,
+    log: state.logY,
+    template,
+  }), [rows, state, colourMap, template]);
+
+  return (
+    <PlotPanel
+      title={title}
+      description={description}
+      controls={(
+        <>
+          <PropertySelect
+            label="Property"
+            value={state.prop}
+            onChange={(prop) => setState({ prop })}
+            options={numerics}
+          />
+          <PropertySelect
+            label="Group by"
+            value={state.groupBy}
+            onChange={(groupBy) => setState({ groupBy })}
+            options={categoricals}
+            includeBlank
+          />
+          <LogToggle label="log Y" value={state.logY} onChange={(logY) => setState({ logY })} />
+        </>
+      )}
+      data={config.data}
+      layout={config.layout}
+      height={height}
+    />
+  );
+}

--- a/javascript/packages/baselode/src/panels/PanelControls.jsx
+++ b/javascript/packages/baselode/src/panels/PanelControls.jsx
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2026 Darkmine Pty Ltd
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { useEffect, useRef } from 'react';
+import Plotly from 'plotly.js-dist-min';
+
+import './panels.css';
+
+/**
+ * Plotly chart in a card layout, shared by every analytics panel.
+ *
+ * Mounts a Plotly chart in a sized container and re-renders via
+ * `Plotly.react` whenever the data / layout / height props change.
+ * The `controls` slot renders an interactive control row between
+ * the header and the chart so each panel can own its own pickers
+ * without the page above needing to know about them.
+ *
+ * @param {Object} props
+ * @param {string} [props.title]
+ * @param {string} [props.description]
+ * @param {React.ReactNode} [props.controls] - Picker / toggle row
+ *   rendered above the chart.
+ * @param {Array<Object>} props.data - Plotly trace data.
+ * @param {Object} props.layout - Plotly layout config.
+ * @param {number} [props.height=380] - Chart height in pixels.
+ * @param {string} [props.className] - Extra class on the outer
+ *   `<section>` so callers can theme individual panels.
+ */
+export function PlotPanel({
+  title, description, controls, data, layout, height = 380, className = '',
+}) {
+  const containerRef = useRef(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return undefined;
+    Plotly.react(container, data || [], { autosize: true, ...layout, height }, {
+      responsive: true,
+      displayModeBar: 'hover',
+    });
+    return () => {
+      try {
+        Plotly.purge(container);
+      } catch (_) {
+        /* container already detached */
+      }
+    };
+  }, [data, layout, height]);
+
+  return (
+    <section className={`baselode-plot-panel ${className}`.trim()}>
+      {(title || description) && (
+        <header className="baselode-plot-panel__header">
+          {title && <h2>{title}</h2>}
+          {description && <p>{description}</p>}
+        </header>
+      )}
+      {controls && <div className="baselode-plot-panel__controls">{controls}</div>}
+      <div
+        ref={containerRef}
+        className="baselode-plot-panel__chart"
+        style={{ height: `${height}px` }}
+      />
+    </section>
+  );
+}
+
+/**
+ * Property dropdown used everywhere a panel needs an X / Y / Group-
+ * by / etc. selector.
+ *
+ * Options are rendered alphabetically (case-insensitive) for scannability;
+ * upstream column ordering is preserved for default picking via
+ * column frequency.  Pass `includeBlank` to surface a `(none)`
+ * option — useful for the "no colour-by" case.
+ */
+export function PropertySelect({ label, value, onChange, options, includeBlank = false }) {
+  const sortedOptions = [...(options || [])].sort((a, b) =>
+    String(a).localeCompare(String(b), undefined, { sensitivity: 'base' }),
+  );
+  return (
+    <label className="baselode-prop-select">
+      <span>{label}</span>
+      <select value={value ?? ''} onChange={(event) => onChange(event.target.value)}>
+        {includeBlank && <option value="">(none)</option>}
+        {sortedOptions.map((option) => (
+          <option key={option} value={option}>{option}</option>
+        ))}
+      </select>
+    </label>
+  );
+}
+
+/**
+ * Log-scale checkbox used wherever a panel needs an axis-scale toggle.
+ */
+export function LogToggle({ label, value, onChange }) {
+  return (
+    <label className="baselode-log-toggle">
+      <input
+        type="checkbox"
+        checked={Boolean(value)}
+        onChange={(event) => onChange(event.target.checked)}
+      />
+      <span>{label}</span>
+    </label>
+  );
+}
+
+/**
+ * Histogram bar-stacking selector.
+ *
+ * Three modes correspond to Plotly's `barmode`:
+ * - `'overlay'` — bars from different groups z-stacked at the same x
+ *   with transparency (default in the histogram primitive).
+ * - `'stack'` — bars y-stacked so the bin height is the sum of group
+ *   counts.
+ * - `'group'` — bars side-by-side.
+ */
+export function BarmodeSelect({ value, onChange }) {
+  return (
+    <label className="baselode-prop-select">
+      <span>stack</span>
+      <select value={value} onChange={(event) => onChange(event.target.value)}>
+        <option value="overlay">in z (overlay)</option>
+        <option value="stack">in y (stacked)</option>
+        <option value="group">side-by-side</option>
+      </select>
+    </label>
+  );
+}

--- a/javascript/packages/baselode/src/panels/columnDetection.js
+++ b/javascript/packages/baselode/src/panels/columnDetection.js
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2026 Darkmine Pty Ltd
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+/**
+ * Column-classification helpers shared by every interactive panel.
+ * Lifted verbatim from the inline implementations that lived in
+ * `demo-viewer-react` and `baselode-frontend`, so the panels (and
+ * the viewer apps now consuming them) all classify columns the same
+ * way regardless of which app they're rendered in.
+ *
+ * Two heuristics:
+ * - Numeric columns: rows where the value parses as a finite number,
+ *   sorted by frequency descending so the most-populated columns
+ *   surface as defaults.
+ * - Categorical columns: majority-non-numeric (≥50% of populated
+ *   values are non-numeric) with 2–40 distinct values.  The
+ *   majority-rule lets columns like `geology_code` — where most rows
+ *   are strings but a few happen to be integers — through, which the
+ *   stricter "no row is numeric" rule would reject.
+ */
+
+import { FROM, HOLE_ID, MID, TO } from '../data/datamodel.js';
+
+const RESERVED_COLUMN_NAMES = new Set([
+  HOLE_ID, FROM, TO, MID,
+  'depth', '_source',
+]);
+
+/**
+ * Detect numeric columns in a row array.
+ *
+ * @param {Array<Object>} rows
+ * @param {Object} [options]
+ * @param {Set<string>} [options.reserved=RESERVED_COLUMN_NAMES] -
+ *   Override the always-skip set when the caller knows columns we
+ *   don't ship in the default reservation (e.g. extra IDs).
+ * @returns {Array<string>} Column names, sorted by populated-row
+ *   count descending so the loudest analytes come first.
+ */
+export function detectNumericColumns(rows, options = {}) {
+  const reserved = options.reserved || RESERVED_COLUMN_NAMES;
+  if (!rows || !rows.length) return [];
+  const counts = new Map();
+  for (const row of rows) {
+    for (const [key, value] of Object.entries(row)) {
+      if (reserved.has(key)) continue;
+      // `Number('')` is 0 — explicit blank-string skip prevents
+      // empty cells from masquerading as numeric.
+      if (value == null) continue;
+      if (typeof value === 'string' && value.trim() === '') continue;
+      const numeric = Number(value);
+      if (!Number.isFinite(numeric)) continue;
+      counts.set(key, (counts.get(key) || 0) + 1);
+    }
+  }
+  return [...counts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .map(([key]) => key);
+}
+
+/**
+ * Detect categorical columns in a row array.
+ *
+ * @param {Array<Object>} rows
+ * @param {Object} [options]
+ * @param {Set<string>} [options.reserved=RESERVED_COLUMN_NAMES]
+ * @param {number} [options.maxDistinct=40] - Reject columns with
+ *   more than this many distinct values — they're almost certainly
+ *   free-text or IDs rather than a categorical breakdown.
+ * @returns {Array<string>} Column names, sorted by distinct-value
+ *   count ascending so the smallest (most useful) categoricals come
+ *   first.
+ */
+export function detectCategoricalColumns(rows, options = {}) {
+  const reserved = options.reserved || RESERVED_COLUMN_NAMES;
+  const maxDistinct = options.maxDistinct ?? 40;
+  if (!rows || !rows.length) return [];
+  // Track distinct values + how many of them parse as numeric per
+  // column.  Majority-non-numeric → categorical.
+  const stats = new Map();
+  for (const row of rows) {
+    for (const [key, value] of Object.entries(row)) {
+      if (reserved.has(key)) continue;
+      if (value == null) continue;
+      if (typeof value === 'string' && value.trim() === '') continue;
+      if (!stats.has(key)) stats.set(key, { distinct: new Set(), numeric: 0, total: 0 });
+      const entry = stats.get(key);
+      entry.distinct.add(String(value));
+      entry.total += 1;
+      if (Number.isFinite(Number(value))) entry.numeric += 1;
+    }
+  }
+  return [...stats.entries()]
+    .filter(([, entry]) => {
+      const distinct = entry.distinct.size;
+      if (distinct < 2 || distinct > maxDistinct) return false;
+      // Majority non-numeric: at most half the populated values
+      // parse as numbers.
+      return entry.numeric * 2 <= entry.total;
+    })
+    .sort((a, b) => a[1].distinct.size - b[1].distinct.size)
+    .map(([key]) => key);
+}
+
+/**
+ * Pick a default colour-by column from a categorical list.
+ *
+ * Prefers names containing `lithology` / `litho`, then
+ * `surface_sample_type`, then `project_id`, then the first entry.
+ * Mirrors the convention the demo viewer + baselode-frontend
+ * settled on so panels behave the same when dropped into either app.
+ *
+ * @param {Array<string>} categoricalColumns
+ * @returns {string} Column name or `''` when the list is empty.
+ */
+export function defaultColorByColumn(categoricalColumns) {
+  if (!categoricalColumns || !categoricalColumns.length) return '';
+  const preferred = ['litho', 'surface_sample_type', 'project_id'];
+  for (const hint of preferred) {
+    const hit = categoricalColumns.find((column) => column.toLowerCase().includes(hint));
+    if (hit) return hit;
+  }
+  return categoricalColumns[0];
+}

--- a/javascript/packages/baselode/src/panels/panels.css
+++ b/javascript/packages/baselode/src/panels/panels.css
@@ -98,3 +98,14 @@
 .baselode-analytics-grid .baselode-plot-panel {
   margin-bottom: 0;
 }
+
+/* Multi-track strip-log grid.  `grid-template-columns` is set
+   inline by `BaselodeStripLogGrid` so the column count is callable. */
+.baselode-strip-log-grid {
+  display: grid;
+  grid-auto-rows: minmax(0, 1fr);
+  gap: 12px;
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+}

--- a/javascript/packages/baselode/src/panels/panels.css
+++ b/javascript/packages/baselode/src/panels/panels.css
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2026 Darkmine Pty Ltd
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * Default cosmetics for the baselode panel components.  Every rule
+ * is scoped under `.baselode-plot-panel` (or the small control
+ * primitives' own classes), so importing this stylesheet won't
+ * collide with a host app's globals.  Apps that want to fully
+ * restyle just override the classes — every value here uses CSS
+ * custom properties that fall back to neutral defaults.
+ */
+
+.baselode-plot-panel {
+  background: var(--baselode-panel-bg, white);
+  color: var(--baselode-panel-fg, #1e293b);
+  border: var(--baselode-panel-border, 1px solid #e2e8f0);
+  border-radius: var(--baselode-panel-radius, 8px);
+  padding: 16px;
+  margin-bottom: 18px;
+}
+
+.baselode-plot-panel__header {
+  margin-bottom: 8px;
+}
+
+.baselode-plot-panel__header h2 {
+  margin: 0 0 2px;
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.baselode-plot-panel__header p {
+  margin: 0;
+  font-size: 0.82rem;
+  color: var(--baselode-panel-muted, #64748b);
+}
+
+.baselode-plot-panel__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 12px;
+  align-items: end;
+  padding: 8px 10px;
+  margin-bottom: 10px;
+  background: var(--baselode-panel-controls-bg, rgba(148, 163, 184, 0.08));
+  border-radius: var(--baselode-panel-controls-radius, 6px);
+}
+
+.baselode-plot-panel__chart {
+  width: 100%;
+}
+
+.baselode-prop-select {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 0.78rem;
+  color: var(--baselode-panel-muted, #475569);
+}
+
+.baselode-prop-select select {
+  padding: 4px 8px;
+  border: 1px solid var(--baselode-control-border, rgba(148, 163, 184, 0.4));
+  border-radius: 4px;
+  background: var(--baselode-control-bg, white);
+  color: var(--baselode-panel-fg, #1e293b);
+  font-size: 0.85rem;
+  min-width: 120px;
+}
+
+.baselode-log-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.78rem;
+  color: var(--baselode-panel-muted, #475569);
+  padding: 4px 8px;
+  border: 1px solid var(--baselode-control-border, rgba(148, 163, 184, 0.3));
+  border-radius: 4px;
+  background: var(--baselode-control-bg, white);
+  cursor: pointer;
+  user-select: none;
+  white-space: nowrap;
+}
+
+.baselode-log-toggle input[type='checkbox'] {
+  margin: 0;
+  cursor: pointer;
+}
+
+.baselode-analytics-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(360px, 1fr));
+  gap: 18px;
+  margin-bottom: 18px;
+}
+
+.baselode-analytics-grid .baselode-plot-panel {
+  margin-bottom: 0;
+}

--- a/javascript/packages/baselode/src/panels/panels.css
+++ b/javascript/packages/baselode/src/panels/panels.css
@@ -100,12 +100,17 @@
 }
 
 /* Multi-track strip-log grid.  `grid-template-columns` is set
-   inline by `BaselodeStripLogGrid` so the column count is callable. */
+   inline by `BaselodeStripLogGrid` so the column count is callable.
+   `min-width: 0` + `max-width: 100%` make the grid honour the
+   `minmax(0, 1fr)` column tracks even when the parent is a scroll
+   container that would otherwise let cells grow to fit content. */
 .baselode-strip-log-grid {
   display: grid;
   grid-auto-rows: minmax(0, 1fr);
   gap: 12px;
   width: 100%;
+  max-width: 100%;
+  min-width: 0;
   height: 100%;
   min-height: 0;
 }

--- a/javascript/packages/baselode/src/panels/useControllable.js
+++ b/javascript/packages/baselode/src/panels/useControllable.js
@@ -33,9 +33,20 @@ import { useCallback, useRef, useState } from 'react';
  *   it into the current state shallowly.
  */
 export function useControllable({ value, onChange, defaultValue } = {}) {
-  const isControlled = value !== undefined && typeof onChange === 'function';
+  // The panel state is always an object — accept controlled mode
+  // only when the caller actually hands us one.  This rejects
+  // `value: null` (a common "not ready yet" sentinel) and
+  // `value: undefined`, both of which would otherwise enter
+  // controlled mode and then crash the first `{ ...value }` spread.
+  const isControlled = (
+    value !== null
+    && typeof value === 'object'
+    && typeof onChange === 'function'
+  );
   const controlledRef = useRef(isControlled);
-  const [internal, setInternal] = useState(defaultValue);
+  // Default the internal store to `{}` so an uncontrolled caller
+  // that omits `defaultValue` doesn't crash the merge below.
+  const [internal, setInternal] = useState(() => defaultValue ?? {});
 
   // Warn (dev only) if the caller flips between controlled and
   // uncontrolled — React's own components do the same and the
@@ -52,11 +63,16 @@ export function useControllable({ value, onChange, defaultValue } = {}) {
     if (isControlled) {
       const current = value;
       const patch = typeof patchOrFn === 'function' ? patchOrFn(current) : patchOrFn;
+      // Patch functions returning null / undefined → no-op (the
+      // current state stays).  Same shape as React's `setState`
+      // returning early when the next value is the same reference.
+      if (patch == null) return;
       onChange({ ...current, ...patch });
       return;
     }
     setInternal((current) => {
       const patch = typeof patchOrFn === 'function' ? patchOrFn(current) : patchOrFn;
+      if (patch == null) return current;
       return { ...current, ...patch };
     });
   }, [isControlled, value, onChange]);

--- a/javascript/packages/baselode/src/panels/useControllable.js
+++ b/javascript/packages/baselode/src/panels/useControllable.js
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2026 Darkmine Pty Ltd
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { useCallback, useRef, useState } from 'react';
+
+/**
+ * Controlled / uncontrolled state hook used by every panel.
+ *
+ * When the caller passes `{ value, onChange }`, the hook is fully
+ * controlled — `value` is the source of truth and every setter
+ * routes back through `onChange`.  Mode is locked on first render;
+ * a runtime switch (controlled ↔ uncontrolled) would lose user
+ * picks, so we warn instead of toggling.
+ *
+ * When `value` or `onChange` is missing, the hook is uncontrolled —
+ * it holds its own state seeded from `defaultValue`.
+ *
+ * The returned setter accepts either a flat patch object (merged
+ * into the current state) or a function `(current) => patch` —
+ * matching the way callers thread defaults through `useEffect`s
+ * without listing the state itself as a dep.
+ *
+ * @param {Object} options
+ * @param {Object} [options.value] - Controlled value (caller-owned).
+ * @param {Function} [options.onChange] - Notified with the next
+ *   state object whenever a setter is invoked in controlled mode.
+ * @param {Object} options.defaultValue - Initial state in
+ *   uncontrolled mode; ignored in controlled mode.
+ * @returns {[Object, Function]} `[state, setState]` — setState
+ *   accepts `(current) => patch` or a flat patch object and merges
+ *   it into the current state shallowly.
+ */
+export function useControllable({ value, onChange, defaultValue } = {}) {
+  const isControlled = value !== undefined && typeof onChange === 'function';
+  const controlledRef = useRef(isControlled);
+  const [internal, setInternal] = useState(defaultValue);
+
+  // Warn (dev only) if the caller flips between controlled and
+  // uncontrolled — React's own components do the same and the
+  // mid-life switch loses state silently otherwise.
+  if (process.env.NODE_ENV !== 'production' && controlledRef.current !== isControlled) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      'useControllable: panel switched between controlled and uncontrolled modes — ' +
+      'pass a stable `value` + `onChange` from the first render.'
+    );
+  }
+
+  const setState = useCallback((patchOrFn) => {
+    if (isControlled) {
+      const current = value;
+      const patch = typeof patchOrFn === 'function' ? patchOrFn(current) : patchOrFn;
+      onChange({ ...current, ...patch });
+      return;
+    }
+    setInternal((current) => {
+      const patch = typeof patchOrFn === 'function' ? patchOrFn(current) : patchOrFn;
+      return { ...current, ...patch };
+    });
+  }, [isControlled, value, onChange]);
+
+  return [isControlled ? value : internal, setState];
+}

--- a/javascript/packages/baselode/src/viz/TracePlot.css
+++ b/javascript/packages/baselode/src/viz/TracePlot.css
@@ -65,3 +65,16 @@
 .plot-card .plot-select--hole {
   flex: 1 1 0;
 }
+
+/* The hole picker is rendered inside a `.plot-title` wrapper.
+   Without `min-width: 0` here the wrapper's flex layout uses the
+   select's natural (option-text) width as its minimum, which lets
+   the wrapper — and the surrounding card — grow past the grid
+   track's `1fr` allocation.  Setting `min-width: 0` + `max-width:
+   100%` makes the wrapper honour its parent's width, so the
+   select's `max-width: 100%` finally has a bounded reference. */
+.plot-card .plot-title {
+  min-width: 0;
+  max-width: 100%;
+  flex: 1 1 0;
+}

--- a/javascript/packages/baselode/src/viz/TracePlot.css
+++ b/javascript/packages/baselode/src/viz/TracePlot.css
@@ -19,12 +19,40 @@
 .plot-card__controls {
   flex-shrink: 0;
   display: flex;
+  flex-direction: column;
   gap: 6px;
-  flex-wrap: wrap;
-  /* Allow the row to shrink below the natural width of its
-     children so flex-wrap actually kicks in. */
   min-width: 0;
   width: 100%;
+}
+
+/* Strict row layout: one row per logical group (project, hole,
+   property+charttype).  Avoids the previous `flex-wrap: wrap`
+   behaviour where the dropdowns shuffled around based on natural
+   widths — wrappers should give predictable, consistent layout. */
+.plot-card__row {
+  display: flex;
+  gap: 6px;
+  width: 100%;
+  min-width: 0;
+}
+
+/* Single-select rows (group, hole, field) — the select fills the
+   full row width and truncates its rendered value with `…` when a
+   long option would otherwise spill past the card. */
+.plot-card__row--group .plot-select,
+.plot-card__row--hole .plot-select,
+.plot-card__row--field .plot-select {
+  flex: 1 1 0;
+  min-width: 0;
+  width: 100%;
+}
+
+/* Property + chart-type sit side-by-side, exactly 50/50.
+   `flex: 1 1 0` + `min-width: 0` is the canonical "equal share,
+   shrinkable" combo. */
+.plot-card__row--split .plot-select {
+  flex: 1 1 0;
+  min-width: 0;
 }
 
 .plot-card__body {
@@ -59,22 +87,3 @@
   white-space: nowrap;
 }
 
-/* The hole picker is usually the widest — give it the lion's share
-   when several pickers share a row, and let property / chart-type
-   take a fixed minimum. */
-.plot-card .plot-select--hole {
-  flex: 1 1 0;
-}
-
-/* The hole picker is rendered inside a `.plot-title` wrapper.
-   Without `min-width: 0` here the wrapper's flex layout uses the
-   select's natural (option-text) width as its minimum, which lets
-   the wrapper — and the surrounding card — grow past the grid
-   track's `1fr` allocation.  Setting `min-width: 0` + `max-width:
-   100%` makes the wrapper honour its parent's width, so the
-   select's `max-width: 100%` finally has a bounded reference. */
-.plot-card .plot-title {
-  min-width: 0;
-  max-width: 100%;
-  flex: 1 1 0;
-}

--- a/javascript/packages/baselode/src/viz/TracePlot.css
+++ b/javascript/packages/baselode/src/viz/TracePlot.css
@@ -6,7 +6,14 @@
 .plot-card {
   display: flex;
   flex-direction: column;
+  min-width: 0;
   min-height: 0;
+  /* Without this, a `<select>` whose widest option exceeds the
+     card's width (e.g. a long composite hole_id like
+     "119644Balladonia18BAC024") forces the card itself to grow,
+     breaking the grid.  `overflow: hidden` keeps the wrapper as
+     the authoritative bound. */
+  overflow: hidden;
 }
 
 .plot-card__controls {
@@ -14,11 +21,16 @@
   display: flex;
   gap: 6px;
   flex-wrap: wrap;
+  /* Allow the row to shrink below the natural width of its
+     children so flex-wrap actually kicks in. */
+  min-width: 0;
+  width: 100%;
 }
 
 .plot-card__body {
   flex: 1;
   min-height: 0;
+  min-width: 0;
   display: flex;
 }
 
@@ -31,4 +43,25 @@
 .plot-card.empty .plot-card__body {
   align-items: center;
   justify-content: center;
+}
+
+/* Every dropdown inside a TracePlot — the hole picker most
+   importantly — must respect the parent card's width.  Without
+   these rules a `<select>` reports its natural width as the widest
+   option's width, which can be many times the card's width for
+   composite hole IDs.  Truncate the rendered selected value with
+   an ellipsis instead. */
+.plot-card .plot-select {
+  min-width: 0;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* The hole picker is usually the widest — give it the lion's share
+   when several pickers share a row, and let property / chart-type
+   take a fixed minimum. */
+.plot-card .plot-select--hole {
+  flex: 1 1 0;
 }

--- a/javascript/packages/baselode/src/viz/TracePlot.jsx
+++ b/javascript/packages/baselode/src/viz/TracePlot.jsx
@@ -49,80 +49,68 @@ function genericOptionAsTuple(o) {
   return [value, label];
 }
 
-function renderHoleSelector({ selector, holeOptions, selectedHoleId, onConfigChange }) {
+/**
+ * Standalone renderer for a `group+hole` selector's group select.
+ * Returns just the group dropdown — the matching hole select is
+ * rendered separately by `renderHoleSelect` so the two can live on
+ * their own rows in the controls layout.
+ */
+function renderGroupSelect({ selector }) {
+  const groupValue = selector.groupValue ?? '';
+  const groupLabel = selector.groupLabel || 'Group';
+  const groupOptions = selector.groupOptions || [];
+  return (
+    <select
+      className="plot-select plot-select--group"
+      value={groupValue}
+      onChange={(e) => selector.onGroupChange && selector.onGroupChange(e.target.value)}
+      disabled={groupOptions.length === 0}
+      aria-label={groupLabel}
+    >
+      {groupOptions.length === 0 && <option value="">No {groupLabel.toLowerCase()}s</option>}
+      {!groupValue && groupOptions.length > 0 && (
+        <option value="" disabled hidden>{`Select ${groupLabel.toLowerCase()}`}</option>
+      )}
+      {groupOptions.map((g) => {
+        const [v, l] = genericOptionAsTuple(g);
+        return <option key={v} value={v}>{l}</option>;
+      })}
+    </select>
+  );
+}
+
+function renderFieldSelect({ selector }) {
+  const value = selector.value ?? '';
+  const opts = selector.options || [];
+  const label = selector.label || 'Selection';
+  return (
+    <select
+      className="plot-select plot-select--field"
+      value={value}
+      onChange={(e) => selector.onChange && selector.onChange(e.target.value)}
+      disabled={opts.length === 0}
+      aria-label={label}
+    >
+      {opts.length === 0 && <option value="">—</option>}
+      {!value && opts.length > 0 && (
+        <option value="" disabled hidden>{`Select ${label.toLowerCase()}`}</option>
+      )}
+      {opts.map((o) => {
+        const [v, l] = genericOptionAsTuple(o);
+        return <option key={v} value={v}>{l}</option>;
+      })}
+    </select>
+  );
+}
+
+function renderHoleSelect({ selector, holeOptions, selectedHoleId, onConfigChange }) {
   const kind = selector?.kind || 'hole';
-
-  if (kind === 'field') {
-    const value = selector.value ?? '';
-    const opts = selector.options || [];
-    const label = selector.label || 'Selection';
-    return (
-      <select
-        className="plot-select plot-select--field"
-        value={value}
-        onChange={(e) => selector.onChange && selector.onChange(e.target.value)}
-        disabled={opts.length === 0}
-        aria-label={label}
-      >
-        {opts.length === 0 && <option value="">—</option>}
-        {!value && opts.length > 0 && (
-          <option value="" disabled hidden>{`Select ${label.toLowerCase()}`}</option>
-        )}
-        {opts.map((o) => {
-          const [v, l] = genericOptionAsTuple(o);
-          return <option key={v} value={v}>{l}</option>;
-        })}
-      </select>
-    );
-  }
-
-  if (kind === 'group+hole') {
-    const groupBy = selector.groupBy;
-    const groupValue = selector.groupValue ?? '';
-    const groupLabel = selector.groupLabel || 'Group';
-    const groupOptions = selector.groupOptions
-      || groupValuesFromHoles(holeOptions, groupBy);
-    const visibleHoles = filterHolesByGroup(holeOptions, groupBy, groupValue);
-    return (
-      <>
-        <select
-          className="plot-select plot-select--group"
-          value={groupValue}
-          onChange={(e) => selector.onGroupChange && selector.onGroupChange(e.target.value)}
-          disabled={groupOptions.length === 0}
-          aria-label={groupLabel}
-        >
-          {groupOptions.length === 0 && <option value="">No {groupLabel.toLowerCase()}s</option>}
-          {!groupValue && groupOptions.length > 0 && (
-            <option value="" disabled hidden>{`Select ${groupLabel.toLowerCase()}`}</option>
-          )}
-          {groupOptions.map((g) => {
-            const [v, l] = genericOptionAsTuple(g);
-            return <option key={v} value={v}>{l}</option>;
-          })}
-        </select>
-        <select
-          className="plot-select plot-select--hole"
-          value={selectedHoleId}
-          onChange={(e) => onConfigChange && onConfigChange({ holeId: e.target.value })}
-          disabled={visibleHoles.length === 0}
-          aria-label="Hole"
-        >
-          {visibleHoles.length === 0 && <option value="">No holes</option>}
-          {!selectedHoleId && visibleHoles.length > 0 && (
-            <option value="" disabled hidden>Select a hole</option>
-          )}
-          {visibleHoles.map((h) => {
-            const [v, l] = holeOptionAsTuple(h);
-            return <option key={v} value={v}>{l}</option>;
-          })}
-        </select>
-      </>
-    );
-  }
-
-  // kind === 'hole' (default)
-  const enabled = holeOptions.length > 0;
+  // `group+hole` filters the hole list by the picked group;
+  // `hole` (default) shows every hole.
+  const visibleHoles = kind === 'group+hole'
+    ? filterHolesByGroup(holeOptions, selector.groupBy, selector.groupValue ?? '')
+    : holeOptions;
+  const enabled = visibleHoles.length > 0;
   return (
     <select
       className="plot-select plot-select--hole"
@@ -131,16 +119,24 @@ function renderHoleSelector({ selector, holeOptions, selectedHoleId, onConfigCha
       disabled={!enabled}
       aria-label="Hole"
     >
-      {!enabled && <option value="">No holes loaded</option>}
+      {!enabled && <option value="">{kind === 'group+hole' ? 'No holes' : 'No holes loaded'}</option>}
       {!selectedHoleId && enabled && (
         <option value="" disabled hidden>Select a hole</option>
       )}
-      {holeOptions.map((h) => {
+      {visibleHoles.map((h) => {
         const [v, l] = holeOptionAsTuple(h);
         return <option key={v} value={v}>{l}</option>;
       })}
     </select>
   );
+}
+
+function resolveGroupOptions(selector, holeOptions) {
+  if (!selector || selector.kind !== 'group+hole') return selector;
+  // Materialise group options once so `renderGroupSelect` doesn't
+  // re-derive them on every render.
+  if (selector.groupOptions) return selector;
+  return { ...selector, groupOptions: groupValuesFromHoles(holeOptions, selector.groupBy) };
 }
 
 /**
@@ -351,21 +347,46 @@ function TracePlot({
     return () => resizeObserver.disconnect();
   }, [bodyState.kind]);
 
+  // Resolve a `group+hole` selector once per render so the group
+  // options + filtered hole list are computed identically by both
+  // the group row and the hole row below.
+  const resolvedSelector = resolveGroupOptions(holeSelector, holeOptions);
+  const holeKind = resolvedSelector?.kind || 'hole';
+
   return (
     <div className={`plot-card${isPlaceholder ? ' empty' : ''}`}>
       <header className="plot-card__controls">
-        {visibility.hole && (
-          <div className="plot-title">
-            {renderHoleSelector({
-              selector: holeSelector,
+        {/* Row 1: optional group / project selector when the caller
+            opts into `group+hole`.  Skipped otherwise. */}
+        {visibility.hole && holeKind === 'group+hole' && (
+          <div className="plot-card__row plot-card__row--group">
+            {renderGroupSelect({ selector: resolvedSelector })}
+          </div>
+        )}
+        {/* Row 1 (alt): a fully-custom `field` selector replaces the
+            hole picker entirely.  Caller-controlled, no hole list. */}
+        {visibility.hole && holeKind === 'field' && (
+          <div className="plot-card__row plot-card__row--field">
+            {renderFieldSelect({ selector: resolvedSelector })}
+          </div>
+        )}
+        {/* Row 2: hole picker — always takes a full row of its own
+            so a long composite hole_id never has to negotiate with
+            the property / chart-type pickers. */}
+        {visibility.hole && holeKind !== 'field' && (
+          <div className="plot-card__row plot-card__row--hole">
+            {renderHoleSelect({
+              selector: resolvedSelector,
               holeOptions,
               selectedHoleId,
               onConfigChange,
             })}
           </div>
         )}
+        {/* Row 3: property + chart-type, split 50/50.  When only
+            one is visible it fills the whole row. */}
         {(visibility.property || visibility.chartType) && (
-          <div className="plot-controls column">
+          <div className="plot-card__row plot-card__row--split">
             {visibility.property && (
               <select
                 className="plot-select plot-select--property"

--- a/javascript/packages/baselode/tests/columnDetection.test.js
+++ b/javascript/packages/baselode/tests/columnDetection.test.js
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2026 Darkmine Pty Ltd
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  defaultColorByColumn,
+  detectCategoricalColumns,
+  detectNumericColumns,
+} from '../src/panels/columnDetection.js';
+
+describe('detectNumericColumns', () => {
+  it('returns columns sorted by populated-row count desc', () => {
+    const rows = [
+      { au: 0.5, cu: 0.1 },
+      { au: 1.2, cu: null },
+      { au: 0.7 },
+    ];
+    expect(detectNumericColumns(rows)).toEqual(['au', 'cu']);
+  });
+
+  it('skips reserved columns', () => {
+    const rows = [
+      { hole_id: 'H1', from: 0, to: 1, au: 0.5 },
+    ];
+    expect(detectNumericColumns(rows)).toEqual(['au']);
+  });
+
+  it('treats blank strings as missing rather than zero', () => {
+    // Number('') is 0; without the explicit blank skip, an
+    // all-blank column would falsely register as numeric.
+    const rows = [{ junk: '' }, { junk: '' }];
+    expect(detectNumericColumns(rows)).toEqual([]);
+  });
+
+  it('returns [] for empty input', () => {
+    expect(detectNumericColumns([])).toEqual([]);
+    expect(detectNumericColumns(null)).toEqual([]);
+  });
+});
+
+describe('detectCategoricalColumns', () => {
+  it('accepts columns with mostly-string values', () => {
+    const rows = [
+      { lithology: 'granite', au: 0.5 },
+      { lithology: 'schist', au: 1.2 },
+      { lithology: 'basalt', au: 0.7 },
+    ];
+    expect(detectCategoricalColumns(rows)).toEqual(['lithology']);
+  });
+
+  it('accepts mixed string + numeric columns via majority rule', () => {
+    // 3 strings + 1 number → still categorical.
+    const rows = [
+      { geology_code: 'GRA' },
+      { geology_code: 'SCH' },
+      { geology_code: 'BAS' },
+      { geology_code: 5 },
+    ];
+    expect(detectCategoricalColumns(rows)).toContain('geology_code');
+  });
+
+  it('rejects all-numeric columns', () => {
+    const rows = [{ au: 0.5 }, { au: 1.2 }, { au: 0.7 }];
+    expect(detectCategoricalColumns(rows)).toEqual([]);
+  });
+
+  it('rejects single-value columns (no useful split)', () => {
+    const rows = [
+      { project: 'A' }, { project: 'A' }, { project: 'A' },
+    ];
+    expect(detectCategoricalColumns(rows)).toEqual([]);
+  });
+
+  it('respects the maxDistinct cap', () => {
+    const rows = Array.from({ length: 50 }, (_, idx) => ({ id: `v${idx}` }));
+    // 50 distinct → exceeds default cap of 40.
+    expect(detectCategoricalColumns(rows)).toEqual([]);
+    // Bumping the cap surfaces it.
+    expect(detectCategoricalColumns(rows, { maxDistinct: 100 })).toEqual(['id']);
+  });
+});
+
+describe('defaultColorByColumn', () => {
+  it('prefers a lithology column when present', () => {
+    expect(defaultColorByColumn(['project_id', 'lithology', 'hole_type'])).toBe('lithology');
+    expect(defaultColorByColumn(['litho_code', 'project_id'])).toBe('litho_code');
+  });
+
+  it('falls through to surface_sample_type, then project_id', () => {
+    expect(defaultColorByColumn(['project_id', 'surface_sample_type'])).toBe('surface_sample_type');
+    expect(defaultColorByColumn(['project_id', 'hole_type'])).toBe('project_id');
+  });
+
+  it('returns the first entry when no preferred name matches', () => {
+    expect(defaultColorByColumn(['hole_type', 'rock_class'])).toBe('hole_type');
+  });
+
+  it('returns "" for an empty list', () => {
+    expect(defaultColorByColumn([])).toBe('');
+    expect(defaultColorByColumn(null)).toBe('');
+  });
+});


### PR DESCRIPTION
A new layer of React components, one per analytics plot type, that bundles the existing config-builder primitive with its own property pickers + view toggles.  Embedding apps now drop in one component per chart and pass `rows` (+ optional `template` / `colourMap`) instead of reimplementing the same dropdown plumbing each time.

Six panels under `src/panels/`:

- `BaselodeScatterPanel`   — X / Y / Colour-by + log X & Y
- `BaselodeHistogramPanel` — Property / Group-by + log Y +
  stack-mode picker (overlay / stack / side-by-side)
- `BaselodeBoxPanel`       — Property / Group-by + log Y
- `BaselodeViolinPanel`    — Property / Group-by + log Y
- `BaselodeTernaryPanel`   — A / B / C apices + Colour-by
- `BaselodeStripLogPanel`  — TracePlot + useDrillholeTraceGrid in
  one wrapper, supports the existing `holeSelector` group+hole
  mode for project filtering

State model:

- **Uncontrolled mode (default)**: state lives inside the panel. Seeds column picks the first time numeric / categorical lists are known; functional setters mean a user's explicit pick is never overwritten on re-seed.
- **Controlled mode**: pass `value` + `onChange` and the caller owns the state object.  The mode is locked on first render; a dev-mode warning fires if the caller flips between modes mid-life.

Shared primitives under `src/panels/`:

- `PanelControls.jsx` — `PlotPanel` layout wrapper + reusable `PropertySelect` / `LogToggle` / `BarmodeSelect` controls.  All classes namespaced `baselode-*` so the imported stylesheet won't collide with host CSS.
- `columnDetection.js` — `detectNumericColumns` (frequency-ordered), `detectCategoricalColumns` (majority-non-numeric rule), and `defaultColorByColumn` (prefer-lithology heuristic).  Lifted from the inline copies in demo-viewer-react + baselode-frontend.
- `useControllable.js` — controlled/uncontrolled hook.
- `panels.css` — neutral defaults with CSS-custom-property overrides for host theming.

Exports: every component + primitive is wired through `src/index.js`.

Tests:
- 13 new `columnDetection.test.js` cases — frequency sort, blank handling, majority-numeric rejection, max-distinct cap, prefer- lithology default.
- Panel rendering tests would need a DOM environment (jsdom + @testing-library/react); not added in this ticket — the demo viewer migration below is the smoke test.

Demo viewer migration (`demo-viewer-react/app/src/pages/AnalyticsPlots.jsx`):

- Replaces ~430 lines of inline pickers + per-plot state with five `BaselodeXPanel` instances (net -335 lines on that file).
- Auto-detection in the panels removes the need for the page-level `detectNumericColumns` / `detectCategoricalColumns` / per-plot `useState` blocks.
- Dark-template toggle + row count chrome unchanged.

Build: vite-builds clean for both the lib and demo-viewer.
Tests: 394 Python + 526 JS green (+13 from this ticket).

baselode-frontend migration is filed separately — it lives in a different repo and needs its own PR.