### PR TITLE
TRK-268: add row-object loader entry points

### DIFF
--- a/PARITY_SPEC.md
+++ b/PARITY_SPEC.md
@@ -20,6 +20,9 @@ The two implementations should remain aligned for:
 - JavaScript favors browser/runtime-native structures (arrays/objects, interactive scene APIs).
 - Python favors DataFrame-centric workflows and figure/dataframe utilities.
 - JS `loadTable` supports CSV/array sources in-browser; SQL/Parquet are out of runtime scope and should fail clearly.
+- JavaScript specialized loaders expose synchronous `*FromRows` cores so
+  external format decoders can supply structured rows without a CSV round
+  trip; CSV functions remain adapters over the same domain transformations.
 - 3D parity target is payload-level parity in both languages; interactive renderer remains JS-first.
 - JavaScript `Extent` adds GeoJSON Polygon/Feature helpers; Python callers can
   use the existing Shapely `bbox` geometry for equivalent geometry workflows.

--- a/docs/guide/javascript.md
+++ b/docs/guide/javascript.md
@@ -108,6 +108,43 @@ const assays   = loadAssays(assaysText);
 const dataset = assembleDataset({ collars, surveys, assays });
 ```
 
+### Already-parsed rows
+
+When another decoder has already produced row objects—for example Parquet,
+Arrow, LAS, or a database query—pass those rows directly instead of converting
+them to CSV:
+
+```js
+import {
+  parseAssaysFromRows,
+  parseStructuralFromRows,
+  parseUnifiedDatasetFromRows,
+} from 'baselode';
+
+const assays = parseAssaysFromRows(parquetAssayRows);
+const structural = parseStructuralFromRows(parquetStructuralRows);
+const unified = parseUnifiedDatasetFromRows({
+  assayRows: parquetAssayRows,
+  structuralRows: parquetStructuralRows,
+  geologyRows: parquetGeologyRows,
+});
+```
+
+Row entry points are synchronous and do not mutate their inputs. They avoid a
+rows → CSV → rows round trip and preserve typed extra values. Existing CSV
+functions remain available as adapters. Assay CSV scans continue to use
+PapaParse incrementally for large files.
+
+The specialized row APIs are `parseAssayHoleIdsFromRows`,
+`parseAssayHoleIdsWithAssaysFromRows`, `parseAssayHoleFromRows`,
+`parseAssaysFromRows`, `loadAssayFromRows`, `parseSurveyFromRows`,
+`parseDrillholesFromRows`, `parseBlockModelFromRows`,
+`parseStructuralPointsFromRows`, `parseStructuralIntervalsFromRows`,
+`parseStructuralFromRows`, `parseAssayHolesFromRows`,
+`parseGeologyFromRows`, `parseUnifiedDatasetFromRows`, and
+`parseGeophysicsFromRows`. The higher-level `loadTable`, `loadCollars`,
+`loadSurveys`, `loadAssays`, and `loadGeology` APIs also accept row arrays.
+
 ### Assay-focused loaders
 
 For large assay CSVs with multiple analyte columns:

--- a/javascript/packages/baselode/README.md
+++ b/javascript/packages/baselode/README.md
@@ -53,6 +53,24 @@ definitions. WGS84, Web Mercator, GDA94, and MGA zones 49–58 work out of the
 box. See the [JavaScript guide](../../../docs/guide/javascript.md#spatial-extents)
 for the full API.
 
+## Parsed row inputs
+
+Specialized data loaders publish synchronous `*FromRows` entry points for
+Parquet, Arrow, database, and other decoders that already produce row objects:
+
+```javascript
+import { parseUnifiedDatasetFromRows } from 'baselode';
+
+const dataset = parseUnifiedDatasetFromRows({
+  assayRows,
+  structuralRows,
+  geologyRows,
+});
+```
+
+This preserves typed values and avoids serializing rows to CSV only to parse
+them again. Existing CSV APIs remain backward compatible.
+
 ## Tool UI for assistant-ui
 
 Baselode publishes schemas, React renderers, and a ready-made assistant-ui

--- a/javascript/packages/baselode/src/data/assayDataLoader.js
+++ b/javascript/packages/baselode/src/data/assayDataLoader.js
@@ -2,7 +2,12 @@
  * Copyright (C) 2026 Darkmine Pty Ltd
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
-import { parseAssayHole, parseAssayHoleIdsWithAssays, parseAssaysCSV } from './assayLoader.js';
+import {
+  parseAssayHole,
+  parseAssayHoleIdsWithAssays,
+  parseAssaysCSV,
+  parseAssaysFromRows,
+} from './assayLoader.js';
 import { buildTraceConfigsForHoleIds, reorderHoleIds } from './traceGridConfig.js';
 import { classifyColumns } from './columnMeta.js';
 
@@ -97,7 +102,23 @@ export function buildAssayState(holes = [], focusedHoleId = '') {
  * @throws {Error} If no valid assay intervals found
  */
 export async function loadAssayFile(file, focusedHoleId = '', sourceColumnMap = null) {
-  const { holes } = await parseAssaysCSV(file, sourceColumnMap);
+  const { holes } = await parseAssaysCSV(file, null, sourceColumnMap);
+  const state = buildAssayState(holes, focusedHoleId);
+  if (!state) throw new Error('No valid assay intervals found.');
+  return state;
+}
+
+/**
+ * Build complete assay state directly from parsed row objects.
+ *
+ * @param {Array<Object>} rows - Parsed assay row objects
+ * @param {string} focusedHoleId - Hole ID to focus on
+ * @param {Object|null} sourceColumnMap - Optional column name mappings
+ * @returns {Object} Complete assay state
+ * @throws {Error} If no valid assay intervals are found
+ */
+export function loadAssayFromRows(rows, focusedHoleId = '', sourceColumnMap = null) {
+  const { holes } = parseAssaysFromRows(rows, null, sourceColumnMap);
   const state = buildAssayState(holes, focusedHoleId);
   if (!state) throw new Error('No valid assay intervals found.');
   return state;

--- a/javascript/packages/baselode/src/data/assayLoader.js
+++ b/javascript/packages/baselode/src/data/assayLoader.js
@@ -43,11 +43,11 @@ function extractInterval(row, sourceColumnMap = null) {
   if (!Number.isFinite(from) || !Number.isFinite(to) || to <= from) return null;
 
   return {
+    ...row,
     holeId,
     project,
     from,
-    to,
-    ...row
+    to
   };
 }
 
@@ -77,6 +77,100 @@ function intervalsToHole(holeId, intervals) {
   return { id: holeId, project: sorted[0]?.project, points };
 }
 
+function addHoleId(holeIds, rawRow, sourceColumnMap) {
+  const row = normalizeRow(rawRow, sourceColumnMap);
+  const holeId = row[HOLE_ID];
+  if (holeId !== undefined && `${holeId}`.trim() !== '') {
+    holeIds.add(`${holeId}`.trim());
+  }
+}
+
+function addHoleWithAssays(byHole, rawRow, sourceColumnMap) {
+  const row = normalizeRow(rawRow, sourceColumnMap);
+  if (!hasAssayValue(row)) return;
+  const { holeId } = extractIdFields(row);
+  if (holeId === undefined || `${holeId}`.trim() === '') return;
+  const key = `${holeId}`.trim();
+  if (!byHole.has(key)) byHole.set(key, { holeId: key });
+}
+
+function addInterval(byHole, rawRow, sourceColumnMap, wantedHoleId = null) {
+  const row = normalizeRow(rawRow, sourceColumnMap);
+  const interval = extractInterval(row, sourceColumnMap);
+  if (!interval || (wantedHoleId !== null && interval.holeId !== wantedHoleId)) return;
+  if (!byHole.has(interval.holeId)) byHole.set(interval.holeId, []);
+  byHole.get(interval.holeId).push(interval);
+}
+
+function holesFromIntervals(byHole) {
+  return Array.from(byHole.entries()).map(
+    ([holeId, intervals]) => intervalsToHole(holeId, intervals),
+  );
+}
+
+/**
+ * Extract unique hole IDs from already-parsed assay rows.
+ *
+ * @param {Array<Object>} rows - Parsed assay row objects
+ * @param {Object|null} sourceColumnMap - Optional column name mappings
+ * @returns {Array<string>} Unique hole IDs in source order
+ */
+export function parseAssayHoleIdsFromRows(rows, sourceColumnMap = null) {
+  const holeIds = new Set();
+  for (const row of rows || []) addHoleId(holeIds, row, sourceColumnMap);
+  return Array.from(holeIds);
+}
+
+/**
+ * Extract hole IDs with assay values from already-parsed rows.
+ *
+ * @param {Array<Object>} rows - Parsed assay row objects
+ * @param {Object|null} sourceColumnMap - Optional column name mappings
+ * @returns {Array<{holeId: string}>} Hole IDs with assay data
+ */
+export function parseAssayHoleIdsWithAssaysFromRows(rows, sourceColumnMap = null) {
+  const byHole = new Map();
+  for (const row of rows || []) addHoleWithAssays(byHole, row, sourceColumnMap);
+  return Array.from(byHole.values());
+}
+
+/**
+ * Parse one hole from already-parsed assay rows.
+ *
+ * @param {Array<Object>} rows - Parsed assay row objects
+ * @param {string} holeId - Hole identifier to extract
+ * @param {Object|null} config - Reserved for backwards-compatible call shapes
+ * @param {Object|null} sourceColumnMap - Optional column name mappings
+ * @returns {Object|null} Hole object or null when no intervals match
+ */
+export function parseAssayHoleFromRows(
+  rows,
+  holeId,
+  config = null,
+  sourceColumnMap = null,
+) {
+  const wanted = `${holeId}`.trim();
+  if (!wanted) throw withDataErrorContext('parseAssayHoleFromRows', new Error('Missing hole id'));
+  const byHole = new Map();
+  for (const row of rows || []) addInterval(byHole, row, sourceColumnMap, wanted);
+  const intervals = byHole.get(wanted);
+  return intervals?.length ? intervalsToHole(wanted, intervals) : null;
+}
+
+/**
+ * Parse all holes from already-parsed assay rows.
+ *
+ * @param {Array<Object>} rows - Parsed assay row objects
+ * @param {Object|null} config - Reserved for backwards-compatible call shapes
+ * @param {Object|null} sourceColumnMap - Optional column name mappings
+ * @returns {{holes: Array<Object>}} Parsed assay holes
+ */
+export function parseAssaysFromRows(rows, config = null, sourceColumnMap = null) {
+  const byHole = new Map();
+  for (const row of rows || []) addInterval(byHole, row, sourceColumnMap);
+  return { holes: holesFromIntervals(byHole) };
+}
+
 /**
  * Parse assay CSV to extract unique hole IDs (quick pass, no interval data)
  * @param {File|Blob} file - Assay CSV file
@@ -90,13 +184,7 @@ export function parseAssayHoleIds(file, sourceColumnMap = null) {
       header: true,
       dynamicTyping: true,
       skipEmptyLines: true,
-      step: (results) => {
-        const row = normalizeRow(results.data, sourceColumnMap);
-        const hid = row[HOLE_ID];
-        if (hid !== undefined && `${hid}`.trim() !== '') {
-          holeIds.add(`${hid}`.trim());
-        }
-      },
+      step: (results) => addHoleId(holeIds, results.data, sourceColumnMap),
       complete: () => resolve(Array.from(holeIds)),
       error: (error) => reject(withDataErrorContext('parseAssayHoleIds', error))
     });
@@ -131,20 +219,7 @@ export function parseAssayHoleIdsWithAssays(file, sourceColumnMap = null) {
       header: true,
       dynamicTyping: true,
       skipEmptyLines: true,
-      step: (results) => {
-        const row = normalizeRow(results.data, sourceColumnMap);
-        if (!hasAssayValue(row)) return;
-        const ids = extractIdFields(row);
-        const hid = ids.holeId;
-        if (hid !== undefined && `${hid}`.trim() !== '') {
-          const key = `${hid}`.trim();
-          if (!byHole.has(key)) {
-            byHole.set(key, {
-              holeId: key
-            });
-          }
-        }
-      },
+      step: (results) => addHoleWithAssays(byHole, results.data, sourceColumnMap),
       complete: () => resolve(Array.from(byHole.values())),
       error: (error) => reject(withDataErrorContext('parseAssayHoleIdsWithAssays', error))
     });
@@ -166,20 +241,15 @@ export function parseAssayHole(file, holeId, config = null, sourceColumnMap = nu
       reject(withDataErrorContext('parseAssayHole', new Error('Missing hole id')));
       return;
     }
-    const intervals = [];
+    const byHole = new Map();
     Papa.parse(file, {
       header: true,
       dynamicTyping: true,
       skipEmptyLines: true,
-      step: (results) => {
-        const row = normalizeRow(results.data, sourceColumnMap);
-        const interval = extractInterval(row, sourceColumnMap);
-        if (!interval) return;
-        if (`${interval.holeId}`.trim() !== wanted) return;
-        intervals.push(interval);
-      },
+      step: (results) => addInterval(byHole, results.data, sourceColumnMap, wanted),
       complete: () => {
-        if (!intervals.length) {
+        const intervals = byHole.get(wanted);
+        if (!intervals?.length) {
           resolve(null);
           return;
         }
@@ -200,23 +270,13 @@ export function parseAssayHole(file, holeId, config = null, sourceColumnMap = nu
  */
 export function parseAssaysCSV(file, config = null, sourceColumnMap = null) {
   return new Promise((resolve, reject) => {
+    const byHole = new Map();
     Papa.parse(file, {
       header: true,
       dynamicTyping: true,
       skipEmptyLines: true,
-      complete: (results) => {
-        const byHole = new Map();
-        results.data.forEach((rawRow) => {
-          const row = normalizeRow(rawRow, sourceColumnMap);
-          const interval = extractInterval(row, sourceColumnMap);
-          if (!interval) return;
-          if (!byHole.has(interval.holeId)) byHole.set(interval.holeId, []);
-          byHole.get(interval.holeId).push(interval);
-        });
-
-        const holes = Array.from(byHole.entries()).map(([hid, intervals]) => intervalsToHole(hid, intervals));
-        resolve({ holes });
-      },
+      step: (results) => addInterval(byHole, results.data, sourceColumnMap),
+      complete: () => resolve({ holes: holesFromIntervals(byHole) }),
       error: (error) => reject(withDataErrorContext('parseAssaysCSV', error))
     });
   });

--- a/javascript/packages/baselode/src/data/blockModelLoader.js
+++ b/javascript/packages/baselode/src/data/blockModelLoader.js
@@ -48,6 +48,24 @@ export function normalizeBlockRow(row) {
 // ---------------------------------------------------------------------------
 
 /**
+ * Parse already-decoded block model rows.
+ *
+ * @param {Array<Object>} rows - Parsed block model row objects
+ * @returns {{data: Array<Object>, properties: Array<string>}}
+ *   Parsed blocks and property column names
+ */
+export function parseBlockModelFromRows(rows) {
+  const normalized = (rows || []).map(normalizeBlockRow);
+  const data = normalized.filter(
+    (row) => row.x !== null && row.y !== null && row.z !== null,
+  );
+  const properties = Object.keys(data[0] || {}).filter(
+    (key) => !GEOMETRY_COLS.includes(key),
+  );
+  return { data, properties };
+}
+
+/**
  * Parse block model CSV data.
  *
  * Accepts columns named ``x/y/z/dx/dy/dz`` (baselode canonical) or the
@@ -64,18 +82,7 @@ export function parseBlockModelCSV(file) {
       header: true,
       dynamicTyping: true,
       skipEmptyLines: true,
-      complete: (results) => {
-        const normalized = (results.data || []).map(normalizeBlockRow);
-        const data = normalized.filter(
-          (row) => row.x !== null && row.y !== null && row.z !== null
-        );
-
-        const propertyColumns = Object.keys(data[0] || {}).filter(
-          (key) => !GEOMETRY_COLS.includes(key)
-        );
-
-        resolve({ data, properties: propertyColumns });
-      },
+      complete: (results) => resolve(parseBlockModelFromRows(results.data)),
       error: (error) => {
         reject(withDataErrorContext('parseBlockModelCSV', error));
       }

--- a/javascript/packages/baselode/src/data/desurvey.js
+++ b/javascript/packages/baselode/src/data/desurvey.js
@@ -8,6 +8,24 @@ import { withDataErrorContext } from './dataErrorUtils.js';
 import { HOLE_ID, LATITUDE, LONGITUDE, AZIMUTH, DIP, DEPTH, PROJECT_ID } from './datamodel.js';
 
 /**
+ * Normalize already-parsed survey rows.
+ *
+ * @param {Array<Object>} rows - Parsed survey row objects
+ * @param {Object|null} sourceColumnMap - Optional column name mappings
+ * @returns {Array<Object>} Valid normalized survey rows
+ */
+export function parseSurveyFromRows(rows, sourceColumnMap = null) {
+  return (rows || [])
+    .map((row) => normalizeRow(row, sourceColumnMap))
+    .filter((row) => (
+      row[HOLE_ID]
+      && Number.isFinite(row[DEPTH])
+      && Number.isFinite(row[DIP])
+      && Number.isFinite(row[AZIMUTH])
+    ));
+}
+
+/**
  * Parse survey CSV file containing downhole survey measurements
  * Expected columns: hole_id, depth, azimuth, dip
  * @param {File|Blob} file - Survey CSV file
@@ -20,12 +38,7 @@ export function parseSurveyCSV(file, sourceColumnMap = null) {
       header: true,
       dynamicTyping: true,
       skipEmptyLines: true,
-      complete: (results) => {
-        const rows = results.data
-          .map((row) => normalizeRow(row, sourceColumnMap))
-          .filter((row) => row[HOLE_ID] && Number.isFinite(row[DEPTH]) && Number.isFinite(row[DIP]) && Number.isFinite(row[AZIMUTH]));
-        resolve(rows);
-      },
+      complete: (results) => resolve(parseSurveyFromRows(results.data, sourceColumnMap)),
       error: (err) => reject(withDataErrorContext('parseSurveyCSV', err))
     });
   });

--- a/javascript/packages/baselode/src/data/drillholeLoader.js
+++ b/javascript/packages/baselode/src/data/drillholeLoader.js
@@ -8,6 +8,55 @@ import { withDataErrorContext } from './dataErrorUtils.js';
 import { HOLE_ID, EASTING, NORTHING, ELEVATION, DEPTH } from './datamodel.js';
 
 /**
+ * Parse already-decoded desurveyed trace rows.
+ *
+ * @param {Array<Object>} rows - Parsed drillhole row objects
+ * @param {Object} [sourceColumnMap] - Optional user-provided column mappings
+ * @returns {{holes: Array}} Parsed drillhole data
+ */
+export function parseDrillholesFromRows(rows, sourceColumnMap = null) {
+  const byHole = new Map();
+  for (const [idx, rawRow] of (rows || []).entries()) {
+    const row = standardizeColumns(rawRow, null, sourceColumnMap);
+
+    const holeIdRaw = row[HOLE_ID];
+    const holeId = holeIdRaw !== undefined ? `${holeIdRaw}`.trim() : '';
+    const x = row[EASTING] ?? row.x;
+    const y = row[NORTHING] ?? row.y;
+    const z = row[ELEVATION] ?? row.z;
+    const order = row.order ?? idx;
+
+    if (!holeId || x === null || x === undefined || y === null || y === undefined || z === null || z === undefined) continue;
+
+    if (!byHole.has(holeId)) byHole.set(holeId, []);
+    const md = row[DEPTH];
+    byHole.get(holeId).push({
+      ...row,
+      holeId,
+      order,
+      md,
+      x: Number(x) ?? 0,
+      y: Number(y) ?? 0,
+      z: Number(z) ?? 0,
+    });
+  }
+
+  const holes = Array.from(byHole.entries()).map(([holeId, points]) => ({
+    id: holeId,
+    points: points
+      .sort((a, b) => a.order - b.order)
+      .map((point) => ({
+        ...point,
+        x: Number(point.x) || 0,
+        y: Number(point.y) || 0,
+        z: Number(point.z) || 0,
+      })),
+  }));
+
+  return { holes };
+}
+
+/**
  * Parse drillholes CSV with desurveyed trace points
  * Expect CSV columns: hole_id, x (easting), y (northing), z (elevation), order (optional) plus any attributes per point
  * @param {File|Blob|string} file - CSV file or data
@@ -20,52 +69,7 @@ export function parseDrillholesCSV(file, sourceColumnMap = null) {
       header: true,
       dynamicTyping: true,
       skipEmptyLines: true,
-      complete: (results) => {
-        const byHole = new Map();
-        results.data.forEach((rawRow, idx) => {
-          const row = standardizeColumns(rawRow, null, sourceColumnMap);
-          
-          const holeIdRaw = row[HOLE_ID];
-          const holeId = holeIdRaw !== undefined ? `${holeIdRaw}`.trim() : '';
-          const x = row[EASTING] ?? row.x;
-          const y = row[NORTHING] ?? row.y;
-          const z = row[ELEVATION] ?? row.z;
-          const order = row.order ?? idx;
-
-          if (!holeId || x === null || x === undefined || y === null || y === undefined || z === null || z === undefined) return;
-
-          if (!byHole.has(holeId)) byHole.set(holeId, []);
-          // standardizeColumns renames the source `md` (or `measured_depth`,
-          // `survey_depth`, etc.) to the canonical `depth`.  Expose both as
-          // `md` and `depth` on the output point so consumers reading either
-          // field name (notably scene renderers that look up segment MD via
-          // `point.md`) don't see NaN.
-          const md = row[DEPTH];
-          byHole.get(holeId).push({
-            ...row,
-            holeId,
-            order,
-            md,
-            x: Number(x) ?? 0,
-            y: Number(y) ?? 0,
-            z: Number(z) ?? 0
-          });
-        });
-
-        const holes = Array.from(byHole.entries()).map(([holeId, pts]) => ({
-          id: holeId,
-          points: pts
-            .sort((a, b) => a.order - b.order)
-            .map((p) => ({
-              ...p,
-              x: Number(p.x) || 0,
-              y: Number(p.y) || 0,
-              z: Number(p.z) || 0
-            }))
-        }));
-
-        resolve({ holes });
-      },
+      complete: (results) => resolve(parseDrillholesFromRows(results.data, sourceColumnMap)),
       error: (error) => reject(withDataErrorContext('parseDrillholesCSV', error))
     });
   });

--- a/javascript/packages/baselode/src/data/geophysicsLoader.js
+++ b/javascript/packages/baselode/src/data/geophysicsLoader.js
@@ -71,6 +71,54 @@ function detectValueColumns(rows) {
 }
 
 /**
+ * Parse already-decoded geophysics rows into per-hole channel arrays.
+ *
+ * @param {Array<Object>} rawRows - Parsed geophysics row objects
+ * @param {object} [columnMap] - Optional `{ rawName: standardName }` overrides
+ * @returns {Array<{holeId: string, channels: object}>}
+ */
+export function parseGeophysicsFromRows(rawRows, columnMap = null) {
+  if (!rawRows?.length) return [];
+  const rows = rawRows.map((row) => standardizeColumns(row, null, columnMap));
+  const valueCols = detectValueColumns(rows);
+
+  const byHole = new Map();
+  for (const row of rows) {
+    const holeId = row[HOLE_ID] != null ? `${row[HOLE_ID]}`.trim() : '';
+    if (!holeId) continue;
+
+    const depth = resolveDepth(row);
+    if (depth === null || depth < 0) continue;
+
+    if (!byHole.has(holeId)) byHole.set(holeId, []);
+    byHole.get(holeId).push({ depth, row });
+  }
+
+  const holes = [];
+  for (const [holeId, samples] of byHole) {
+    samples.sort((a, b) => a.depth - b.depth);
+
+    const channels = {};
+    for (const col of valueCols) {
+      const depths = [];
+      const values = [];
+      for (const { depth, row } of samples) {
+        const value = Number(row[col]);
+        if (Number.isFinite(value) && value !== GEOPHYSICS_NULL_SENTINEL) {
+          depths.push(depth);
+          values.push(value);
+        }
+      }
+      if (depths.length >= 2) channels[col] = { depths, values };
+    }
+
+    if (Object.keys(channels).length > 0) holes.push({ holeId, channels });
+  }
+
+  return holes;
+}
+
+/**
  * Parse a geophysics point-log CSV into per-hole arrays of depths and values.
  *
  * Unlike assay intervals (from/to), geophysics logs contain one row per sample
@@ -114,54 +162,7 @@ export function parseGeophysicsCSV(csvText, columnMap = null) {
     dynamicTyping: false,
   });
 
-  const rawRows = result.data || [];
-  if (rawRows.length === 0) return [];
-
-  const rows = rawRows.map((r) => standardizeColumns(r, null, columnMap));
-
-  // Discover value columns from the full dataset
-  const valueCols = detectValueColumns(rows);
-
-  // Group rows by hole
-  const byHole = new Map();
-  for (const row of rows) {
-    const holeId = row[HOLE_ID] != null ? `${row[HOLE_ID]}`.trim() : '';
-    if (!holeId) continue;
-
-    const depth = resolveDepth(row);
-    if (depth === null || depth < 0) continue;
-
-    if (!byHole.has(holeId)) byHole.set(holeId, []);
-    byHole.get(holeId).push({ depth, row });
-  }
-
-  const holes = [];
-  for (const [holeId, samples] of byHole) {
-    // Sort by depth (ascending)
-    samples.sort((a, b) => a.depth - b.depth);
-
-    const channels = {};
-    for (const col of valueCols) {
-      const depths = [];
-      const values = [];
-      for (const { depth, row } of samples) {
-        const v = Number(row[col]);
-        if (Number.isFinite(v) && v !== GEOPHYSICS_NULL_SENTINEL) {
-          depths.push(depth);
-          values.push(v);
-        }
-      }
-      if (depths.length >= 2) {
-        channels[col] = { depths, values };
-      }
-    }
-
-    if (Object.keys(channels).length > 0) {
-      holes.push({ holeId, channels });
-    }
-  }
-
-  return holes;
+  return parseGeophysicsFromRows(result.data, columnMap);
 }
 
 /**

--- a/javascript/packages/baselode/src/data/structuralLoader.js
+++ b/javascript/packages/baselode/src/data/structuralLoader.js
@@ -154,15 +154,12 @@ export function parseStructuralIntervalsFromRows(rows, sourceColumnMap = null) {
  * @param {Object|null} sourceColumnMap - Optional column name overrides
  * @returns {{schema: 'point'|'interval', rows: Array<Object>}}
  */
-export function parseStructuralFromRows(rows, sourceColumnMap = null) {
+function parseStructuralRows(rows, sourceColumnMap = null) {
   const sourceRows = rows || [];
   const first = sourceRows.length ? normalizeRow(sourceRows[0], sourceColumnMap) : null;
   const schema = detectSchema(first ? [first] : []);
   if (!schema) {
-    throw withDataErrorContext(
-      'parseStructuralFromRows',
-      new Error("Structural rows require either 'depth' (point) or 'from'/'to' (interval) columns"),
-    );
+    throw new Error("Structural rows require either 'depth' (point) or 'from'/'to' (interval) columns");
   }
 
   const parsed = [];
@@ -174,6 +171,14 @@ export function parseStructuralFromRows(rows, sourceColumnMap = null) {
     if (value) parsed.push(value);
   }
   return { schema, rows: parsed };
+}
+
+export function parseStructuralFromRows(rows, sourceColumnMap = null) {
+  try {
+    return parseStructuralRows(rows, sourceColumnMap);
+  } catch (error) {
+    throw withDataErrorContext('parseStructuralFromRows', error);
+  }
 }
 
 /**
@@ -256,7 +261,7 @@ export function parseStructuralCSV(source, sourceColumnMap = null) {
       skipEmptyLines: true,
       complete: (results) => {
         try {
-          resolve(parseStructuralFromRows(results.data, sourceColumnMap));
+          resolve(parseStructuralRows(results.data, sourceColumnMap));
         } catch (error) {
           reject(withDataErrorContext('parseStructuralCSV', error));
         }

--- a/javascript/packages/baselode/src/data/structuralLoader.js
+++ b/javascript/packages/baselode/src/data/structuralLoader.js
@@ -49,12 +49,12 @@ function extractStructuralPoint(row) {
   if (depth === null) return null;
 
   return {
+    ...row,
     [HOLE_ID]: holeId,
     [DEPTH]: depth,
     [DIP]: toNumber(row[DIP]),
     [AZIMUTH]: toNumber(row[AZIMUTH]),
     comments: row.comments != null ? `${row.comments}` : null,
-    ...row,
   };
 }
 
@@ -71,6 +71,7 @@ function extractStructuralInterval(row) {
 
   const mid = 0.5 * (from + to);
   return {
+    ...row,
     [HOLE_ID]: holeId,
     [FROM]: from,
     [TO]: to,
@@ -79,7 +80,6 @@ function extractStructuralInterval(row) {
     [AZIMUTH]: toNumber(row[AZIMUTH]),
     classification: row.classification != null ? `${row.classification}` : null,
     comments: row.comments != null ? `${row.comments}` : null,
-    ...row,
   };
 }
 
@@ -116,6 +116,67 @@ export function validateStructuralPoints(rows) {
 }
 
 /**
+ * Parse structural point measurements from already-decoded rows.
+ *
+ * @param {Array<Object>} rows - Parsed structural row objects
+ * @param {Object|null} sourceColumnMap - Optional column name overrides
+ * @returns {Array<Object>} Structural point objects
+ */
+export function parseStructuralPointsFromRows(rows, sourceColumnMap = null) {
+  const parsed = [];
+  for (const rawRow of rows || []) {
+    const point = extractStructuralPoint(normalizeRow(rawRow, sourceColumnMap));
+    if (point) parsed.push(point);
+  }
+  return parsed;
+}
+
+/**
+ * Parse structural interval measurements from already-decoded rows.
+ *
+ * @param {Array<Object>} rows - Parsed structural row objects
+ * @param {Object|null} sourceColumnMap - Optional column name overrides
+ * @returns {Array<Object>} Structural interval objects
+ */
+export function parseStructuralIntervalsFromRows(rows, sourceColumnMap = null) {
+  const parsed = [];
+  for (const rawRow of rows || []) {
+    const interval = extractStructuralInterval(normalizeRow(rawRow, sourceColumnMap));
+    if (interval) parsed.push(interval);
+  }
+  return parsed;
+}
+
+/**
+ * Auto-detect and parse structural measurements from already-decoded rows.
+ *
+ * @param {Array<Object>} rows - Parsed structural row objects
+ * @param {Object|null} sourceColumnMap - Optional column name overrides
+ * @returns {{schema: 'point'|'interval', rows: Array<Object>}}
+ */
+export function parseStructuralFromRows(rows, sourceColumnMap = null) {
+  const sourceRows = rows || [];
+  const first = sourceRows.length ? normalizeRow(sourceRows[0], sourceColumnMap) : null;
+  const schema = detectSchema(first ? [first] : []);
+  if (!schema) {
+    throw withDataErrorContext(
+      'parseStructuralFromRows',
+      new Error("Structural rows require either 'depth' (point) or 'from'/'to' (interval) columns"),
+    );
+  }
+
+  const parsed = [];
+  for (let index = 0; index < sourceRows.length; index += 1) {
+    const row = index === 0 ? first : normalizeRow(sourceRows[index], sourceColumnMap);
+    const value = schema === 'interval'
+      ? extractStructuralInterval(row)
+      : extractStructuralPoint(row);
+    if (value) parsed.push(value);
+  }
+  return { schema, rows: parsed };
+}
+
+/**
  * Parse a structural points CSV (point schema: hole_id, depth, dip, azimuth, ...).
  *
  * @param {File|Blob|string} source - CSV file or text
@@ -128,15 +189,7 @@ export function parseStructuralPointsCSV(source, sourceColumnMap = null) {
       header: true,
       dynamicTyping: true,
       skipEmptyLines: true,
-      complete: (results) => {
-        const rows = [];
-        for (const rawRow of results.data) {
-          const row = normalizeRow(rawRow, sourceColumnMap);
-          const point = extractStructuralPoint(row);
-          if (point) rows.push(point);
-        }
-        resolve(rows);
-      },
+      complete: (results) => resolve(parseStructuralPointsFromRows(results.data, sourceColumnMap)),
       error: (error) => reject(withDataErrorContext('parseStructuralPointsCSV', error)),
     };
 
@@ -161,15 +214,7 @@ export function parseStructuralIntervalsCSV(source, sourceColumnMap = null) {
       header: true,
       dynamicTyping: true,
       skipEmptyLines: true,
-      complete: (results) => {
-        const rows = [];
-        for (const rawRow of results.data) {
-          const row = normalizeRow(rawRow, sourceColumnMap);
-          const interval = extractStructuralInterval(row);
-          if (interval) rows.push(interval);
-        }
-        resolve(rows);
-      },
+      complete: (results) => resolve(parseStructuralIntervalsFromRows(results.data, sourceColumnMap)),
       error: (error) => reject(withDataErrorContext('parseStructuralIntervalsCSV', error)),
     });
   });
@@ -210,23 +255,11 @@ export function parseStructuralCSV(source, sourceColumnMap = null) {
       dynamicTyping: true,
       skipEmptyLines: true,
       complete: (results) => {
-        const normalized = results.data.map(r => normalizeRow(r, sourceColumnMap));
-        const schema = detectSchema(normalized);
-
-        if (!schema) {
-          reject(withDataErrorContext('parseStructuralCSV',
-            new Error("Structural CSV requires either 'depth' (point) or 'from'/'to' (interval) columns")));
-          return;
+        try {
+          resolve(parseStructuralFromRows(results.data, sourceColumnMap));
+        } catch (error) {
+          reject(withDataErrorContext('parseStructuralCSV', error));
         }
-
-        const rows = [];
-        for (const row of normalized) {
-          const parsed = schema === 'interval'
-            ? extractStructuralInterval(row)
-            : extractStructuralPoint(row);
-          if (parsed) rows.push(parsed);
-        }
-        resolve({ schema, rows });
       },
       error: (error) => reject(withDataErrorContext('parseStructuralCSV', error)),
     });

--- a/javascript/packages/baselode/src/data/unifiedLoader.js
+++ b/javascript/packages/baselode/src/data/unifiedLoader.js
@@ -5,7 +5,11 @@
 import Papa from 'papaparse';
 import { standardizeColumns } from './keying.js';
 import { HOLE_ID, FROM, TO, MID, DEPTH, DIP, AZIMUTH } from './datamodel.js';
-import { parseStructuralFromRows, groupRowsByHole } from './structuralLoader.js';
+import {
+  parseStructuralCSV,
+  parseStructuralFromRows,
+  groupRowsByHole,
+} from './structuralLoader.js';
 
 function parseCsvRows(csvText) {
   return new Promise((resolve) => {
@@ -23,6 +27,32 @@ function holesFromPoints(byHole) {
     holeId,
     points: points.sort((a, b) => a[FROM] - b[FROM]),
   }));
+}
+
+function structuralHolesFromRows(rows) {
+  if (!rows.length) return [];
+  return groupRowsByHole(
+    parseStructuralFromRows(rows).rows.map(
+      (row) => ({ ...row, _source: 'structural' }),
+    ),
+  );
+}
+
+function mergeUnifiedHoles(assayHoles, structuralHoles, geologyHoles) {
+  const byId = new Map(
+    assayHoles.map((hole) => [hole.holeId, { ...hole, points: [...hole.points] }]),
+  );
+  for (const hole of [...structuralHoles, ...geologyHoles]) {
+    const id = hole.holeId;
+    if (!id) continue;
+    if (byId.has(id)) {
+      const existing = byId.get(id);
+      byId.set(id, { ...existing, points: [...existing.points, ...(hole.points || [])] });
+    } else {
+      byId.set(id, hole);
+    }
+  }
+  return { holes: Array.from(byId.values()) };
 }
 
 /**
@@ -133,29 +163,9 @@ export function parseUnifiedDatasetFromRows({
   geologyRows = [],
 } = {}) {
   const assayHoles = parseAssayHolesFromRows(assayRows);
-  const structuralHoles = structuralRows.length
-    ? groupRowsByHole(
-        parseStructuralFromRows(structuralRows).rows.map(
-          (row) => ({ ...row, _source: 'structural' }),
-        ),
-      )
-    : [];
+  const structuralHoles = structuralHolesFromRows(structuralRows);
   const geologyHoles = parseGeologyFromRows(geologyRows).holes;
-
-  const byId = new Map(
-    assayHoles.map((hole) => [hole.holeId, { ...hole, points: [...hole.points] }]),
-  );
-  for (const hole of [...structuralHoles, ...geologyHoles]) {
-    const id = hole.holeId;
-    if (!id) continue;
-    if (byId.has(id)) {
-      const existing = byId.get(id);
-      byId.set(id, { ...existing, points: [...existing.points, ...(hole.points || [])] });
-    } else {
-      byId.set(id, hole);
-    }
-  }
-  return { holes: Array.from(byId.values()) };
+  return mergeUnifiedHoles(assayHoles, structuralHoles, geologyHoles);
 }
 
 /**
@@ -191,20 +201,22 @@ export async function parseUnifiedDataset({
   structuralRows,
   geologyRows,
 } = {}) {
-  const [resolvedAssays, resolvedStructural, resolvedGeology] = await Promise.all([
+  const [assayHoles, structuralHoles, geologyHoles] = await Promise.all([
     assayRows !== undefined
-      ? Promise.resolve(assayRows)
-      : (assayCsv ? parseCsvRows(assayCsv) : Promise.resolve([])),
+      ? Promise.resolve(parseAssayHolesFromRows(assayRows))
+      : (assayCsv ? parseAssayCsvTextToHoles(assayCsv) : Promise.resolve([])),
     structuralRows !== undefined
-      ? Promise.resolve(structuralRows)
-      : (structuralCsv ? parseCsvRows(structuralCsv) : Promise.resolve([])),
+      ? Promise.resolve(structuralHolesFromRows(structuralRows))
+      : (structuralCsv
+          ? parseStructuralCSV(structuralCsv).then(({ rows }) => groupRowsByHole(
+              rows.map((row) => ({ ...row, _source: 'structural' })),
+            ))
+          : Promise.resolve([])),
     geologyRows !== undefined
-      ? Promise.resolve(geologyRows)
-      : (geologyCsv ? parseCsvRows(geologyCsv) : Promise.resolve([])),
+      ? Promise.resolve(parseGeologyFromRows(geologyRows).holes)
+      : (geologyCsv
+          ? parseGeologyCsvText(geologyCsv).then(({ holes }) => holes)
+          : Promise.resolve([])),
   ]);
-  return parseUnifiedDatasetFromRows({
-    assayRows: resolvedAssays,
-    structuralRows: resolvedStructural,
-    geologyRows: resolvedGeology,
-  });
+  return mergeUnifiedHoles(assayHoles, structuralHoles, geologyHoles);
 }

--- a/javascript/packages/baselode/src/data/unifiedLoader.js
+++ b/javascript/packages/baselode/src/data/unifiedLoader.js
@@ -5,7 +5,93 @@
 import Papa from 'papaparse';
 import { standardizeColumns } from './keying.js';
 import { HOLE_ID, FROM, TO, MID, DEPTH, DIP, AZIMUTH } from './datamodel.js';
-import { parseStructuralCSV, groupRowsByHole } from './structuralLoader.js';
+import { parseStructuralFromRows, groupRowsByHole } from './structuralLoader.js';
+
+function parseCsvRows(csvText) {
+  return new Promise((resolve) => {
+    Papa.parse(csvText, {
+      header: true,
+      dynamicTyping: true,
+      skipEmptyLines: true,
+      complete: (results) => resolve(results.data || []),
+    });
+  });
+}
+
+function holesFromPoints(byHole) {
+  return Array.from(byHole.entries()).map(([holeId, points]) => ({
+    holeId,
+    points: points.sort((a, b) => a[FROM] - b[FROM]),
+  }));
+}
+
+/**
+ * Convert already-parsed assay rows into unified hole records.
+ *
+ * @param {Array<Object>} rows - Parsed assay row objects
+ * @returns {Array<{holeId: string, points: Array<Object>}>}
+ */
+export function parseAssayHolesFromRows(rows) {
+  const byHole = new Map();
+  for (const rawRow of rows || []) {
+    const row = standardizeColumns(rawRow);
+    const holeId = row[HOLE_ID] != null ? `${row[HOLE_ID]}`.trim() : '';
+    if (!holeId) continue;
+    const from = Number(row[FROM]);
+    const to = Number(row[TO]);
+    if (!Number.isFinite(from) || !Number.isFinite(to) || to <= from) continue;
+    const mid = (from + to) / 2;
+    // These describe borehole orientation in some assay exports, not a
+    // structural measurement that should become a selectable property.
+    // eslint-disable-next-line no-unused-vars
+    const { [DIP]: _dip, [AZIMUTH]: _azimuth, ...rest } = row;
+    const point = {
+      ...rest,
+      [HOLE_ID]: holeId,
+      [FROM]: from,
+      [TO]: to,
+      [MID]: mid,
+      [DEPTH]: mid,
+      _source: 'assay',
+    };
+    if (!byHole.has(holeId)) byHole.set(holeId, []);
+    byHole.get(holeId).push(point);
+  }
+  return holesFromPoints(byHole);
+}
+
+/**
+ * Convert already-parsed geology rows into unified hole records.
+ *
+ * @param {Array<Object>} rows - Parsed geology row objects
+ * @returns {{holes: Array<{holeId: string, points: Array<Object>}>}}
+ */
+export function parseGeologyFromRows(rows) {
+  const byHole = new Map();
+  for (const rawRow of rows || []) {
+    const row = standardizeColumns(rawRow);
+    const holeId = row[HOLE_ID] != null ? `${row[HOLE_ID]}`.trim() : '';
+    if (!holeId) continue;
+    const from = Number(row[FROM]);
+    const to = Number(row[TO]);
+    if (!Number.isFinite(from) || !Number.isFinite(to) || to <= from) continue;
+    const mid = (from + to) / 2;
+    // eslint-disable-next-line no-unused-vars
+    const { [DIP]: _dip, [AZIMUTH]: _azimuth, ...rest } = row;
+    const point = {
+      ...rest,
+      [HOLE_ID]: holeId,
+      [FROM]: from,
+      [TO]: to,
+      [MID]: mid,
+      [DEPTH]: mid,
+      _source: 'geology',
+    };
+    if (!byHole.has(holeId)) byHole.set(holeId, []);
+    byHole.get(holeId).push(point);
+  }
+  return { holes: holesFromPoints(byHole) };
+}
 
 
 /**
@@ -19,47 +105,7 @@ import { parseStructuralCSV, groupRowsByHole } from './structuralLoader.js';
  * @returns {Promise<Array<{holeId: string, points: Array<Object>}>>}
  */
 export function parseAssayCsvTextToHoles(csvText) {
-  return new Promise((resolve) => {
-    Papa.parse(csvText, {
-      header: true,
-      dynamicTyping: true,
-      skipEmptyLines: true,
-      complete: (results) => {
-        const byHole = new Map();
-        for (const rawRow of results.data) {
-          const row = standardizeColumns(rawRow);
-          const holeId = row[HOLE_ID] != null ? `${row[HOLE_ID]}`.trim() : '';
-          if (!holeId) continue;
-          const from = Number(row[FROM]);
-          const to = Number(row[TO]);
-          if (!Number.isFinite(from) || !Number.isFinite(to) || to <= from) continue;
-          const mid = (from + to) / 2;
-          // Strip structural-domain columns that some assay exports (e.g. GSWA) include
-          // as per-interval hole-orientation values — these are borehole survey attributes,
-          // not structural plane measurements, and must not appear as selectable properties
-          // alongside true structural data.
-          // eslint-disable-next-line no-unused-vars
-          const { [DIP]: _dip, [AZIMUTH]: _az, ...rowWithoutStructural } = row;
-          const point = {
-            ...rowWithoutStructural,
-            [HOLE_ID]: holeId,
-            [FROM]: from,
-            [TO]: to,
-            [MID]: mid,
-            [DEPTH]: mid, // unified depth field for y-axis rendering
-            _source: 'assay',
-          };
-          if (!byHole.has(holeId)) byHole.set(holeId, []);
-          byHole.get(holeId).push(point);
-        }
-        const holes = Array.from(byHole.entries()).map(([holeId, points]) => ({
-          holeId,
-          points: points.sort((a, b) => a[FROM] - b[FROM]),
-        }));
-        resolve(holes);
-      },
-    });
-  });
+  return parseCsvRows(csvText).then(parseAssayHolesFromRows);
 }
 
 /**
@@ -69,44 +115,47 @@ export function parseAssayCsvTextToHoles(csvText) {
  * @returns {Promise<{holes: Array<{holeId: string, points: Array<Object>}>}>}
  */
 export function parseGeologyCsvText(csvText) {
-  return new Promise((resolve) => {
-    Papa.parse(csvText, {
-      header: true,
-      dynamicTyping: true,
-      skipEmptyLines: true,
-      complete: (results) => {
-        const byHole = new Map();
-        for (const rawRow of results.data) {
-          const row = standardizeColumns(rawRow);
-          const holeId = (row[HOLE_ID] ?? '').toString().trim();
-          if (!holeId) continue;
-          const from = Number(row[FROM]);
-          const to = Number(row[TO]);
-          if (!Number.isFinite(from) || !Number.isFinite(to) || to <= from) continue;
-          const mid = (from + to) / 2;
-          // eslint-disable-next-line no-unused-vars
-          const { [DIP]: _dip, [AZIMUTH]: _az, ...rest } = row;
-          const point = {
-            ...rest,
-            [HOLE_ID]: holeId,
-            [FROM]: from,
-            [TO]: to,
-            [MID]: mid,
-            [DEPTH]: mid,
-            _source: 'geology',
-          };
-          if (!byHole.has(holeId)) byHole.set(holeId, []);
-          byHole.get(holeId).push(point);
-        }
-        resolve({
-          holes: Array.from(byHole.entries()).map(([holeId, points]) => ({
-            holeId,
-            points: points.sort((a, b) => a[FROM] - b[FROM]),
-          })),
-        });
-      },
-    });
-  });
+  return parseCsvRows(csvText).then(parseGeologyFromRows);
+}
+
+/**
+ * Build a unified drillhole dataset directly from parsed row objects.
+ *
+ * @param {Object} options
+ * @param {Array<Object>} [options.assayRows]
+ * @param {Array<Object>} [options.structuralRows]
+ * @param {Array<Object>} [options.geologyRows]
+ * @returns {{holes: Array<{holeId: string, points: Array<Object>}>}}
+ */
+export function parseUnifiedDatasetFromRows({
+  assayRows = [],
+  structuralRows = [],
+  geologyRows = [],
+} = {}) {
+  const assayHoles = parseAssayHolesFromRows(assayRows);
+  const structuralHoles = structuralRows.length
+    ? groupRowsByHole(
+        parseStructuralFromRows(structuralRows).rows.map(
+          (row) => ({ ...row, _source: 'structural' }),
+        ),
+      )
+    : [];
+  const geologyHoles = parseGeologyFromRows(geologyRows).holes;
+
+  const byId = new Map(
+    assayHoles.map((hole) => [hole.holeId, { ...hole, points: [...hole.points] }]),
+  );
+  for (const hole of [...structuralHoles, ...geologyHoles]) {
+    const id = hole.holeId;
+    if (!id) continue;
+    if (byId.has(id)) {
+      const existing = byId.get(id);
+      byId.set(id, { ...existing, points: [...existing.points, ...(hole.points || [])] });
+    } else {
+      byId.set(id, hole);
+    }
+  }
+  return { holes: Array.from(byId.values()) };
 }
 
 /**
@@ -129,31 +178,33 @@ export function parseGeologyCsvText(csvText) {
  * @param {string} [options.assayCsv]      - Assay CSV text
  * @param {string} [options.structuralCsv] - Structural CSV text
  * @param {string} [options.geologyCsv]    - Geology CSV text
+ * @param {Array<Object>} [options.assayRows]      - Parsed assay rows (takes precedence)
+ * @param {Array<Object>} [options.structuralRows] - Parsed structural rows (takes precedence)
+ * @param {Array<Object>} [options.geologyRows]    - Parsed geology rows (takes precedence)
  * @returns {Promise<{holes: Array<{holeId: string, points: Array<Object>}>}>}
  */
-export async function parseUnifiedDataset({ assayCsv, structuralCsv, geologyCsv } = {}) {
-  const [assayHoles, structuralHoles, geologyHoles] = await Promise.all([
-    assayCsv ? parseAssayCsvTextToHoles(assayCsv) : Promise.resolve([]),
-    structuralCsv
-      ? parseStructuralCSV(structuralCsv).then(({ rows }) =>
-          groupRowsByHole(rows.map((r) => ({ ...r, _source: 'structural' })))
-        )
-      : Promise.resolve([]),
-    geologyCsv ? parseGeologyCsvText(geologyCsv).then(({ holes }) => holes) : Promise.resolve([]),
+export async function parseUnifiedDataset({
+  assayCsv,
+  structuralCsv,
+  geologyCsv,
+  assayRows,
+  structuralRows,
+  geologyRows,
+} = {}) {
+  const [resolvedAssays, resolvedStructural, resolvedGeology] = await Promise.all([
+    assayRows !== undefined
+      ? Promise.resolve(assayRows)
+      : (assayCsv ? parseCsvRows(assayCsv) : Promise.resolve([])),
+    structuralRows !== undefined
+      ? Promise.resolve(structuralRows)
+      : (structuralCsv ? parseCsvRows(structuralCsv) : Promise.resolve([])),
+    geologyRows !== undefined
+      ? Promise.resolve(geologyRows)
+      : (geologyCsv ? parseCsvRows(geologyCsv) : Promise.resolve([])),
   ]);
-
-  // Merge holes from all sources by holeId
-  const byId = new Map(assayHoles.map((h) => [h.holeId, { ...h, points: [...h.points] }]));
-  for (const sh of [...structuralHoles, ...geologyHoles]) {
-    const id = sh.holeId;
-    if (!id) continue;
-    if (byId.has(id)) {
-      const existing = byId.get(id);
-      byId.set(id, { ...existing, points: [...existing.points, ...(sh.points || [])] });
-    } else {
-      byId.set(id, sh);
-    }
-  }
-
-  return { holes: Array.from(byId.values()) };
+  return parseUnifiedDatasetFromRows({
+    assayRows: resolvedAssays,
+    structuralRows: resolvedStructural,
+    geologyRows: resolvedGeology,
+  });
 }

--- a/javascript/packages/baselode/src/index.js
+++ b/javascript/packages/baselode/src/index.js
@@ -75,9 +75,13 @@ export {
 
 export {
   parseAssayHoleIds,
+  parseAssayHoleIdsFromRows,
   parseAssayHoleIdsWithAssays,
+  parseAssayHoleIdsWithAssaysFromRows,
   parseAssayHole,
-  parseAssaysCSV
+  parseAssayHoleFromRows,
+  parseAssaysCSV,
+  parseAssaysFromRows
 } from './data/assayLoader.js';
 
 export {
@@ -102,11 +106,13 @@ export {
   loadAssayMetadata,
   loadAssayHole,
   buildAssayState,
-  loadAssayFile
+  loadAssayFile,
+  loadAssayFromRows
 } from './data/assayDataLoader.js';
 
 export {
   parseSurveyCSV,
+  parseSurveyFromRows,
   desurveyTraces
 } from './data/desurvey.js';
 
@@ -120,7 +126,8 @@ export {
 } from './data/desurveyMethods.js';
 
 export {
-  parseDrillholesCSV
+  parseDrillholesCSV,
+  parseDrillholesFromRows
 } from './data/drillholeLoader.js';
 
 export {
@@ -137,6 +144,7 @@ export {
 
 export {
   parseBlockModelCSV,
+  parseBlockModelFromRows,
   normalizeBlockRow,
   loadBlockModelMetadata,
   calculatePropertyStats,
@@ -148,16 +156,22 @@ export {
 
 export {
   parseStructuralPointsCSV,
+  parseStructuralPointsFromRows,
   parseStructuralIntervalsCSV,
+  parseStructuralIntervalsFromRows,
   parseStructuralCSV,
+  parseStructuralFromRows,
   validateStructuralPoints,
   groupRowsByHole
 } from './data/structuralLoader.js';
 
 export {
   parseAssayCsvTextToHoles,
+  parseAssayHolesFromRows,
   parseGeologyCsvText,
-  parseUnifiedDataset
+  parseGeologyFromRows,
+  parseUnifiedDataset,
+  parseUnifiedDatasetFromRows
 } from './data/unifiedLoader.js';
 
 export {
@@ -222,6 +236,7 @@ export { DrillholeSet } from './data/drillholeSet.js';
 
 export {
   parseGeophysicsCSV,
+  parseGeophysicsFromRows,
   geophysicsToStripLogs,
 } from './data/geophysicsLoader.js';
 

--- a/javascript/packages/baselode/tests/rowObjectLoaders.test.js
+++ b/javascript/packages/baselode/tests/rowObjectLoaders.test.js
@@ -149,4 +149,13 @@ describe('row-object loader entry points', () => {
     expect(result.holes).toHaveLength(1);
     expect(result.holes[0].holeId).toBe('H1');
   });
+
+  it('preserves structural CSV validation and clean error context', async () => {
+    await expect(parseStructuralCSV('hole_id,depth,dip,azimuth\n')).rejects.toThrow(
+      "parseStructuralCSV: Structural rows require either 'depth' (point) or 'from'/'to' (interval) columns",
+    );
+    await expect(parseUnifiedDataset({
+      structuralCsv: 'hole_id,depth,dip,azimuth\n',
+    })).rejects.toThrow('parseStructuralCSV: Structural rows require');
+  });
 });

--- a/javascript/packages/baselode/tests/rowObjectLoaders.test.js
+++ b/javascript/packages/baselode/tests/rowObjectLoaders.test.js
@@ -1,0 +1,152 @@
+/*
+ * Copyright (C) 2026 Darkmine Pty Ltd
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  parseAssayHoleFromRows,
+  parseAssayHoleIdsFromRows,
+  parseAssayHoleIdsWithAssaysFromRows,
+  parseAssaysCSV,
+  parseAssaysFromRows,
+} from '../src/data/assayLoader.js';
+import { loadAssayFromRows } from '../src/data/assayDataLoader.js';
+import {
+  parseAssayHolesFromRows,
+  parseAssayCsvTextToHoles,
+  parseGeologyCsvText,
+  parseGeologyFromRows,
+  parseUnifiedDataset,
+  parseUnifiedDatasetFromRows,
+} from '../src/data/unifiedLoader.js';
+import {
+  parseBlockModelCSV,
+  parseBlockModelFromRows,
+} from '../src/data/blockModelLoader.js';
+import {
+  parseDrillholesCSV,
+  parseDrillholesFromRows,
+} from '../src/data/drillholeLoader.js';
+import {
+  parseGeophysicsCSV,
+  parseGeophysicsFromRows,
+} from '../src/data/geophysicsLoader.js';
+import {
+  parseStructuralCSV,
+  parseStructuralFromRows,
+} from '../src/data/structuralLoader.js';
+import {
+  parseSurveyCSV,
+  parseSurveyFromRows,
+} from '../src/data/desurvey.js';
+
+describe('row-object loader entry points', () => {
+  it('matches the streaming assay CSV APIs', async () => {
+    const rows = [
+      { hole_id: 'H1', from: 10, to: 20, au_ppm: 1.5 },
+      { hole_id: 'H1', from: 0, to: 10, au_ppm: 0.5 },
+      { hole_id: 'H2', from: 0, to: 5, au_ppm: null },
+    ];
+    const csv = [
+      'hole_id,from,to,au_ppm',
+      'H1,10,20,1.5',
+      'H1,0,10,0.5',
+      'H2,0,5,',
+    ].join('\n');
+
+    expect(parseAssaysFromRows(rows)).toEqual(await parseAssaysCSV(csv));
+    expect(parseAssayHoleIdsFromRows(rows)).toEqual(['H1', 'H2']);
+    expect(parseAssayHoleIdsWithAssaysFromRows(rows)).toEqual([{ holeId: 'H1' }]);
+    expect(parseAssayHoleFromRows(rows, 'H1')).toEqual(
+      parseAssaysFromRows(rows).holes[0],
+    );
+    expect(loadAssayFromRows(rows).holes).toEqual(parseAssaysFromRows(rows).holes);
+  });
+
+  it('matches survey, drillhole, block-model, and geophysics CSV adapters', async () => {
+    const surveyRows = [
+      { hole_id: 'H1', depth: 0, dip: -60, azimuth: 120 },
+      { hole_id: 'H1', depth: 20, dip: -62, azimuth: 125 },
+    ];
+    const surveyCsv = 'hole_id,depth,dip,azimuth\nH1,0,-60,120\nH1,20,-62,125';
+    expect(parseSurveyFromRows(surveyRows)).toEqual(await parseSurveyCSV(surveyCsv));
+
+    const drillholeRows = [
+      { hole_id: 'H1', easting: 1, northing: 2, elevation: 3, md: 0 },
+      { hole_id: 'H1', easting: 4, northing: 5, elevation: 6, md: 10 },
+    ];
+    const drillholeCsv = 'hole_id,easting,northing,elevation,md\nH1,1,2,3,0\nH1,4,5,6,10';
+    expect(parseDrillholesFromRows(drillholeRows)).toEqual(
+      await parseDrillholesCSV(drillholeCsv),
+    );
+
+    const blockRows = [
+      { center_x: 1, center_y: 2, center_z: 3, size_x: 4, size_y: 5, size_z: 6, au: 2.5 },
+    ];
+    const blockCsv = 'center_x,center_y,center_z,size_x,size_y,size_z,au\n1,2,3,4,5,6,2.5';
+    expect(parseBlockModelFromRows(blockRows)).toEqual(await parseBlockModelCSV(blockCsv));
+
+    const geophysicsRows = [
+      { hole_id: 'H1', depth: 0, gamma: 10 },
+      { hole_id: 'H1', depth: 1, gamma: 20 },
+    ];
+    const geophysicsCsv = 'hole_id,depth,gamma\nH1,0,10\nH1,1,20';
+    expect(parseGeophysicsFromRows(geophysicsRows)).toEqual(
+      parseGeophysicsCSV(geophysicsCsv),
+    );
+  });
+
+  it('matches structural and unified CSV adapters', async () => {
+    const assayRows = [{ hole_id: 'H1', from: 0, to: 10, au_ppm: 1.2 }];
+    const structuralRows = [{ hole_id: 'H1', depth: 5, dip: 45, azimuth: 180 }];
+    const geologyRows = [{ hole_id: 'H1', from: 0, to: 10, geology_code: 'BIF' }];
+
+    expect(parseStructuralFromRows(structuralRows)).toEqual(
+      await parseStructuralCSV('hole_id,depth,dip,azimuth\nH1,5,45,180'),
+    );
+    expect(parseAssayHolesFromRows(assayRows)).toEqual(
+      await parseAssayCsvTextToHoles('hole_id,from,to,au_ppm\nH1,0,10,1.2'),
+    );
+    expect(parseGeologyFromRows(geologyRows)).toEqual(
+      await parseGeologyCsvText('hole_id,from,to,geology_code\nH1,0,10,BIF'),
+    );
+
+    expect(parseUnifiedDatasetFromRows({ assayRows, structuralRows, geologyRows })).toEqual(
+      await parseUnifiedDataset({
+        assayCsv: 'hole_id,from,to,au_ppm\nH1,0,10,1.2',
+        structuralCsv: 'hole_id,depth,dip,azimuth\nH1,5,45,180',
+        geologyCsv: 'hole_id,from,to,geology_code\nH1,0,10,BIF',
+      }),
+    );
+  });
+
+  it('preserves typed extra values and does not mutate source rows', () => {
+    const observedAt = new Date('2026-08-15T00:00:00Z');
+    const assayRows = [{
+      hole_id: 'H1',
+      from: 0,
+      to: 10,
+      source_record_id: 9007199254740993n,
+      observed_at: observedAt,
+    }];
+    const original = { ...assayRows[0] };
+
+    const { holes } = parseUnifiedDatasetFromRows({ assayRows });
+    const point = holes[0].points[0];
+
+    expect(point.source_record_id).toBe(9007199254740993n);
+    expect(point.observed_at).toBe(observedAt);
+    expect(assayRows[0]).toEqual(original);
+  });
+
+  it('lets row sources take precedence without parsing fallback CSV', async () => {
+    const result = await parseUnifiedDataset({
+      assayRows: [{ hole_id: 'H1', from: 0, to: 1, au_ppm: 2 }],
+      assayCsv: 'not,a,valid,assay',
+    });
+
+    expect(result.holes).toHaveLength(1);
+    expect(result.holes[0].holeId).toBe('H1');
+  });
+});

--- a/test/data/parity_contract.json
+++ b/test/data/parity_contract.json
@@ -120,7 +120,22 @@
         "joinAssaysToTraces",
         "filterByProject",
         "coerceNumeric",
-        "assembleDataset"
+        "assembleDataset",
+        "parseAssayHoleIdsFromRows",
+        "parseAssayHoleIdsWithAssaysFromRows",
+        "parseAssayHoleFromRows",
+        "parseAssaysFromRows",
+        "loadAssayFromRows",
+        "parseSurveyFromRows",
+        "parseDrillholesFromRows",
+        "parseBlockModelFromRows",
+        "parseStructuralPointsFromRows",
+        "parseStructuralIntervalsFromRows",
+        "parseStructuralFromRows",
+        "parseAssayHolesFromRows",
+        "parseGeologyFromRows",
+        "parseUnifiedDatasetFromRows",
+        "parseGeophysicsFromRows"
       ],
       "pythonSymbols": [
         ["baselode.drill.data", "DEFAULT_COLUMN_MAP"],


### PR DESCRIPTION
## Summary
- publish synchronous row-object entry points for specialized JavaScript loaders
- keep existing CSV APIs as compatible adapters
- document and test direct structured-row loading

## Ticket
TRK-268

## Test plan
- npm run verify: 41 files, 687 tests, build, types, package checks
- .venv/bin/python -m pytest test -q: 487 passed

## Risk
Low-to-medium loader contract refactor. Existing CSV behavior is covered by parity tests; no new runtime dependencies.

## Reviewer
Claude Sonnet 5: clean final review