### PR TITLE
TRK-369 Add canonical CSV and Parquet export layer

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -24,6 +24,29 @@ import baselode.drill.data
 gdf = baselode.drill.data.load_collars(COLLAR_CSV)
 ```
 
+### Export canonical projects
+
+Use `baselode.export` to normalize serialization-sensitive values once and
+atomically write matching CSV/Parquet tables plus a manifest:
+
+```python
+import baselode.export
+
+manifest = baselode.export.write_project(
+    {
+        "collars": collars,
+        "survey": survey,
+        "assays": assays,
+    },
+    "output/my-project",
+)
+```
+
+Known canonical identifiers such as `hole_id`, `sample_id`, and `project_id`
+are exported as nullable strings. Mixed object columns are string-normalized,
+nested values are JSON-encoded, and nulls remain null. Source-specific joins,
+filtering, and output policy belong in the calling adaptor or workflow.
+
 ---
 
 ## Included in 0.1.0

--- a/python/src/baselode/export.py
+++ b/python/src/baselode/export.py
@@ -101,6 +101,13 @@ def _normalize_identifier_value(value):
     value = _normalize_object_value(value)
     if value is None:
         return None
+    if (
+        isinstance(value, numbers.Real)
+        and not isinstance(value, (bool, np.bool_))
+        and np.isfinite(value)
+        and float(value).is_integer()
+    ):
+        return str(int(value))
     return str(value)
 
 
@@ -129,7 +136,8 @@ def normalize_table(table, identifier_columns=None):
     """Normalize a DataFrame for consistent CSV and Parquet serialization.
 
     Known canonical identifier columns, plus any caller-declared identifier
-    columns, are stored as nullable strings. Dicts, lists, tuples, sets, and
+    columns, are stored as nullable strings. Integer-valued numeric identifiers
+    omit pandas float-upcast suffixes such as ``.0``. Dicts, lists, tuples, sets, and
     arrays in object columns become deterministic JSON strings. Other object
     columns containing incompatible scalar types become nullable strings.
     Numeric columns retain their numeric dtype and null values remain null.

--- a/python/src/baselode/export.py
+++ b/python/src/baselode/export.py
@@ -1,0 +1,383 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Portable exports for canonical Baselode tables.
+
+The functions in this module keep source-specific transformation policy out of
+the library. They normalize serialization-sensitive values, then write generic
+CSV/Parquet tables and a small project manifest.
+"""
+
+import datetime
+import decimal
+import json
+import numbers
+import os
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pyarrow
+import pyarrow.parquet
+
+import baselode.datamodel
+
+
+__all__ = [
+    "DEFAULT_IDENTIFIER_COLUMNS",
+    "SUPPORTED_FORMATS",
+    "normalize_table",
+    "write_table",
+    "write_table_pair",
+    "write_project",
+]
+
+
+DEFAULT_IDENTIFIER_COLUMNS = frozenset({
+    baselode.datamodel.HOLE_ID,
+    baselode.datamodel.COLLAR_ID,
+    baselode.datamodel.DATASOURCE_HOLE_ID,
+    baselode.datamodel.SURFACE_SAMPLE_ID,
+    baselode.datamodel.DATASOURCE_SURFACE_SAMPLE_ID,
+    baselode.datamodel.SAMPLE_ID,
+    baselode.datamodel.DATASOURCE_SAMPLE_ID,
+    baselode.datamodel.PROJECT_ID,
+    baselode.datamodel.REPORT_NUMBER,
+})
+
+SUPPORTED_FORMATS = frozenset({"csv", "parquet"})
+
+
+def _is_missing_scalar(value):
+    if value is None or value is pd.NA or value is pd.NaT:
+        return True
+    try:
+        result = pd.isna(value)
+    except (TypeError, ValueError):
+        return False
+    return isinstance(result, (bool, np.bool_)) and bool(result)
+
+
+def _json_compatible(value):
+    if isinstance(value, dict):
+        return {str(key): _json_compatible(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_compatible(item) for item in value]
+    if isinstance(value, np.ndarray):
+        return [_json_compatible(item) for item in value.tolist()]
+    if isinstance(value, set):
+        return [_json_compatible(item) for item in sorted(value, key=repr)]
+    if _is_missing_scalar(value):
+        return None
+    if isinstance(value, numbers.Real) and not np.isfinite(value):
+        return None
+    if isinstance(value, np.generic):
+        return _json_compatible(value.item())
+    if isinstance(value, (pd.Timestamp, pd.Timedelta)):
+        return value.isoformat()
+    if isinstance(value, (datetime.datetime, datetime.date, datetime.time)):
+        return value.isoformat()
+    if isinstance(value, decimal.Decimal):
+        return str(value)
+    if isinstance(value, Path):
+        return str(value)
+    return value
+
+
+def _normalize_object_value(value):
+    if isinstance(value, (dict, list, tuple, set, np.ndarray)):
+        return json.dumps(
+            _json_compatible(value),
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+    if _is_missing_scalar(value):
+        return None
+    return value
+
+
+def _normalize_identifier_value(value):
+    value = _normalize_object_value(value)
+    if value is None:
+        return None
+    return str(value)
+
+
+def _identifier_columns(identifier_columns):
+    if identifier_columns is None:
+        return DEFAULT_IDENTIFIER_COLUMNS
+    if isinstance(identifier_columns, str):
+        identifier_columns = [identifier_columns]
+    return DEFAULT_IDENTIFIER_COLUMNS.union(identifier_columns)
+
+
+def _is_mixed_object_series(series):
+    value_types = {type(value) for value in series if value is not None}
+    if not value_types:
+        return False
+    if value_types == {str}:
+        return True
+    if len(value_types) == 1:
+        return False
+    if all(issubclass(value_type, numbers.Number) for value_type in value_types):
+        return bool in value_types
+    return True
+
+
+def normalize_table(table, identifier_columns=None):
+    """Normalize a DataFrame for consistent CSV and Parquet serialization.
+
+    Known canonical identifier columns, plus any caller-declared identifier
+    columns, are stored as nullable strings. Dicts, lists, tuples, sets, and
+    arrays in object columns become deterministic JSON strings. Other object
+    columns containing incompatible scalar types become nullable strings.
+    Numeric columns retain their numeric dtype and null values remain null.
+
+    Parameters
+    ----------
+    table : pd.DataFrame
+        Canonical or derived table to normalize.
+    identifier_columns : iterable of str or str, optional
+        Additional columns that carry identifiers and must be strings.
+
+    Returns
+    -------
+    pd.DataFrame
+        A normalized copy. The input is never modified.
+    """
+    if not isinstance(table, pd.DataFrame):
+        raise TypeError("table must be a pandas DataFrame")
+
+    normalized = table.copy()
+    identifiers = _identifier_columns(identifier_columns)
+    for column in normalized.columns:
+        if column in identifiers:
+            normalized[column] = (
+                normalized[column].map(_normalize_identifier_value).astype("string")
+            )
+            continue
+        if not pd.api.types.is_object_dtype(normalized[column].dtype):
+            continue
+        normalized[column] = normalized[column].map(_normalize_object_value)
+        if _is_mixed_object_series(normalized[column]):
+            normalized[column] = (
+                normalized[column].map(_normalize_identifier_value).astype("string")
+            )
+    return normalized
+
+
+def _validate_table_name(name):
+    if (
+        not isinstance(name, str)
+        or not name
+        or Path(name).name != name
+        or name in {".", ".."}
+    ):
+        raise ValueError("table names must be non-empty filenames without directory components")
+
+
+def _normalize_formats(formats):
+    if isinstance(formats, str):
+        formats = [formats]
+    normalized = tuple(dict.fromkeys(str(value).lower().lstrip(".") for value in formats))
+    unsupported = set(normalized).difference(SUPPORTED_FORMATS)
+    if not normalized or unsupported:
+        supported = ", ".join(sorted(SUPPORTED_FORMATS))
+        raise ValueError(f"formats must contain one or more of: {supported}")
+    return normalized
+
+
+def _atomic_write(target, writer):
+    target = Path(target)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        dir=target.parent,
+        prefix=f".{target.name}.",
+        suffix=".tmp",
+    )
+    os.close(descriptor)
+    temporary_path = Path(temporary_name)
+    try:
+        writer(temporary_path)
+        mode = target.stat().st_mode & 0o777 if target.exists() else 0o644
+        os.chmod(temporary_path, mode)
+        os.replace(temporary_path, target)
+    finally:
+        temporary_path.unlink(missing_ok=True)
+    return target
+
+
+def _write_csv(table, path):
+    table.to_csv(path, index=False, lineterminator="\n")
+
+
+def _write_parquet(arrow_table, path, compression):
+    pyarrow.parquet.write_table(arrow_table, path, compression=compression)
+
+
+def _prepare_table(table, identifier_columns, needs_parquet):
+    normalized = normalize_table(table, identifier_columns=identifier_columns)
+    arrow_table = None
+    if needs_parquet:
+        arrow_table = pyarrow.Table.from_pandas(normalized, preserve_index=False)
+    return normalized, arrow_table
+
+
+def _write_prepared_table(normalized, arrow_table, target, file_format, compression):
+    if file_format == "csv":
+        return _atomic_write(target, lambda path: _write_csv(normalized, path))
+    return _atomic_write(
+        target,
+        lambda path: _write_parquet(arrow_table, path, compression),
+    )
+
+
+def write_table(table, path, identifier_columns=None, compression="snappy"):
+    """Atomically write one normalized CSV or Parquet table.
+
+    Parameters
+    ----------
+    table : pd.DataFrame
+        Table to normalize and write.
+    path : str or pathlib.Path
+        Target ending in ``.csv`` or ``.parquet``.
+    identifier_columns : iterable of str or str, optional
+        Additional identifier columns to serialize as strings.
+    compression : str, optional
+        PyArrow Parquet compression codec. Defaults to ``snappy``.
+
+    Returns
+    -------
+    pathlib.Path
+        The written target path.
+    """
+    target = Path(path)
+    file_format = target.suffix.lower().lstrip(".")
+    if file_format not in SUPPORTED_FORMATS:
+        raise ValueError("path must end in .csv or .parquet")
+    normalized, arrow_table = _prepare_table(
+        table,
+        identifier_columns,
+        needs_parquet=file_format == "parquet",
+    )
+    return _write_prepared_table(normalized, arrow_table, target, file_format, compression)
+
+
+def write_table_pair(table, output_dir, name, identifier_columns=None, compression="snappy"):
+    """Write atomic CSV and Parquet files from one normalized table.
+
+    Parameters
+    ----------
+    table : pd.DataFrame
+        Table to normalize and write.
+    output_dir : str or pathlib.Path
+        Destination directory.
+    name : str
+        Filename stem without directory components.
+    identifier_columns : iterable of str or str, optional
+        Additional identifier columns to serialize as strings.
+    compression : str, optional
+        PyArrow Parquet compression codec. Defaults to ``snappy``.
+
+    Returns
+    -------
+    dict
+        Mapping of ``csv`` and ``parquet`` to written paths.
+    """
+    _validate_table_name(name)
+    normalized, arrow_table = _prepare_table(table, identifier_columns, needs_parquet=True)
+    output_dir = Path(output_dir)
+    paths = {}
+    for file_format in ("csv", "parquet"):
+        target = output_dir / f"{name}.{file_format}"
+        paths[file_format] = _write_prepared_table(
+            normalized,
+            arrow_table,
+            target,
+            file_format,
+            compression,
+        )
+    return paths
+
+
+def write_project(
+    tables,
+    output_dir,
+    formats=("csv", "parquet"),
+    identifier_columns=None,
+    compression="snappy",
+    manifest_name="baselode_manifest.json",
+    metadata=None,
+):
+    """Write canonical tables and a generic project manifest.
+
+    All tables are normalized and, when requested, converted to Arrow before
+    any output is written. Individual files use atomic replacement. The
+    manifest is serialized during preflight and replaced only after every
+    listed file is emitted successfully.
+
+    Parameters
+    ----------
+    tables : mapping of str to pd.DataFrame
+        Table names and values to export.
+    output_dir : str or pathlib.Path
+        Destination directory.
+    formats : iterable of str or str, optional
+        Any of ``csv`` and ``parquet``. Both are written by default.
+    identifier_columns : iterable of str or str, optional
+        Additional identifier columns to serialize as strings in every table.
+    compression : str, optional
+        PyArrow Parquet compression codec. Defaults to ``snappy``.
+    manifest_name : str, optional
+        Manifest filename without directory components.
+    metadata : dict, optional
+        JSON-compatible caller metadata to include unchanged.
+
+    Returns
+    -------
+    dict
+        The manifest that was written.
+    """
+    if not hasattr(tables, "items"):
+        raise TypeError("tables must be a mapping of names to DataFrames")
+    _validate_table_name(manifest_name)
+    formats = _normalize_formats(formats)
+    needs_parquet = "parquet" in formats
+
+    prepared = {}
+    manifest = {"format_version": 1, "tables": {}}
+    if metadata is not None:
+        manifest["metadata"] = metadata
+    for name, table in tables.items():
+        _validate_table_name(name)
+        normalized, arrow_table = _prepare_table(table, identifier_columns, needs_parquet)
+        prepared[name] = (normalized, arrow_table)
+        manifest["tables"][name] = {
+            "rows": len(normalized),
+            "columns": [str(column) for column in normalized.columns],
+            "files": {file_format: f"{name}.{file_format}" for file_format in formats},
+        }
+
+    manifest = _json_compatible(manifest)
+    manifest_text = json.dumps(
+        manifest,
+        ensure_ascii=False,
+        indent=2,
+        sort_keys=True,
+    ) + "\n"
+    output_dir = Path(output_dir)
+    for name, (normalized, arrow_table) in prepared.items():
+        for file_format in formats:
+            _write_prepared_table(
+                normalized,
+                arrow_table,
+                output_dir / f"{name}.{file_format}",
+                file_format,
+                compression,
+            )
+    _atomic_write(
+        output_dir / manifest_name,
+        lambda path: path.write_text(manifest_text, encoding="utf-8"),
+    )
+    return manifest

--- a/test/test_export.py
+++ b/test/test_export.py
@@ -72,11 +72,20 @@ def test_write_table_failure_does_not_replace_existing_target(tmp_path, monkeypa
 
 
 def test_normalize_table_stringifies_caller_declared_identifier():
-    source = pd.DataFrame({"external_id": pd.Series([101, 102, None], dtype=object)})
+    source = pd.DataFrame({"external_id": [101, 102, None]})
 
     normalized = baselode.export.normalize_table(source, identifier_columns="external_id")
 
     assert normalized["external_id"].tolist() == ["101", "102", pd.NA]
+
+
+def test_normalize_table_removes_float_upcast_suffix_from_canonical_identifier():
+    source = pd.DataFrame({"hole_id": [101, 102, None]})
+
+    normalized = baselode.export.normalize_table(source)
+
+    assert source["hole_id"].dtype == "float64"
+    assert normalized["hole_id"].tolist() == ["101", "102", pd.NA]
 
 
 def test_write_table_pair_normalizes_only_once(tmp_path, monkeypatch):

--- a/test/test_export.py
+++ b/test/test_export.py
@@ -1,0 +1,144 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import json
+
+import pandas as pd
+import pandas.testing
+import pyarrow
+import pytest
+
+import baselode.export
+
+
+def _mixed_table():
+    return pd.DataFrame({
+        "hole_id": [101, "A-2", None],
+        "source_value": [1, "2", None],
+        "grade": [1.5, None, 3.25],
+        "extra": [{"b": 2, "a": [1, None]}, ["x", 2], None],
+    })
+
+
+def test_normalize_table_preserves_input_and_serializes_sensitive_values():
+    source = _mixed_table()
+    original = source.copy(deep=True)
+
+    normalized = baselode.export.normalize_table(source)
+
+    assert normalized["hole_id"].tolist() == ["101", "A-2", pd.NA]
+    assert normalized["source_value"].tolist() == ["1", "2", pd.NA]
+    assert normalized["extra"].tolist() == [
+        '{"a":[1,null],"b":2}',
+        '["x",2]',
+        pd.NA,
+    ]
+    assert normalized.loc[0, "grade"] == 1.5
+    assert pd.isna(normalized.loc[1, "grade"])
+    pandas.testing.assert_frame_equal(source, original)
+
+
+def test_write_table_round_trips_csv_and_parquet(tmp_path):
+    source = _mixed_table()
+
+    csv_path = baselode.export.write_table(source, tmp_path / "collars.csv")
+    parquet_path = baselode.export.write_table(source, tmp_path / "collars.parquet")
+
+    csv = pd.read_csv(csv_path, dtype={"hole_id": "string", "source_value": "string"})
+    parquet = pd.read_parquet(parquet_path)
+    assert len(csv) == len(source)
+    assert len(parquet) == len(source)
+    assert parquet["hole_id"].tolist()[:2] == ["101", "A-2"]
+    assert parquet["source_value"].tolist()[:2] == ["1", "2"]
+    assert pd.isna(parquet.loc[2, "hole_id"])
+    assert pd.isna(parquet.loc[2, "source_value"])
+    assert parquet.loc[0, "extra"] == '{"a":[1,null],"b":2}'
+
+
+def test_write_table_failure_does_not_replace_existing_target(tmp_path, monkeypatch):
+    target = tmp_path / "collars.csv"
+    target.write_text("original\n", encoding="utf-8")
+
+    def fail_after_partial_write(table, path):
+        path.write_text("partial\n", encoding="utf-8")
+        raise RuntimeError("simulated writer failure")
+
+    monkeypatch.setattr(baselode.export, "_write_csv", fail_after_partial_write)
+
+    with pytest.raises(RuntimeError, match="simulated writer failure"):
+        baselode.export.write_table(_mixed_table(), target)
+
+    assert target.read_text(encoding="utf-8") == "original\n"
+    assert not list(tmp_path.glob(".collars.csv.*.tmp"))
+
+
+def test_normalize_table_stringifies_caller_declared_identifier():
+    source = pd.DataFrame({"external_id": pd.Series([101, 102, None], dtype=object)})
+
+    normalized = baselode.export.normalize_table(source, identifier_columns="external_id")
+
+    assert normalized["external_id"].tolist() == ["101", "102", pd.NA]
+
+
+def test_write_table_pair_normalizes_only_once(tmp_path, monkeypatch):
+    original = baselode.export.normalize_table
+    calls = []
+
+    def recording_normalize(table, identifier_columns=None):
+        calls.append(table)
+        return original(table, identifier_columns=identifier_columns)
+
+    monkeypatch.setattr(baselode.export, "normalize_table", recording_normalize)
+
+    paths = baselode.export.write_table_pair(_mixed_table(), tmp_path, "collars")
+
+    assert len(calls) == 1
+    assert paths == {
+        "csv": tmp_path / "collars.csv",
+        "parquet": tmp_path / "collars.parquet",
+    }
+
+
+def test_write_project_preflights_all_tables_before_creating_output(tmp_path):
+    output_dir = tmp_path / "project"
+    tables = {
+        "collars": _mixed_table(),
+        "unsupported": pd.DataFrame({"value": [object()]}),
+    }
+
+    with pytest.raises((pyarrow.ArrowInvalid, pyarrow.ArrowTypeError)):
+        baselode.export.write_project(tables, output_dir)
+
+    assert not output_dir.exists()
+
+
+def test_write_project_emits_manifest_after_requested_files(tmp_path):
+    output_dir = tmp_path / "project"
+    tables = {
+        "collars": _mixed_table(),
+        "survey": pd.DataFrame({
+            "hole_id": [101],
+            "depth": [0.0],
+            "azimuth": [10.0],
+            "dip": [-60.0],
+        }),
+    }
+
+    manifest = baselode.export.write_project(
+        tables,
+        output_dir,
+        manifest_name="conversion_manifest.json",
+        metadata={"project": "example"},
+    )
+
+    on_disk = json.loads((output_dir / "conversion_manifest.json").read_text())
+    assert on_disk == manifest
+    assert on_disk["format_version"] == 1
+    assert on_disk["metadata"] == {"project": "example"}
+    assert on_disk["tables"]["collars"]["rows"] == 3
+    assert on_disk["tables"]["survey"]["files"] == {
+        "csv": "survey.csv",
+        "parquet": "survey.parquet",
+    }
+    for name in tables:
+        assert (output_dir / f"{name}.csv").is_file()
+        assert (output_dir / f"{name}.parquet").is_file()


### PR DESCRIPTION
## What changed

- add `baselode.export` normalization for canonical identifiers, mixed scalar columns, nested JSON values, and nulls
- add atomic CSV/Parquet writers, paired table output, and generic project manifests
- document the public export contract
- cover round trips, manifest output, preflight failure, atomic replacement, and nullable numeric identifiers

## Why

New assistant and data workflows need one stable Baselode-owned serialization boundary instead of duplicating subtly incompatible CSV and Parquet handling.

## Review and validation

- 495 Python tests passed
- Claude Sonnet 5 review found one nullable-integer ID issue; fixed in `bad8aeb`
- second Claude Sonnet 5 review returned no findings

Tracker: TRK-369
