### PR TITLE
[TRK-134] fix_overlaps: auto-resolve safe interval overlaps

### DIFF
--- a/python/src/baselode/drill/validate.py
+++ b/python/src/baselode/drill/validate.py
@@ -304,6 +304,253 @@ def swap_inverted_intervals(table, from_col=FROM, to_col=TO):
     return out
 
 
+OVERLAP_REPORT_COLUMNS = ("hole_id", "kind", "action", "from", "to", "note")
+
+
+def _values_agree(outer_idx, inner_idxs, value_cols, work, from_col, to_col, merge_tol):
+    """Return True if outer-row values agree with inner-rows length-weighted.
+
+    For each value column:
+
+    - If the outer value is NaN, the column is skipped (nothing to compare).
+    - If the column is non-numeric, every non-NaN inner value must equal
+      the outer value exactly.
+    - If the column is numeric, the length-weighted mean of inner non-NaN
+      values must be within ``merge_tol`` (relative) of the outer value.
+    """
+    for col in value_cols:
+        outer_val = work.at[outer_idx, col]
+        if pd.isna(outer_val):
+            continue
+        try:
+            outer_float = float(outer_val)
+        except (TypeError, ValueError):
+            outer_float = None
+
+        if outer_float is None:
+            for inner_idx in inner_idxs:
+                inner_val = work.at[inner_idx, col]
+                if pd.isna(inner_val):
+                    continue
+                if inner_val != outer_val:
+                    return False
+            continue
+
+        weighted_sum = 0.0
+        total_weight = 0.0
+        for inner_idx in inner_idxs:
+            inner_val = work.at[inner_idx, col]
+            if pd.isna(inner_val):
+                continue
+            try:
+                inner_float = float(inner_val)
+            except (TypeError, ValueError):
+                return False
+            weight = float(work.at[inner_idx, to_col]) - float(work.at[inner_idx, from_col])
+            weighted_sum += inner_float * weight
+            total_weight += weight
+        if total_weight == 0:
+            continue
+        inner_mean = weighted_sum / total_weight
+        denom = max(abs(outer_float), 1e-9)
+        if abs(inner_mean - outer_float) / denom > merge_tol:
+            return False
+    return True
+
+
+def fix_overlaps(
+    table,
+    hole_col=HOLE_ID,
+    from_col=FROM,
+    to_col=TO,
+    value_cols=None,
+    touching_tol=0.01,
+    merge_tol=0.05,
+    coverage_min=0.95,
+    return_diagnostics=False,
+):
+    """Resolve interval overlaps where it's safe, leave the rest flagged.
+
+    Handles three classes of overlap automatically:
+
+    * **Touching overlap** — consecutive intervals where the later one
+      starts inside the earlier by less than ``touching_tol`` metres.
+      Caused by floating-point rounding.  Snaps the earlier ``to`` down
+      to the later ``from``.
+    * **Exact duplicate** — rows with identical ``(hole_id, from, to)``
+      *and* identical values in every column of ``value_cols``.  Drops
+      all but the first row of each duplicate group.
+    * **Resampled superset** — a longer interval fully contains shorter
+      ones whose length-weighted mean of ``value_cols`` matches the
+      longer's value within ``merge_tol`` (relative), and the shorter
+      intervals cover at least ``coverage_min`` of the longer.  Drops
+      the longer interval, keeps the higher-resolution rows.
+
+    Anything else — same depth zone, materially different values, or
+    partial overlaps — is left untouched and returned in the
+    *conflicts* frame for human review.
+
+    Parameters
+    ----------
+    table : pd.DataFrame
+        Interval table.
+    hole_col, from_col, to_col : str
+        Column-name overrides (defaults from :mod:`baselode.datamodel`).
+    value_cols : iterable of str, optional
+        Columns to compare for duplicate / superset classification.
+        Default: every column other than ``hole_col``/``from_col``/``to_col``.
+    touching_tol : float, optional
+        Maximum overlap, in metres, treated as a "snap me" rounding
+        glitch.  Default ``0.01``.
+    merge_tol : float, optional
+        Maximum relative difference, per value column, allowed between
+        a candidate superset interval and the length-weighted mean of
+        its inner intervals.  Default ``0.05`` (5%).
+    coverage_min : float, optional
+        Minimum fraction of a candidate superset that must be covered by
+        inner intervals before it qualifies as a "resampled superset".
+        Default ``0.95``.
+    return_diagnostics : bool, optional
+        When ``True``, return ``(fixed, conflicts, report)``: the fixed
+        table, the rows still in conflict, and an audit-log frame with
+        one row per resolved overlap.  Default ``False`` (returns just
+        the fixed table).
+
+    Returns
+    -------
+    pd.DataFrame, or tuple of (pd.DataFrame, pd.DataFrame, pd.DataFrame)
+        See ``return_diagnostics``.
+    """
+    empty_report = pd.DataFrame(columns=list(OVERLAP_REPORT_COLUMNS))
+
+    if table.empty:
+        if return_diagnostics:
+            return table.copy(), table.iloc[0:0].copy(), empty_report
+        return table.copy()
+
+    required = {hole_col, from_col, to_col}
+    if not required.issubset(table.columns):
+        if return_diagnostics:
+            return table.copy(), table.iloc[0:0].copy(), empty_report
+        return table.copy()
+
+    if value_cols is None:
+        value_cols = [c for c in table.columns if c not in (hole_col, from_col, to_col)]
+    else:
+        value_cols = [c for c in value_cols if c in table.columns]
+
+    work = table.copy().reset_index(drop=True)
+    work[from_col] = pd.to_numeric(work[from_col], errors="coerce")
+    work[to_col] = pd.to_numeric(work[to_col], errors="coerce")
+
+    keep = pd.Series(True, index=work.index)
+    report_rows = []
+
+    def _emit(hole_id, kind, action, frm, to, note=""):
+        report_rows.append({
+            "hole_id": hole_id,
+            "kind": kind,
+            "action": action,
+            "from": frm,
+            "to": to,
+            "note": note,
+        })
+
+    # ---- Pass 1: drop exact duplicates -------------------------------------
+    dup_keys = [hole_col, from_col, to_col] + value_cols
+    dup_keys = [k for k in dup_keys if k in work.columns]
+    duplicated_mask = work.duplicated(subset=dup_keys, keep="first")
+    for idx in work.index[duplicated_mask]:
+        row = work.loc[idx]
+        _emit(row[hole_col], "duplicate", "dropped", row[from_col], row[to_col])
+    keep &= ~duplicated_mask
+
+    # ---- Pass 2: snap touching overlaps ------------------------------------
+    for hole_id, group in work.loc[keep].groupby(hole_col, sort=False):
+        ordered = group.sort_values([from_col, to_col])
+        prev_idx = None
+        for idx in ordered.index:
+            if prev_idx is None:
+                prev_idx = idx
+                continue
+            a_to = float(work.at[prev_idx, to_col])
+            b_from = float(work.at[idx, from_col])
+            if a_to > b_from and (a_to - b_from) <= touching_tol:
+                work.at[prev_idx, to_col] = b_from
+                _emit(hole_id, "touching", "snapped",
+                      float(work.at[prev_idx, from_col]), a_to,
+                      f"{to_col}: {a_to} -> {b_from}")
+            prev_idx = idx
+
+    # ---- Pass 3: resampled supersets ---------------------------------------
+    for hole_id, group in work.loc[keep].groupby(hole_col, sort=False):
+        ordered_idxs = list(group.sort_values([from_col, to_col]).index)
+        for outer_idx in ordered_idxs:
+            if not keep[outer_idx]:
+                continue
+            outer_from = float(work.at[outer_idx, from_col])
+            outer_to = float(work.at[outer_idx, to_col])
+            outer_length = outer_to - outer_from
+            if outer_length <= 0:
+                continue
+            inner_idxs = []
+            for inner_idx in ordered_idxs:
+                if inner_idx == outer_idx or not keep[inner_idx]:
+                    continue
+                inner_from = float(work.at[inner_idx, from_col])
+                inner_to = float(work.at[inner_idx, to_col])
+                if inner_from >= outer_from and inner_to <= outer_to and (
+                    inner_from > outer_from or inner_to < outer_to
+                ):
+                    inner_idxs.append(inner_idx)
+            if not inner_idxs:
+                continue
+            covered = sum(
+                float(work.at[i, to_col]) - float(work.at[i, from_col])
+                for i in inner_idxs
+            )
+            if covered / outer_length < coverage_min:
+                continue
+            if not _values_agree(outer_idx, inner_idxs, value_cols, work,
+                                 from_col, to_col, merge_tol):
+                continue
+            keep[outer_idx] = False
+            _emit(hole_id, "superset", "dropped",
+                  outer_from, outer_to,
+                  f"covered by {len(inner_idxs)} finer rows ({covered / outer_length:.0%})")
+
+    # ---- Pass 4: surface remaining real conflicts --------------------------
+    conflict_idx_set = []
+    seen = set()
+    for hole_id, group in work.loc[keep].groupby(hole_col, sort=False):
+        ordered_idxs = list(group.sort_values([from_col, to_col]).index)
+        for a_pos, a_idx in enumerate(ordered_idxs):
+            a_from = float(work.at[a_idx, from_col])
+            a_to = float(work.at[a_idx, to_col])
+            for b_idx in ordered_idxs[a_pos + 1:]:
+                b_from = float(work.at[b_idx, from_col])
+                if b_from >= a_to:
+                    break
+                b_to = float(work.at[b_idx, to_col])
+                if a_idx not in seen:
+                    conflict_idx_set.append(a_idx)
+                    seen.add(a_idx)
+                if b_idx not in seen:
+                    conflict_idx_set.append(b_idx)
+                    seen.add(b_idx)
+                _emit(hole_id, "conflict", "kept",
+                      min(a_from, b_from), max(a_to, b_to),
+                      "unresolved overlap")
+
+    fixed = work.loc[keep].reset_index(drop=True)
+    conflicts = work.loc[conflict_idx_set].reset_index(drop=True) if conflict_idx_set else work.iloc[0:0].copy()
+    report = pd.DataFrame(report_rows, columns=list(OVERLAP_REPORT_COLUMNS))
+
+    if return_diagnostics:
+        return fixed, conflicts, report
+    return fixed
+
+
 def normalize_azimuth(survey, azimuth_col=AZIMUTH):
     """Wrap survey azimuths into ``[0, 360)``.
 

--- a/test/test_drill_validate_db.py
+++ b/test/test_drill_validate_db.py
@@ -256,6 +256,109 @@ def test_swap_inverted_intervals_preserves_other_columns():
     assert fixed.iloc[0]["lithology"] == "granite"
 
 
+def test_fix_overlaps_snaps_touching_within_tolerance():
+    assays = _assays([
+        ("A", 0.0, 5.005, 0.1),
+        ("A", 5.0, 10.0, 0.2),
+    ])
+    fixed = validate.fix_overlaps(assays, touching_tol=0.01)
+    assert list(fixed["from"]) == [0.0, 5.0]
+    assert list(fixed["to"]) == [5.0, 10.0]
+
+
+def test_fix_overlaps_leaves_overlap_larger_than_tolerance_alone():
+    assays = _assays([
+        ("A", 0.0, 5.5, 0.1),
+        ("A", 5.0, 10.0, 0.2),
+    ])
+    fixed, conflicts, _ = validate.fix_overlaps(assays, touching_tol=0.01, return_diagnostics=True)
+    # Untouched (still overlapping by 0.5 m), and flagged as conflict.
+    assert list(fixed["to"]) == [5.5, 10.0]
+    assert len(conflicts) == 2
+
+
+def test_fix_overlaps_drops_exact_duplicates():
+    assays = _assays([
+        ("A", 0.0, 1.0, 0.1),
+        ("A", 0.0, 1.0, 0.1),  # exact duplicate
+        ("A", 1.0, 2.0, 0.2),
+    ])
+    fixed = validate.fix_overlaps(assays)
+    assert len(fixed) == 2
+    assert list(fixed["from"]) == [0.0, 1.0]
+
+
+def test_fix_overlaps_keeps_partial_duplicates_as_conflicts():
+    # Same (from, to) but different values — not a true duplicate.
+    assays = _assays([
+        ("A", 0.0, 1.0, 0.1),
+        ("A", 0.0, 1.0, 0.7),
+    ])
+    fixed, conflicts, _ = validate.fix_overlaps(assays, return_diagnostics=True)
+    assert len(fixed) == 2
+    assert len(conflicts) == 2
+
+
+def test_fix_overlaps_drops_resampled_superset():
+    # 0-10 m coarse interval @ 0.3, fully covered by 1 m fines averaging 0.3
+    assays = _assays([("A", 0.0, 10.0, 0.3)]
+        + [("A", float(i), float(i + 1), 0.3) for i in range(10)])
+    fixed = validate.fix_overlaps(assays, merge_tol=0.05)
+    assert len(fixed) == 10
+    assert (fixed["to"] - fixed["from"] == 1.0).all()
+
+
+def test_fix_overlaps_keeps_superset_when_values_disagree():
+    # Coarse says 0.3, fines average 0.7 — materially different, not safe.
+    assays = _assays([("A", 0.0, 4.0, 0.3)]
+        + [("A", float(i), float(i + 1), 0.7) for i in range(4)])
+    fixed, conflicts, _ = validate.fix_overlaps(assays, merge_tol=0.05, return_diagnostics=True)
+    assert len(fixed) == 5  # nothing dropped
+    assert len(conflicts) >= 2  # outer + at least one inner reported
+
+
+def test_fix_overlaps_keeps_superset_when_coverage_too_low():
+    # 0-10 coarse, but only 0-3 has fines (30% coverage) — keep coarse.
+    assays = _assays([("A", 0.0, 10.0, 0.3)]
+        + [("A", float(i), float(i + 1), 0.3) for i in range(3)])
+    fixed = validate.fix_overlaps(assays, coverage_min=0.95)
+    assert len(fixed) == 4
+
+
+def test_fix_overlaps_handles_holes_independently():
+    # Hole A has a touching overlap, hole B is clean — A is fixed, B unchanged.
+    assays = _assays([
+        ("A", 0.0, 5.005, 0.1),
+        ("A", 5.0, 10.0, 0.2),
+        ("B", 0.0, 5.0, 0.5),
+        ("B", 5.0, 10.0, 0.6),
+    ])
+    fixed = validate.fix_overlaps(assays, touching_tol=0.01)
+    a_rows = fixed[fixed["hole_id"] == "A"]
+    b_rows = fixed[fixed["hole_id"] == "B"]
+    assert list(a_rows["to"]) == [5.0, 10.0]
+    assert list(b_rows["to"]) == [5.0, 10.0]
+
+
+def test_fix_overlaps_diagnostic_report_shape():
+    assays = _assays([
+        ("A", 0.0, 1.0, 0.1),
+        ("A", 0.0, 1.0, 0.1),
+    ])
+    fixed, conflicts, report = validate.fix_overlaps(assays, return_diagnostics=True)
+    assert list(report.columns) == ["hole_id", "kind", "action", "from", "to", "note"]
+    assert len(report) == 1
+    assert report.iloc[0]["kind"] == "duplicate"
+    assert report.iloc[0]["action"] == "dropped"
+
+
+def test_fix_overlaps_returns_copy_when_empty():
+    empty = _assays([])
+    fixed = validate.fix_overlaps(empty)
+    assert fixed.empty
+    assert fixed is not empty
+
+
 def test_orphan_intervals_fix_recipe_points_at_drop_helper():
     collar = _collar([("A", 0.0, 0.0, 0.0, 100.0)])
     survey = _survey([("A", 0.0, 0.0, -90.0), ("A", 100.0, 0.0, -90.0)])


### PR DESCRIPTION
Add baselode.drill.validate.fix_overlaps(table, ..., touching_tol, merge_tol, coverage_min, return_diagnostics=False) that handles three classes of interval-table overlap automatically:

- touching: A.to > B.from by less than touching_tol (default 0.01 m) — snap A.to down to B.from.  Caused by float rounding.
- duplicate: identical (hole_id, from, to) AND identical value_cols — drop all but the first.
- resampled superset: a longer interval fully contains shorter ones whose length-weighted mean ≈ the longer's value within merge_tol (default 5%) AND coverage ≥ coverage_min (default 95%) — drop the longer, keep the higher-resolution rows.

Genuine value conflicts (same depth zone, materially different values, or partial overlaps) are left untouched.  When return_diagnostics=True, returns (fixed, conflicts, report) where report has one row per resolved overlap with (hole_id, kind, action, from, to, note).

Motivation: in real QA runs, interval overlaps are the load-bearing failure mode (they corrupt compositing, intercepts, IDW samples), but the existing flow deferred every overlap to "surgical territory" for human review.  This helper resolves the safe cases (typically the majority) and shrinks the remaining list to true conflicts only.