### PR TITLE
TRK-242: add JavaScript Extent parity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,11 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Set up Node.js for cross-language parity
+        uses: actions/setup-node@v5
+        with:
+          node-version: "20"
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -32,6 +37,10 @@ jobs:
           # Install optional extras so tests covering them actually run
           # in CI instead of skipping silently.
           pip install "omf>=1.0,<2.0" "lasio>=0.31"
+
+      - name: Install JavaScript projection dependency for parity tests
+        working-directory: javascript/packages/baselode
+        run: npm ci
 
       - name: Run tests
         run: python -m pytest test -q

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,11 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Set up Node.js for cross-language parity
+        uses: actions/setup-node@v5
+        with:
+          node-version: "20"
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -32,6 +37,10 @@ jobs:
           # Install optional extras so tests covering them actually run
           # in CI instead of skipping silently.
           pip install "omf>=1.0,<2.0" "lasio>=0.31"
+
+      - name: Install JavaScript projection dependency for parity tests
+        working-directory: javascript/packages/baselode
+        run: npm ci
 
       - name: Run tests
         run: python -m pytest test -q

--- a/PARITY_SPEC.md
+++ b/PARITY_SPEC.md
@@ -13,6 +13,7 @@ The two implementations should remain aligned for:
 3. 1D strip/trace plotting helpers
 4. 2D plan/section mapping helpers
 5. 3D drillhole payload/scene helpers
+6. Spatial extent bounds, CRS normalisation, reprojection, and center helpers
 
 ## Runtime differences (intentional)
 
@@ -20,6 +21,10 @@ The two implementations should remain aligned for:
 - Python favors DataFrame-centric workflows and figure/dataframe utilities.
 - JS `loadTable` supports CSV/array sources in-browser; SQL/Parquet are out of runtime scope and should fail clearly.
 - 3D parity target is payload-level parity in both languages; interactive renderer remains JS-first.
+- JavaScript `Extent` adds GeoJSON Polygon/Feature helpers; Python callers can
+  use the existing Shapely `bbox` geometry for equivalent geometry workflows.
+- CRS engines are runtime-native (`proj4` in JavaScript, `pyproj` in Python),
+  with shared EPSG behavior and tolerance-based numeric parity checks.
 
 ### Python-first (no JS counterpart yet)
 
@@ -29,10 +34,6 @@ These belong in JS eventually but aren't there today. Listed here so the gap is 
   converters for the GSWA raw schema. Python-only. JS callers wanting GSWA
   data should hit the HTTP API directly through their own client and feed
   the results to JS loaders manually until a JS adaptor exists.
-- **`baselode.extent.Extent`** — axis-aligned bbox + CRS class with
-  `set_crs` / `to_crs` reprojection (via `pyproj`). JS has no equivalent
-  spatial primitive yet; the JS spatial helpers operate on raw bounds
-  arrays.
 - **`baselode.drill.data.bundle_extras`** — folds non-canonical columns
   into a per-row `extra` dict matching the canonical
   `BASELODE_DATA_MODEL_*` schemas. JS publishes the matching `EXTRA`

--- a/docs/guide/javascript.md
+++ b/docs/guide/javascript.md
@@ -10,6 +10,50 @@ npm install baselode
 
 ---
 
+## Spatial extents
+
+`Extent` is the shared bounds-and-CRS primitive for map requests, spatial
+filters, and GeoJSON study areas. Import it from the lightweight subpath when
+you do not need the rest of Baselode:
+
+```js
+import { Extent } from 'baselode/extent';
+
+const area = Extent.fromBbox(
+  { west: 120, south: -32, east: 120.5, north: -31.5 },
+  'EPSG:4326',
+  'study area',
+);
+
+const mga = area.toCrs('EPSG:28351');
+const [longitude, latitude] = mga.center({ lonlat: true });
+const feature = mga.toFeature({ purpose: 'drillhole-filter' });
+```
+
+The constructor also accepts named bounds:
+
+```js
+const area = new Extent({
+  xmin: 120,
+  ymin: -32,
+  xmax: 120.5,
+  ymax: -31.5,
+  crs: 4326,
+});
+```
+
+Bounds and `name` are immutable. `setCrs(crs)` changes only the CRS label and
+is chainable; use `toCrs(crs)` when the coordinates must be reprojected. EPSG
+strings/numbers and proj4-compatible proj/WKT definitions are accepted.
+Built-in definitions cover WGS84, Web Mercator, GDA94, and MGA zones 49–58.
+Unknown CRS codes fail with an explicit error.
+
+`toPolygon()`, `toFeature(properties)`, and
+`toFeatureCollection(properties)` emit deterministic GeoJSON using the ring
+order southwest → southeast → northeast → northwest → southwest.
+
+---
+
 ## Peer Dependencies
 
 `baselode` relies on the following peer dependencies, which must be installed in your application:

--- a/javascript/packages/baselode/README.md
+++ b/javascript/packages/baselode/README.md
@@ -35,6 +35,24 @@ file.text().then(csvText => {
 });
 ```
 
+## Spatial extents
+
+Use the lightweight `baselode/extent` entry point for CRS-aware bounds and
+GeoJSON study areas:
+
+```javascript
+import { Extent } from 'baselode/extent';
+
+const area = Extent.fromBbox([120, -32, 120.5, -31.5], 'EPSG:4326');
+const mga = area.toCrs('EPSG:28351');
+const feature = mga.toFeature({ id: 'study-area' });
+```
+
+The class accepts EPSG numbers/strings and proj4-compatible proj/WKT
+definitions. WGS84, Web Mercator, GDA94, and MGA zones 49–58 work out of the
+box. See the [JavaScript guide](../../../docs/guide/javascript.md#spatial-extents)
+for the full API.
+
 ## Tool UI for assistant-ui
 
 Baselode publishes schemas, React renderers, and a ready-made assistant-ui

--- a/javascript/packages/baselode/package-lock.json
+++ b/javascript/packages/baselode/package-lock.json
@@ -8,6 +8,9 @@
       "name": "baselode",
       "version": "0.1.11",
       "license": "GPL-3.0-or-later",
+      "dependencies": {
+        "proj4": "^2.21.0"
+      },
       "devDependencies": {
         "@assistant-ui/react": "^0.15.14",
         "@types/react": "^19.2.18",
@@ -3486,6 +3489,12 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/mgrs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mgrs/-/mgrs-1.0.0.tgz",
+      "integrity": "sha512-awNbTOqCxK1DBGjalK3xqWIstBZgN6fxsMSiXLs9/spqWkF2pAhb2rrYCFSsr1/tT7PhcDGjZndG8SWYn0byYA==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -3584,6 +3593,27 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/proj4": {
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/proj4/-/proj4-2.21.0.tgz",
+      "integrity": "sha512-33HfDftqw8kY+Cl1dcL16SJuqTSzYxmz4re7Nmhk+fs1/N1fFrAkkF579msQTR/4fLeJVSNne8/gpoCz0fk1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "mgrs": "1.0.0",
+        "wkt-parser": "^1.5.5"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ahocevar"
+      },
+      "peerDependencies": {
+        "geotiff": "*"
+      },
+      "peerDependenciesMeta": {
+        "geotiff": {
+          "optional": true
+        }
       }
     },
     "node_modules/radix-ui": {
@@ -4295,6 +4325,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/wkt-parser": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/wkt-parser/-/wkt-parser-1.5.6.tgz",
+      "integrity": "sha512-cqHU3lzGt/gt2OqIORP0uVy5yeOX43WABmgFkmJsmcqH3HhQo9PiJG6ftytwGKmpQUbegeX7+pQc2BuNCRfcrw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ahocevar"
       }
     },
     "node_modules/yallist": {

--- a/javascript/packages/baselode/package.json
+++ b/javascript/packages/baselode/package.json
@@ -22,6 +22,10 @@
     ".": {
       "import": "./dist/baselode.js"
     },
+    "./extent": {
+      "types": "./types/extent.d.ts",
+      "import": "./dist/extent.js"
+    },
     "./style.css": "./dist/style.css",
     "./tool-ui": {
       "types": "./types/tool-ui.d.ts",
@@ -46,6 +50,9 @@
   "sideEffects": [
     "**/*.css"
   ],
+  "dependencies": {
+    "proj4": "^2.21.0"
+  },
   "scripts": {
     "version:from-tag": "node ./scripts/set-version-from-tag.mjs",
     "build": "vite build",

--- a/javascript/packages/baselode/scripts/check-package-contracts.mjs
+++ b/javascript/packages/baselode/scripts/check-package-contracts.mjs
@@ -13,6 +13,7 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 const root = resolve(fileURLToPath(new URL('..', import.meta.url)));
 const packageJson = JSON.parse(readFileSync(resolve(root, 'package.json'), 'utf8'));
 const publishedEntries = {
+  './extent': ['dist/extent.js', 'types/extent.d.ts'],
   './tool-ui': ['dist/tool-ui.js', 'types/tool-ui.d.ts'],
   './tool-ui/contracts': ['dist/tool-ui-contracts.js', 'types/tool-ui-contracts.d.ts'],
   './assistant-ui': ['dist/assistant-ui.js', 'types/assistant-ui.d.ts'],
@@ -31,6 +32,11 @@ for (const clientEntry of ['dist/tool-ui.js', 'dist/assistant-ui.js']) {
 
 const contracts = await import(pathToFileURL(resolve(root, 'dist/tool-ui-contracts.js')));
 assert.equal(Object.keys(contracts.BASELODE_TOOL_UI_SCHEMA_CONTRACTS).length, 7);
+
+const extentModule = await import(pathToFileURL(resolve(root, 'dist/extent.js')));
+const extent = extentModule.Extent.fromBbox([118, -32, 120, -30]);
+assert.deepEqual(extent.center(), [119, -31]);
+assert.equal(extentModule.DEFAULT_EXTENT_CRS, 'EPSG:4326');
 
 const npmCache = mkdtempSync(join(tmpdir(), 'baselode-pack-'));
 let pack;
@@ -56,4 +62,4 @@ assert(files.has('dist/style.css'));
 assert(files.has('src/tool-ui/style.css'));
 assert(files.has('README.md'));
 
-console.log('Published Tool UI contracts are present, importable, and typed.');
+console.log('Published Extent and Tool UI contracts are present, importable, and typed.');

--- a/javascript/packages/baselode/scripts/run-extent-parity.mjs
+++ b/javascript/packages/baselode/scripts/run-extent-parity.mjs
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2026 Darkmine Pty Ltd
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { readFileSync } from 'node:fs';
+import { Extent } from '../src/extent/Extent.js';
+
+const input = JSON.parse(readFileSync(0, 'utf8'));
+const results = input.map(({ bounds, crs, targetCrs, name, properties = {} }) => {
+  const extent = new Extent({ ...bounds, crs, name });
+  const projected = extent.toCrs(targetCrs);
+  return {
+    bounds: {
+      xmin: projected.xmin,
+      ymin: projected.ymin,
+      xmax: projected.xmax,
+      ymax: projected.ymax,
+    },
+    crs: projected.crs,
+    name: projected.name,
+    center: projected.center(),
+    foliumRectangle: projected.getFoliumRectangle(),
+    polygon: projected.toPolygon(),
+    feature: projected.toFeature(properties),
+    featureCollection: projected.toFeatureCollection(properties),
+  };
+});
+
+process.stdout.write(JSON.stringify(results));

--- a/javascript/packages/baselode/src/extent/Extent.js
+++ b/javascript/packages/baselode/src/extent/Extent.js
@@ -1,0 +1,280 @@
+/*
+ * Copyright (C) 2026 Darkmine Pty Ltd
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import proj4 from 'proj4';
+
+export const DEFAULT_EXTENT_CRS = 'EPSG:4326';
+
+const EPSG_PATTERN = /^epsg\s*:\s*(\d+)$/i;
+const BARE_EPSG_PATTERN = /^\d+$/;
+
+function registerAustralianCrsDefinitions() {
+  if (!proj4.defs('EPSG:4283')) {
+    proj4.defs(
+      'EPSG:4283',
+      '+proj=longlat +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +no_defs +type=crs',
+    );
+  }
+  for (let zone = 49; zone <= 58; zone += 1) {
+    const code = `EPSG:${28300 + zone}`;
+    if (!proj4.defs(code)) {
+      proj4.defs(
+        code,
+        `+proj=utm +zone=${zone} +south +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs +type=crs`,
+      );
+    }
+  }
+}
+
+registerAustralianCrsDefinitions();
+
+function describe(value) {
+  if (typeof value === 'string') return JSON.stringify(value);
+  return String(value);
+}
+
+function normaliseCrs(crs) {
+  if (crs === null || crs === undefined) {
+    throw new TypeError(
+      "Extent requires a CRS. Pass crs: 'EPSG:4326' (default), an EPSG number, or a proj/WKT definition.",
+    );
+  }
+
+  let normalized;
+  if (typeof crs === 'number') {
+    if (!Number.isSafeInteger(crs) || crs <= 0) {
+      throw new TypeError(`Invalid CRS ${describe(crs)}: EPSG numbers must be positive integers.`);
+    }
+    normalized = `EPSG:${crs}`;
+  } else if (typeof crs === 'string') {
+    const trimmed = crs.trim();
+    if (!trimmed) {
+      throw new TypeError('Invalid CRS "": CRS definitions must not be empty.');
+    }
+    const epsgMatch = trimmed.match(EPSG_PATTERN);
+    if (epsgMatch) {
+      normalized = `EPSG:${Number(epsgMatch[1])}`;
+    } else if (BARE_EPSG_PATTERN.test(trimmed)) {
+      normalized = `EPSG:${Number(trimmed)}`;
+    } else {
+      normalized = trimmed;
+    }
+  } else {
+    throw new TypeError(
+      `Invalid CRS ${describe(crs)}: pass an EPSG string/number or a proj/WKT definition.`,
+    );
+  }
+
+  try {
+    proj4(normalized);
+  } catch (error) {
+    const detail = error?.message ? `: ${error.message}` : '';
+    throw new TypeError(
+      `Invalid CRS ${describe(crs)}${detail}. The definition is not registered or supported by proj4.`,
+      { cause: error },
+    );
+  }
+  return normalized;
+}
+
+function finiteNumber(value, name) {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throw new TypeError(`Extent ${name} must be a finite number; received ${describe(value)}.`);
+  }
+  return value;
+}
+
+function boundsFromBbox(bbox) {
+  if (Array.isArray(bbox)) {
+    if (bbox.length !== 4) {
+      throw new TypeError('Extent bbox arrays must contain [west, south, east, north].');
+    }
+    return {
+      xmin: bbox[0],
+      ymin: bbox[1],
+      xmax: bbox[2],
+      ymax: bbox[3],
+    };
+  }
+  if (bbox && typeof bbox === 'object') {
+    return {
+      xmin: bbox.west,
+      ymin: bbox.south,
+      xmax: bbox.east,
+      ymax: bbox.north,
+    };
+  }
+  throw new TypeError(
+    'Extent bbox must be [west, south, east, north] or { west, south, east, north }.',
+  );
+}
+
+function validateBounds(bounds) {
+  const normalized = {
+    xmin: finiteNumber(bounds.xmin, 'xmin'),
+    ymin: finiteNumber(bounds.ymin, 'ymin'),
+    xmax: finiteNumber(bounds.xmax, 'xmax'),
+    ymax: finiteNumber(bounds.ymax, 'ymax'),
+  };
+  if (normalized.xmin > normalized.xmax) {
+    throw new RangeError('Extent xmin must be less than or equal to xmax.');
+  }
+  if (normalized.ymin > normalized.ymax) {
+    throw new RangeError('Extent ymin must be less than or equal to ymax.');
+  }
+  return normalized;
+}
+
+function transformedBounds(sourceCrs, targetCrs, points) {
+  try {
+    const transformed = points.map((point) => proj4(sourceCrs, targetCrs, point));
+    const xs = transformed.map(([x]) => finiteNumber(x, 'transformed x'));
+    const ys = transformed.map(([, y]) => finiteNumber(y, 'transformed y'));
+    return {
+      xmin: Math.min(...xs),
+      ymin: Math.min(...ys),
+      xmax: Math.max(...xs),
+      ymax: Math.max(...ys),
+    };
+  } catch (error) {
+    throw new Error(
+      `Failed to reproject extent from CRS ${describe(sourceCrs)} to ${describe(targetCrs)}: ${error?.message || error}`,
+      { cause: error },
+    );
+  }
+}
+
+/**
+ * Axis-aligned bounding box with an explicit coordinate reference system.
+ */
+export class Extent {
+  constructor(options = {}) {
+    if (!options || typeof options !== 'object' || Array.isArray(options)) {
+      throw new TypeError('Extent constructor expects an options object.');
+    }
+    const hasBbox = options.bbox !== undefined;
+    const hasBounds = ['xmin', 'ymin', 'xmax', 'ymax']
+      .some((property) => options[property] !== undefined);
+    if (hasBbox && hasBounds) {
+      throw new TypeError('Extent accepts either bbox or xmin/ymin/xmax/ymax, not both.');
+    }
+    const bounds = validateBounds(hasBbox ? boundsFromBbox(options.bbox) : options);
+    const name = options.name ?? null;
+    if (name !== null && typeof name !== 'string') {
+      throw new TypeError('Extent name must be a string or null.');
+    }
+    const crs = normaliseCrs(options.crs ?? DEFAULT_EXTENT_CRS);
+
+    Object.defineProperties(this, {
+      xmin: { value: bounds.xmin, enumerable: true },
+      ymin: { value: bounds.ymin, enumerable: true },
+      xmax: { value: bounds.xmax, enumerable: true },
+      ymax: { value: bounds.ymax, enumerable: true },
+      name: { value: name, enumerable: true },
+      crs: { value: crs, enumerable: true, writable: true },
+    });
+  }
+
+  static fromBbox(bbox, crs = DEFAULT_EXTENT_CRS, name = null) {
+    return new Extent({ bbox, crs, name });
+  }
+
+  static fromFeature(feature, crs = DEFAULT_EXTENT_CRS, name = null) {
+    if (!feature || feature.type !== 'Feature' || feature.geometry?.type !== 'Polygon') {
+      throw new TypeError('Extent.fromFeature expects a GeoJSON Polygon Feature.');
+    }
+    const positions = feature.geometry.coordinates.flat();
+    if (!positions.length) {
+      throw new TypeError('Extent.fromFeature cannot derive bounds from an empty Polygon.');
+    }
+    const xs = positions.map((position) => finiteNumber(position?.[0], 'polygon x'));
+    const ys = positions.map((position) => finiteNumber(position?.[1], 'polygon y'));
+    return new Extent({
+      xmin: Math.min(...xs),
+      ymin: Math.min(...ys),
+      xmax: Math.max(...xs),
+      ymax: Math.max(...ys),
+      crs,
+      name,
+    });
+  }
+
+  setCrs(crs) {
+    this.crs = normaliseCrs(crs);
+    return this;
+  }
+
+  toCrs(targetCrs) {
+    const target = normaliseCrs(targetCrs);
+    if (target === this.crs) {
+      return new Extent({
+        xmin: this.xmin,
+        ymin: this.ymin,
+        xmax: this.xmax,
+        ymax: this.ymax,
+        name: this.name,
+        crs: target,
+      });
+    }
+    const bounds = transformedBounds(this.crs, target, [
+      [this.xmin, this.ymin],
+      [this.xmax, this.ymin],
+      [this.xmax, this.ymax],
+      [this.xmin, this.ymax],
+    ]);
+    return new Extent({ ...bounds, name: this.name, crs: target });
+  }
+
+  center({ lonlat = false } = {}) {
+    const point = [
+      (this.xmin + this.xmax) / 2,
+      (this.ymin + this.ymax) / 2,
+    ];
+    if (!lonlat || this.crs === DEFAULT_EXTENT_CRS) return point;
+    try {
+      return proj4(this.crs, DEFAULT_EXTENT_CRS, point);
+    } catch (error) {
+      throw new Error(
+        `Failed to reproject extent center from CRS ${describe(this.crs)} to ${describe(DEFAULT_EXTENT_CRS)}: ${error?.message || error}`,
+        { cause: error },
+      );
+    }
+  }
+
+  getFoliumRectangle() {
+    return [[this.ymin, this.xmin], [this.ymax, this.xmax]];
+  }
+
+  toPolygon() {
+    return {
+      type: 'Polygon',
+      coordinates: [[
+        [this.xmin, this.ymin],
+        [this.xmax, this.ymin],
+        [this.xmax, this.ymax],
+        [this.xmin, this.ymax],
+        [this.xmin, this.ymin],
+      ]],
+    };
+  }
+
+  toFeature(properties = {}) {
+    if (properties !== null && (typeof properties !== 'object' || Array.isArray(properties))) {
+      throw new TypeError('Extent feature properties must be an object or null.');
+    }
+    return {
+      type: 'Feature',
+      properties,
+      geometry: this.toPolygon(),
+    };
+  }
+
+  toFeatureCollection(properties = {}) {
+    return {
+      type: 'FeatureCollection',
+      features: [this.toFeature(properties)],
+    };
+  }
+}

--- a/javascript/packages/baselode/src/index.js
+++ b/javascript/packages/baselode/src/index.js
@@ -5,6 +5,11 @@
 
 // --- Data model ---
 export {
+  DEFAULT_EXTENT_CRS,
+  Extent,
+} from './extent/Extent.js';
+
+export {
   // Drilling and sampling primitives
   DATASOURCE,
   HOLE_ID,

--- a/javascript/packages/baselode/tests/extent.test.js
+++ b/javascript/packages/baselode/tests/extent.test.js
@@ -1,0 +1,147 @@
+/*
+ * Copyright (C) 2026 Darkmine Pty Ltd
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_EXTENT_CRS, Extent } from '../src/extent/Extent.js';
+
+describe('Extent construction', () => {
+  it('constructs from named bounds with the default CRS', () => {
+    const extent = new Extent({ xmin: 118, ymin: -32, xmax: 120, ymax: -30 });
+
+    expect(extent).toMatchObject({
+      xmin: 118,
+      ymin: -32,
+      xmax: 120,
+      ymax: -30,
+      name: null,
+      crs: DEFAULT_EXTENT_CRS,
+    });
+  });
+
+  it('constructs from tuple and object bbox forms', () => {
+    expect(Extent.fromBbox([118, -32, 120, -30], 4326, 'WA')).toMatchObject({
+      xmin: 118,
+      ymin: -32,
+      xmax: 120,
+      ymax: -30,
+      name: 'WA',
+      crs: 'EPSG:4326',
+    });
+    expect(Extent.fromBbox({ west: 118, south: -32, east: 120, north: -30 }))
+      .toMatchObject({ xmin: 118, ymin: -32, xmax: 120, ymax: -30 });
+  });
+
+  it('keeps bounds and name immutable while setCrs remains chainable', () => {
+    const extent = new Extent({ xmin: 0, ymin: 1, xmax: 2, ymax: 3, name: 'area' });
+
+    expect(() => { extent.xmin = 99; }).toThrow(TypeError);
+    expect(() => { extent.name = 'changed'; }).toThrow(TypeError);
+    expect(extent.setCrs('epsg:3857')).toBe(extent);
+    expect(extent.crs).toBe('EPSG:3857');
+  });
+
+  it('accepts raw proj and WKT definitions', () => {
+    const proj = '+proj=longlat +datum=WGS84 +no_defs';
+    const wkt = 'GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563]],PRIMEM["Greenwich",0],UNIT["degree",0.0174532925199433]]';
+
+    expect(Extent.fromBbox([0, 0, 1, 1], proj).crs).toBe(proj);
+    expect(Extent.fromBbox([0, 0, 1, 1], wkt).crs).toBe(wkt);
+  });
+
+  it.each([
+    [{ xmin: Number.NaN, ymin: 0, xmax: 1, ymax: 1 }, /finite number/],
+    [{ xmin: 2, ymin: 0, xmax: 1, ymax: 1 }, /xmin/],
+    [{ xmin: 0, ymin: 2, xmax: 1, ymax: 1 }, /ymin/],
+    [{ bbox: [0, 0, 1] }, /four|contain/],
+    [{ xmin: 0, ymin: 0, xmax: 1, ymax: 1, crs: 'EPSG:999999' }, /Invalid CRS/],
+  ])('rejects invalid input %#', (options, message) => {
+    expect(() => new Extent(options)).toThrow(message);
+  });
+});
+
+describe('Extent reprojection', () => {
+  it('normalises common CRS forms and returns a fresh same-CRS copy', () => {
+    const extent = Extent.fromBbox([118, -32, 120, -30], '4326', 'WA');
+    const copy = extent.toCrs(4326);
+
+    expect(copy).not.toBe(extent);
+    expect(copy).toEqual(extent);
+  });
+
+  it('supports GDA94 / MGA zone definitions and preserves the complete envelope', () => {
+    const extent = Extent.fromBbox([120, -32, 120.5, -31.5], 'EPSG:4326');
+    const projected = extent.toCrs(28351);
+    const roundTrip = projected.toCrs('EPSG:4326');
+
+    expect(projected.crs).toBe('EPSG:28351');
+    expect(projected.xmin).toBeLessThan(projected.xmax);
+    expect(projected.ymin).toBeLessThan(projected.ymax);
+    expect(roundTrip.xmin).toBeLessThanOrEqual(120);
+    expect(roundTrip.ymin).toBeLessThanOrEqual(-32);
+    expect(roundTrip.xmax).toBeGreaterThanOrEqual(120.5);
+    expect(roundTrip.ymax).toBeGreaterThanOrEqual(-31.5);
+  });
+
+  it('uses all four transformed corners for a projected envelope', () => {
+    const projected = Extent.fromBbox([112, -45, 154, -10]).toCrs('EPSG:28351');
+    const transformedCorners = [
+      [112, -45], [154, -45], [154, -10], [112, -10],
+    ].map(([x, y]) => Extent.fromBbox([x, y, x, y]).toCrs('EPSG:28351'));
+
+    expect(projected.xmin).toBe(Math.min(...transformedCorners.map(({ xmin }) => xmin)));
+    expect(projected.ymin).toBe(Math.min(...transformedCorners.map(({ ymin }) => ymin)));
+    expect(projected.xmax).toBe(Math.max(...transformedCorners.map(({ xmax }) => xmax)));
+    expect(projected.ymax).toBe(Math.max(...transformedCorners.map(({ ymax }) => ymax)));
+  });
+
+  it('returns projected and longitude/latitude centers', () => {
+    const projected = Extent.fromBbox([120, -32, 120.5, -31.5]).toCrs(28351);
+    const [x, y] = projected.center();
+    const [lon, lat] = projected.center({ lonlat: true });
+
+    expect(x).toBeGreaterThan(projected.xmin);
+    expect(y).toBeGreaterThan(projected.ymin);
+    expect(lon).toBeCloseTo(120.25, 2);
+    expect(lat).toBeCloseTo(-31.75, 2);
+  });
+});
+
+describe('Extent GeoJSON helpers', () => {
+  const extent = new Extent({ xmin: 1, ymin: 2, xmax: 4, ymax: 6 });
+  const ring = [[1, 2], [4, 2], [4, 6], [1, 6], [1, 2]];
+
+  it('emits a closed counter-clockwise polygon in deterministic order', () => {
+    expect(extent.toPolygon()).toEqual({ type: 'Polygon', coordinates: [ring] });
+  });
+
+  it('wraps the polygon as Feature and FeatureCollection', () => {
+    const properties = { id: 'study-area' };
+    expect(extent.toFeature(properties)).toEqual({
+      type: 'Feature',
+      properties,
+      geometry: { type: 'Polygon', coordinates: [ring] },
+    });
+    expect(extent.toFeatureCollection(properties).features).toEqual([
+      extent.toFeature(properties),
+    ]);
+  });
+
+  it('derives an envelope from a Polygon Feature and formats Folium bounds', () => {
+    const feature = {
+      type: 'Feature',
+      properties: null,
+      geometry: {
+        type: 'Polygon',
+        coordinates: [[[3, 7], [9, 5], [4, -1], [3, 7]]],
+      },
+    };
+    const derived = Extent.fromFeature(feature, 'EPSG:3857', 'polygon');
+
+    expect(derived).toMatchObject({
+      xmin: 3, ymin: -1, xmax: 9, ymax: 7, crs: 'EPSG:3857', name: 'polygon',
+    });
+    expect(derived.getFoliumRectangle()).toEqual([[-1, 3], [7, 9]]);
+  });
+});

--- a/javascript/packages/baselode/tests/types/extent.ts
+++ b/javascript/packages/baselode/tests/types/extent.ts
@@ -1,0 +1,18 @@
+import {
+  DEFAULT_EXTENT_CRS,
+  Extent,
+  type ExtentFeature,
+  type ExtentPolygon,
+  type ExtentPosition,
+} from 'baselode/extent';
+
+const extent = Extent.fromBbox([118, -32, 120, -30] as const, 4326, 'WA');
+const projected: Extent = extent.toCrs('EPSG:28351');
+const center: ExtentPosition = projected.center({ lonlat: true });
+const polygon: ExtentPolygon = projected.toPolygon();
+const feature: ExtentFeature<{ id: string }> = projected.toFeature({ id: 'wa' });
+
+extent.setCrs(DEFAULT_EXTENT_CRS);
+center[0].toFixed();
+polygon.coordinates[0][0][0].toFixed();
+feature.properties.id.toUpperCase();

--- a/javascript/packages/baselode/tests/types/tsconfig.json
+++ b/javascript/packages/baselode/tests/types/tsconfig.json
@@ -10,5 +10,5 @@
     "strict": true,
     "target": "ES2022"
   },
-  "include": ["contracts.tsx"]
+  "include": ["contracts.tsx", "extent.ts"]
 }

--- a/javascript/packages/baselode/types/extent.d.ts
+++ b/javascript/packages/baselode/types/extent.d.ts
@@ -1,0 +1,68 @@
+export type ExtentBboxTuple = readonly [number, number, number, number];
+
+export interface ExtentBboxObject {
+  west: number;
+  south: number;
+  east: number;
+  north: number;
+}
+
+export type ExtentBbox = ExtentBboxTuple | ExtentBboxObject;
+export type ExtentCrs = string | number;
+export type ExtentPosition = [number, number];
+
+export interface ExtentOptions {
+  xmin?: number;
+  ymin?: number;
+  xmax?: number;
+  ymax?: number;
+  bbox?: ExtentBbox;
+  name?: string | null;
+  crs?: ExtentCrs;
+}
+
+export interface ExtentPolygon {
+  type: 'Polygon';
+  coordinates: ExtentPosition[][];
+}
+
+export interface ExtentFeature<P extends object | null = Record<string, unknown>> {
+  type: 'Feature';
+  properties: P;
+  geometry: ExtentPolygon;
+}
+
+export interface ExtentFeatureCollection<P extends object | null = Record<string, unknown>> {
+  type: 'FeatureCollection';
+  features: Array<ExtentFeature<P>>;
+}
+
+export const DEFAULT_EXTENT_CRS: 'EPSG:4326';
+
+export class Extent {
+  readonly xmin: number;
+  readonly ymin: number;
+  readonly xmax: number;
+  readonly ymax: number;
+  readonly name: string | null;
+  crs: string;
+
+  constructor(options?: ExtentOptions);
+
+  static fromBbox(bbox: ExtentBbox, crs?: ExtentCrs, name?: string | null): Extent;
+  static fromFeature(
+    feature: ExtentFeature<object | null>,
+    crs?: ExtentCrs,
+    name?: string | null,
+  ): Extent;
+
+  setCrs(crs: ExtentCrs): this;
+  toCrs(targetCrs: ExtentCrs): Extent;
+  center(options?: { lonlat?: boolean }): ExtentPosition;
+  getFoliumRectangle(): [ExtentPosition, ExtentPosition];
+  toPolygon(): ExtentPolygon;
+  toFeature<P extends object | null = Record<string, unknown>>(properties?: P): ExtentFeature<P>;
+  toFeatureCollection<P extends object | null = Record<string, unknown>>(
+    properties?: P,
+  ): ExtentFeatureCollection<P>;
+}

--- a/javascript/packages/baselode/vite.config.js
+++ b/javascript/packages/baselode/vite.config.js
@@ -9,6 +9,7 @@ export default defineConfig({
     lib: {
       entry: {
         baselode: resolve(__dirname, 'src/index.js'),
+        extent: resolve(__dirname, 'src/extent/Extent.js'),
         'tool-ui': resolve(__dirname, 'src/tool-ui/index.js'),
         'tool-ui-contracts': resolve(__dirname, 'src/tool-ui/contracts-entry.js'),
         'assistant-ui': resolve(__dirname, 'src/assistant-ui/index.jsx'),
@@ -22,6 +23,7 @@ export default defineConfig({
         'react-dom',
         'react/jsx-runtime',
         '@assistant-ui/react',
+        'proj4',
         'three',
         /^three\//,
         'three-viewport-gizmo',

--- a/python/src/baselode/extent.py
+++ b/python/src/baselode/extent.py
@@ -140,8 +140,12 @@ class Extent():
                 pyproj.CRS.from_user_input(target),
                 always_xy=True,
             )
+            # Transform every corner before taking the envelope. For projected
+            # CRSs the extrema are not guaranteed to be the two diagonal
+            # corners, so transforming only those can clip the result.
             xs, ys = transformer.transform(
-                [self.xmin, self.xmax], [self.ymin, self.ymax],
+                [self.xmin, self.xmax, self.xmax, self.xmin],
+                [self.ymin, self.ymin, self.ymax, self.ymax],
             )
         except Exception as exc:
             raise ValueError(

--- a/test/data/parity_contract.json
+++ b/test/data/parity_contract.json
@@ -380,6 +380,33 @@
       ]
     },
     {
+      "name": "extent",
+      "description": "Axis-aligned bounds with an explicit CRS, four-corner reprojection, centers and Folium-compatible bounds. JavaScript additionally provides GeoJSON Polygon, Feature and FeatureCollection helpers.",
+      "jsExports": [
+        "DEFAULT_EXTENT_CRS",
+        "Extent"
+      ],
+      "jsMethods": [
+        "setCrs",
+        "toCrs",
+        "center",
+        "getFoliumRectangle",
+        "toPolygon",
+        "toFeature",
+        "toFeatureCollection"
+      ],
+      "pythonSymbols": [
+        ["baselode.extent", "DEFAULT_CRS"],
+        ["baselode.extent", "Extent"]
+      ],
+      "pythonMethods": [
+        "set_crs",
+        "to_crs",
+        "center",
+        "get_folium_rectangle"
+      ]
+    },
+    {
       "name": "core_photo_table",
       "jsExports": [
         "DEFAULT_LOD_BREAKPOINTS",

--- a/test/test_extent_parity.py
+++ b/test/test_extent_parity.py
@@ -1,0 +1,118 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Copyright (C) 2026 Darkmine Pty Ltd
+
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PYTHON_SRC_PATH = ROOT / "python" / "src"
+JS_PACKAGE_PATH = ROOT / "javascript" / "packages" / "baselode"
+JS_RUNNER_PATH = JS_PACKAGE_PATH / "scripts" / "run-extent-parity.mjs"
+
+if str(PYTHON_SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(PYTHON_SRC_PATH))
+
+
+def _javascript_results(cases):
+    completed = subprocess.run(
+        ["node", str(JS_RUNNER_PATH)],
+        cwd=JS_PACKAGE_PATH,
+        input=json.dumps(cases),
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    return json.loads(completed.stdout)
+
+
+def _python_result(case):
+    import baselode.extent
+
+    extent = baselode.extent.Extent(
+        xmin=case["bounds"]["xmin"],
+        ymin=case["bounds"]["ymin"],
+        xmax=case["bounds"]["xmax"],
+        ymax=case["bounds"]["ymax"],
+        crs=case["crs"],
+        name=case.get("name"),
+    ).to_crs(case["targetCrs"])
+    bounds = {
+        "xmin": extent.xmin,
+        "ymin": extent.ymin,
+        "xmax": extent.xmax,
+        "ymax": extent.ymax,
+    }
+    ring = [
+        [extent.xmin, extent.ymin],
+        [extent.xmax, extent.ymin],
+        [extent.xmax, extent.ymax],
+        [extent.xmin, extent.ymax],
+        [extent.xmin, extent.ymin],
+    ]
+    polygon = {"type": "Polygon", "coordinates": [ring]}
+    feature = {
+        "type": "Feature",
+        "properties": case.get("properties", {}),
+        "geometry": polygon,
+    }
+    return {
+        "bounds": bounds,
+        "crs": extent.crs,
+        "name": extent.name,
+        "center": list(extent.center()),
+        "foliumRectangle": extent.get_folium_rectangle(),
+        "polygon": polygon,
+        "feature": feature,
+        "featureCollection": {"type": "FeatureCollection", "features": [feature]},
+    }
+
+
+def test_javascript_extent_matches_python_extent_contract():
+    cases = [
+        {
+            "bounds": {"xmin": 118.0, "ymin": -32.0, "xmax": 120.0, "ymax": -30.0},
+            "crs": "EPSG:4326",
+            "targetCrs": "EPSG:3857",
+            "name": "western-australia",
+            "properties": {"id": "wa"},
+        },
+        {
+            "bounds": {"xmin": 120.0, "ymin": -32.0, "xmax": 120.5, "ymax": -31.5},
+            "crs": "EPSG:4326",
+            "targetCrs": "EPSG:28351",
+            "name": None,
+        },
+        {
+            "bounds": {"xmin": 0.0, "ymin": 0.0, "xmax": 1.0, "ymax": 1.0},
+            "crs": "EPSG:4326",
+            "targetCrs": "EPSG:4326",
+            "name": "identity",
+        },
+    ]
+
+    javascript_results = _javascript_results(cases)
+    python_results = [_python_result(case) for case in cases]
+
+    for javascript, python in zip(javascript_results, python_results):
+        assert javascript["crs"] == python["crs"]
+        assert javascript["name"] == python["name"]
+        assert javascript["bounds"] == pytest.approx(python["bounds"], abs=0.05)
+        assert javascript["center"] == pytest.approx(python["center"], abs=0.05)
+        for javascript_pair, python_pair in zip(
+            javascript["foliumRectangle"], python["foliumRectangle"]
+        ):
+            assert javascript_pair == pytest.approx(python_pair, abs=0.05)
+        javascript_ring = javascript["polygon"]["coordinates"][0]
+        python_ring = python["polygon"]["coordinates"][0]
+        for javascript_pair, python_pair in zip(javascript_ring, python_ring):
+            assert javascript_pair == pytest.approx(python_pair, abs=0.05)
+        assert javascript["feature"]["type"] == python["feature"]["type"]
+        assert javascript["feature"]["properties"] == python["feature"]["properties"]
+        assert javascript["featureCollection"]["type"] == "FeatureCollection"
+        assert javascript["featureCollection"]["features"] == [javascript["feature"]]

--- a/test/test_parity_contract.py
+++ b/test/test_parity_contract.py
@@ -37,9 +37,40 @@ def test_python_symbols_exist_for_contract():
             assert hasattr(module, symbol_name), f"Missing python symbol {module_name}.{symbol_name}"
 
 
+def test_python_methods_exist_for_contract():
+    contract = _load_contract()
+    for capability in contract["capabilities"]:
+        methods = capability.get("pythonMethods", [])
+        if not methods:
+            continue
+        class_entries = capability.get("pythonSymbols", [])
+        class_objects = []
+        for module_name, symbol_name in class_entries:
+            symbol = getattr(importlib.import_module(module_name), symbol_name)
+            if isinstance(symbol, type):
+                class_objects.append(symbol)
+        assert class_objects, f"No Python class declared for {capability['name']} methods"
+        for method in methods:
+            assert any(hasattr(class_object, method) for class_object in class_objects), (
+                f"Missing Python method for {capability['name']}: {method}"
+            )
+
+
 def test_js_exports_declared_for_contract():
     contract = _load_contract()
     source = JS_INDEX_PATH.read_text(encoding="utf-8")
     for capability in contract["capabilities"]:
         for symbol in capability.get("jsExports", []):
             assert symbol in source, f"Missing JS export symbol in index.js: {symbol}"
+
+
+def test_js_methods_declared_for_contract():
+    contract = _load_contract()
+    source = JS_INDEX_PATH.parent.joinpath("extent", "Extent.js").read_text(
+        encoding="utf-8"
+    )
+    for capability in contract["capabilities"]:
+        for method in capability.get("jsMethods", []):
+            assert f"{method}(" in source, (
+                f"Missing JS method for {capability['name']}: {method}"
+            )

--- a/test/test_raw_gswa_adaptor.py
+++ b/test/test_raw_gswa_adaptor.py
@@ -566,11 +566,12 @@ def test_api_client_fetch_table_rows_reprojects_extent_to_wgs84():
     s = _FakeSession().queue({"columns": [], "rows": []})
     _client(s).fetch_table_rows("dbo_collar", extent=extent)
     params = s.calls[0][1]
-    # Reprojected back to lon/lat — within a tolerance.
-    assert abs(params["min_lon"] - 120.0) < 1e-3
-    assert abs(params["min_lat"] - (-32.0)) < 1e-3
-    assert abs(params["max_lon"] - 120.5) < 1e-3
-    assert abs(params["max_lat"] - (-31.5)) < 1e-3
+    # Reprojecting an axis-aligned projected bbox creates a new envelope.
+    # It must contain the original lon/lat bounds; it need not equal them.
+    assert params["min_lon"] <= 120.0
+    assert params["min_lat"] <= -32.0
+    assert params["max_lon"] >= 120.5
+    assert params["max_lat"] >= -31.5
 
 
 # (removed: ``test_extent_construction_raises_when_pyproj_missing`` —
@@ -674,12 +675,12 @@ def test_to_crs_reprojects_to_target_crs():
     e = baselode.extent.Extent(xmin=120.0, xmax=120.5, ymin=-32.0, ymax=-31.5)
     projected = e.to_crs(28351)
     assert projected.crs == "EPSG:28351"
-    # Reproject back and compare to the original within tolerance.
+    # Reprojecting an axis-aligned envelope back must contain the original.
     roundtrip = projected.to_crs("EPSG:4326")
-    assert abs(roundtrip.xmin - 120.0) < 1e-3
-    assert abs(roundtrip.ymin - (-32.0)) < 1e-3
-    assert abs(roundtrip.xmax - 120.5) < 1e-3
-    assert abs(roundtrip.ymax - (-31.5)) < 1e-3
+    assert roundtrip.xmin <= 120.0
+    assert roundtrip.ymin <= -32.0
+    assert roundtrip.xmax >= 120.5
+    assert roundtrip.ymax >= -31.5
 
 
 def test_to_crs_validates_target_crs():


### PR DESCRIPTION
## Summary
- publish a typed JavaScript Extent class and baselode/extent entry point
- add proj4 CRS support, GeoJSON helpers, and four-corner reprojection
- update Python Extent to envelope all transformed corners
- add cross-language parity, package, type, CI, and documentation coverage

## Ticket
TRK-242

## Test plan
- npm run verify: 681 tests passed, build/type/package checks passed
- .venv/bin/python -m pytest test -q: 487 tests passed

## Risk
Low-to-medium: introduces a required proj4 runtime dependency and corrects projected bounding envelopes in Python.

## Reviewer
Claude Sonnet 5: no findings.