### PR TITLE
fix(desurvey): correct east/north decomposition in desurveyTraces

### DIFF
--- a/javascript/packages/baselode/src/data/desurvey.js
+++ b/javascript/packages/baselode/src/data/desurvey.js
@@ -174,8 +174,11 @@ export function desurveyTraces(collars, surveys) {
 
       const rf = beta > 1e-6 ? (2 / beta) * Math.tan(beta / 2) : 1;
 
-      const dx = 0.5 * deltaMD * (Math.sin(inc1) * Math.cos(az1) + Math.sin(inc2) * Math.cos(az2)) * rf;
-      const dy = 0.5 * deltaMD * (Math.sin(inc1) * Math.sin(az1) + Math.sin(inc2) * Math.sin(az2)) * rf;
+      // Azimuth is a compass bearing clockwise from north, so east is the
+      // sine component and north the cosine — matching directionCosines() in
+      // desurveyMethods.js and _direction_cosines() in the Python package.
+      const dx = 0.5 * deltaMD * (Math.sin(inc1) * Math.sin(az1) + Math.sin(inc2) * Math.sin(az2)) * rf; // east
+      const dy = 0.5 * deltaMD * (Math.sin(inc1) * Math.cos(az1) + Math.sin(inc2) * Math.cos(az2)) * rf; // north
       const dzDown = 0.5 * deltaMD * (Math.cos(inc1) + Math.cos(inc2)) * rf; // down is positive
 
       accX += dx;

--- a/javascript/packages/baselode/tests/desurvey.test.js
+++ b/javascript/packages/baselode/tests/desurvey.test.js
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2026 Darkmine Pty Ltd
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { desurveyTraces } from '../src/data/desurvey.js';
+
+/**
+ * Azimuth is a compass bearing measured clockwise from north, so the
+ * horizontal components of a trace are east = sin(azimuth) and
+ * north = cos(azimuth).  `desurveyTraces` returns scene-frame `x`/`y`
+ * where `x` is converted to longitude and `y` to latitude, so `x` is
+ * east and `y` is north.
+ *
+ * These bearings are chosen deliberately: 045 is the axis of the
+ * east/north mirror, so it is the one direction that looks correct under
+ * a swapped decomposition and cannot discriminate.
+ */
+describe('desurveyTraces horizontal decomposition', () => {
+  const collars = [{ hole_id: 'H1', latitude: 0, longitude: 0, elevation: 0 }];
+
+  const traceToe = (azimuth) => {
+    const surveys = [
+      { hole_id: 'H1', depth: 0, azimuth, dip: -60 },
+      { hole_id: 'H1', depth: 100, azimuth, dip: -60 }
+    ];
+    const [hole] = desurveyTraces(collars, surveys);
+    return hole.points[hole.points.length - 1];
+  };
+
+  it('sends a hole drilled due east to the east', () => {
+    const toe = traceToe(90);
+    expect(toe.x).toBeGreaterThan(1);
+    expect(toe.y).toBeCloseTo(0, 6);
+  });
+
+  it('sends a hole drilled due north to the north', () => {
+    const toe = traceToe(0);
+    expect(toe.y).toBeGreaterThan(1);
+    expect(toe.x).toBeCloseTo(0, 6);
+  });
+
+  it('sends a hole drilled due south to the south', () => {
+    const toe = traceToe(180);
+    expect(toe.y).toBeLessThan(-1);
+    expect(toe.x).toBeCloseTo(0, 6);
+  });
+
+  it('places the toe on its surveyed bearing', () => {
+    for (const azimuth of [0, 30, 90, 135, 200, 315]) {
+      const toe = traceToe(azimuth);
+      const bearing = ((Math.atan2(toe.x, toe.y) * 180) / Math.PI + 360) % 360;
+      expect(bearing).toBeCloseTo(azimuth, 4);
+    }
+  });
+
+  it('agrees with directionCosines on the horizontal components', () => {
+    // desurveyMethods.directionCosines is the reference implementation and
+    // matches the Python `_direction_cosines`; the two must not drift.
+    const azimuth = 93.2;
+    const toe = traceToe(azimuth);
+    const horizontal = Math.hypot(toe.x, toe.y);
+    const az = (azimuth * Math.PI) / 180;
+    expect(toe.x).toBeCloseTo(horizontal * Math.sin(az), 6);
+    expect(toe.y).toBeCloseTo(horizontal * Math.cos(az), 6);
+  });
+
+  it('keeps depth and downhole length independent of azimuth', () => {
+    const depths = [0, 90, 180, 270].map((azimuth) => traceToe(azimuth).z);
+    depths.forEach((z) => expect(z).toBeCloseTo(depths[0], 6));
+    expect(depths[0]).toBeLessThan(0); // z up, hole goes down
+  });
+});


### PR DESCRIPTION
Fixes #84.

`desurveyTraces` decomposed horizontal displacement as `east = sin(inc)·cos(az)` and `north = sin(inc)·sin(az)`. Azimuth is a compass bearing clockwise from north, so those are the other way round. The effect was a reflection about the 045° line — plotted bearing = `(90 − true bearing) mod 360` — so a hole drilled due east plotted due north. Depth, dip and downhole length were unaffected.

This swaps the two terms so the decomposition matches the two implementations already in the repo:

| implementation | east | north |
|---|---|---|
| `python/src/baselode/drill/desurvey.py` `_direction_cosines` | `cos(dip)·sin(az)` | `cos(dip)·cos(az)` |
| `javascript/…/src/data/desurveyMethods.js` `directionCosines` | `cos(dip)·sin(az)` | `cos(dip)·cos(az)` |
| `desurveyTraces` **(before)** | `sin(inc)·cos(az)` | `sin(inc)·sin(az)` |
| `desurveyTraces` **(after)** | `sin(inc)·sin(az)` | `sin(inc)·cos(az)` |

Since `PARITY_SPEC.md` lists desurveying workflows as a parity-guaranteed area, this brings the JS trace path back in line with the Python reference.

### Tests

New `tests/desurvey.test.js` — `desurveyTraces` had no direct coverage, which is plausibly how the two implementations drifted apart. Six cases:

- due east → `+x`, `y ≈ 0`; due north → `+y`, `x ≈ 0`; due south → `−y`, `x ≈ 0`
- toe bearing matches surveyed azimuth across 0 / 30 / 90 / 135 / 200 / 315
- horizontal components agree with `directionCosines` (the parity assertion)
- depth is independent of azimuth, and z is negative for a downward hole

Bearings are chosen deliberately: **045° is the mirror axis**, so it is the one direction that looks correct under a swapped decomposition. A test at 045° alone would have passed against the old code.

**Before the change:** 5 of the 6 fail. The one that passes is the depth-independence case, which the bug never touched.
**After:** 6/6 pass, and the full suite is green — **660 tests across 38 files, no regressions.**

### One thing this PR does *not* fix — the committed precomputed fixture

`test/data/gswa/demo_gswa_precomputed_desurveyed.csv` is generated by `demo-viewer-react/app/scripts/generate_precomputed_desurvey.mjs`, which calls `desurveyTraces` — so the committed copy carries the mirrored bearings and will disagree with the code after this change.

Confirmed on hole `101533ForrestaniaFFD166`: surveyed azimuth **269.9°** (due west, dip −67.9°), but its precomputed trace runs on bearing **177.5°** — matching the predicted `(90 − 269.9) mod 360 = 180.1°`. Over its 461 m the toe ends up about **304 m** from where the survey puts it.

I've left it out rather than push an 8.5 MB regenerated fixture in a first PR — your call whether to regenerate here or in a follow-up; re-running the generator should be all it needs. Worth flagging because `baselode-frontend` documents `precomputed_desurveyed` as an input that bypasses live desurvey, so anyone who generated one this way has the same offset baked in.

### Compatibility note

Any consumer that had compensated for the old behaviour downstream — e.g. by swapping axes when rendering — will need that compensation removed. I checked the two consumers in this monorepo and neither compensates: `demo-viewer-react/app/src/pages/Drillhole.jsx` uses the traces directly while projecting collars separately, and `baselode-frontend` does the same — so a compensating swap in either would have fixed traces and broken collars.