### PR TITLE
TRK-317: render categorical geology along 3D traces

### DIFF
--- a/javascript/packages/baselode/src/viz/drillholeScene.js
+++ b/javascript/packages/baselode/src/viz/drillholeScene.js
@@ -128,11 +128,13 @@ export function getCategoryHexColor(category) {
  * Normalize drillhole rendering options with defaults
  */
 export function normalizeDrillholeRenderOptions(options = {}) {
+  const selectedAssayVariable = options.selectedAssayVariable || '';
   return {
     preserveView: Boolean(options.preserveView),
     assayIntervalsByHole: options.assayIntervalsByHole || null,
-    selectedAssayVariable: options.selectedAssayVariable || '',
-    isCategoricalVariable: Boolean(options.isCategoricalVariable),
+    selectedAssayVariable,
+    isCategoricalVariable: Boolean(options.isCategoricalVariable)
+      && selectedAssayVariable !== '__HAS_ASSAY__',
     categoryColorMap: options.categoryColorMap || null,
   };
 }

--- a/javascript/packages/baselode/src/viz/drillholeScene.js
+++ b/javascript/packages/baselode/src/viz/drillholeScene.js
@@ -24,6 +24,61 @@ export function getMeasuredDepthRange(p1, p2) {
 }
 
 /**
+ * Split a physical trace segment at categorical interval boundaries.
+ *
+ * Survey traces are often sparse (for example, a vertical hole may have only
+ * collar and end-of-hole stations) while geology is sampled at much finer
+ * intervals. Rendering one cylinder per survey segment would otherwise paint
+ * the whole trace with its dominant category. Each returned slice has the
+ * interpolated physical endpoints and its measured-depth range.
+ */
+export function splitCategoricalSegment(p1, p2, intervals) {
+  const range = getMeasuredDepthRange(p1, p2);
+  if (!range || !Array.isArray(intervals) || intervals.length === 0) return [];
+
+  const boundaries = new Set([range.segStart, range.segEnd]);
+  for (const interval of intervals) {
+    const from = Number(interval?.from);
+    const to = Number(interval?.to);
+    if (!Number.isFinite(from) || !Number.isFinite(to) || to <= from) continue;
+    if (from > range.segStart && from < range.segEnd) boundaries.add(from);
+    if (to > range.segStart && to < range.segEnd) boundaries.add(to);
+  }
+
+  const mdDelta = Number(p2.md) - Number(p1.md);
+  if (!Number.isFinite(mdDelta) || mdDelta === 0) return [];
+  const ordered = [...boundaries].sort((a, b) => a - b);
+  if (mdDelta < 0) ordered.reverse();
+  const pointAtDepth = (depth) => {
+    const fraction = (depth - Number(p1.md)) / mdDelta;
+    const point = p1.clone().lerp(p2, fraction);
+    point.md = depth;
+    return point;
+  };
+
+  const slices = [];
+  for (let index = 0; index < ordered.length - 1; index += 1) {
+    const segmentStart = ordered[index];
+    const segmentEnd = ordered[index + 1];
+    if (segmentEnd === segmentStart) continue;
+    const segStart = Math.min(segmentStart, segmentEnd);
+    const segEnd = Math.max(segmentStart, segmentEnd);
+    const category = getDominantCategory(intervals, segStart, segEnd);
+    const previous = slices[slices.length - 1];
+    if (previous && previous.category === category) {
+      previous.p2 = pointAtDepth(segmentEnd);
+      continue;
+    }
+    slices.push({
+      p1: pointAtDepth(segmentStart),
+      p2: pointAtDepth(segmentEnd),
+      category,
+    });
+  }
+  return slices;
+}
+
+/**
  * Calculate weighted average assay value for a segment overlapping with assay intervals
  */
 export function getWeightedIntervalValue(assayIntervals, segStart, segEnd) {
@@ -274,34 +329,42 @@ export function setDrillholes(sceneCtx, holes, options = {}) {
     for (let i = 0; i < points.length - 1; i += 1) {
       const p1 = points[i];
       const p2 = points[i + 1];
-      const dir = tmpVec.subVectors(p2, p1);
-      const len = dir.length();
-      if (len <= 0.001) continue;
-      const radius = 2.2;
-      const cylinderGeom = new THREE.CylinderGeometry(radius, radius, len, 6, 1, true);
-      const segmentColor = getSegmentColor({
-        selectedAssayVariable,
-        assayIntervals,
-        assayScale,
-        holeId: hole.id,
-        segmentIndex: i,
-        p1,
-        p2,
-        isCategorical: isCategoricalVariable,
-        categoryColorMap,
-      });
-      const cylinderMat = new THREE.MeshLambertMaterial({
-        color: segmentColor,
-        flatShading: true,
-        emissive: segmentColor,
-        emissiveIntensity: 0.15
-      });
-      const mesh = new THREE.Mesh(cylinderGeom, cylinderMat);
-      mesh.position.copy(p1.clone().addScaledVector(dir, 0.5));
-      mesh.quaternion.setFromUnitVectors(up, dir.clone().normalize());
-      mesh.userData = buildHoleUserData(hole);
-      group.add(mesh);
-      sceneCtx.drillMeshes.push(mesh);
+      const categoricalSlices = isCategoricalVariable
+        ? splitCategoricalSegment(p1, p2, assayIntervals)
+        : [];
+      const renderSegments = categoricalSlices.length ? categoricalSlices : [{ p1, p2, category: null }];
+      for (const segment of renderSegments) {
+        const dir = tmpVec.subVectors(segment.p2, segment.p1);
+        const len = dir.length();
+        if (len <= 0.001) continue;
+        const radius = 2.2;
+        const cylinderGeom = new THREE.CylinderGeometry(radius, radius, len, 6, 1, true);
+        const segmentColor = isCategoricalVariable && segment.category != null
+          ? new THREE.Color(categoryColorMap?.[segment.category] || getCategoryHexColor(segment.category))
+          : getSegmentColor({
+            selectedAssayVariable,
+            assayIntervals,
+            assayScale,
+            holeId: hole.id,
+            segmentIndex: i,
+            p1: segment.p1,
+            p2: segment.p2,
+            isCategorical: isCategoricalVariable,
+            categoryColorMap,
+          });
+        const cylinderMat = new THREE.MeshLambertMaterial({
+          color: segmentColor,
+          flatShading: true,
+          emissive: segmentColor,
+          emissiveIntensity: 0.15
+        });
+        const mesh = new THREE.Mesh(cylinderGeom, cylinderMat);
+        mesh.position.copy(segment.p1.clone().addScaledVector(dir, 0.5));
+        mesh.quaternion.setFromUnitVectors(up, dir.clone().normalize());
+        mesh.userData = buildHoleUserData(hole);
+        group.add(mesh);
+        sceneCtx.drillMeshes.push(mesh);
+      }
     }
 
     sceneCtx.scene.add(group);

--- a/javascript/packages/baselode/tests/drillholeScene.test.js
+++ b/javascript/packages/baselode/tests/drillholeScene.test.js
@@ -1,6 +1,9 @@
 import * as THREE from 'three';
 import { describe, expect, it } from 'vitest';
-import { splitCategoricalSegment } from '../src/viz/drillholeScene.js';
+import {
+  normalizeDrillholeRenderOptions,
+  splitCategoricalSegment,
+} from '../src/viz/drillholeScene.js';
 
 describe('splitCategoricalSegment', () => {
   it('subdivides a sparse survey segment at every geology boundary', () => {
@@ -41,5 +44,16 @@ describe('splitCategoricalSegment', () => {
       [0, 20, 'CLAY'],
       [20, 30, 'SAND'],
     ]);
+  });
+});
+
+describe('normalizeDrillholeRenderOptions', () => {
+  it('keeps the assay-presence selector out of categorical rendering mode', () => {
+    const options = normalizeDrillholeRenderOptions({
+      selectedAssayVariable: '__HAS_ASSAY__',
+      isCategoricalVariable: true,
+    });
+
+    expect(options.isCategoricalVariable).toBe(false);
   });
 });

--- a/javascript/packages/baselode/tests/drillholeScene.test.js
+++ b/javascript/packages/baselode/tests/drillholeScene.test.js
@@ -1,0 +1,45 @@
+import * as THREE from 'three';
+import { describe, expect, it } from 'vitest';
+import { splitCategoricalSegment } from '../src/viz/drillholeScene.js';
+
+describe('splitCategoricalSegment', () => {
+  it('subdivides a sparse survey segment at every geology boundary', () => {
+    const p1 = new THREE.Vector3(0, 0, 0); p1.md = 0;
+    const p2 = new THREE.Vector3(0, 0, -126); p2.md = 126;
+    const slices = splitCategoricalSegment(p1, p2, [
+      { from: 0, to: 60, value: 'CLAY' },
+      { from: 60, to: 100, value: 'SAND' },
+      { from: 100, to: 126, value: 'SAPROLITE' },
+    ]);
+
+    expect(slices.map((slice) => [slice.p1.md, slice.p2.md, slice.category])).toEqual([
+      [0, 60, 'CLAY'],
+      [60, 100, 'SAND'],
+      [100, 126, 'SAPROLITE'],
+    ]);
+    expect(slices.map((slice) => slice.p2.z)).toEqual([-60, -100, -126]);
+  });
+
+  it('keeps the correct physical direction when measured depth decreases between points', () => {
+    const p1 = new THREE.Vector3(0, 0, -126); p1.md = 126;
+    const p2 = new THREE.Vector3(0, 0, 0); p2.md = 0;
+    const slices = splitCategoricalSegment(p1, p2, [{ from: 0, to: 126, value: 'CLAY' }]);
+    expect(slices).toHaveLength(1);
+    expect(slices[0].p1.z).toBe(-126);
+    expect(slices[0].p2.z).toBe(0);
+  });
+
+  it('merges adjacent source intervals with the same category', () => {
+    const p1 = new THREE.Vector3(0, 0, 0); p1.md = 0;
+    const p2 = new THREE.Vector3(0, 0, -30); p2.md = 30;
+    const slices = splitCategoricalSegment(p1, p2, [
+      { from: 0, to: 10, value: 'CLAY' },
+      { from: 10, to: 20, value: 'CLAY' },
+      { from: 20, to: 30, value: 'SAND' },
+    ]);
+    expect(slices.map((slice) => [slice.p1.md, slice.p2.md, slice.category])).toEqual([
+      [0, 20, 'CLAY'],
+      [20, 30, 'SAND'],
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

- split sparse 3D drillhole trace segments at categorical geology interval boundaries
- preserve physical direction and merge adjacent slices with the same category
- retain configured category colours and the documented unmatched-data fallback
- enforce the reserved assay-presence selector outside categorical rendering mode

## Ticket

TRK-317 — Baselode 3D: render categorical geology changes along hole traces

## Test plan

- `npm exec vitest run tests/drillholeScene.test.js` — 4 tests passed
- `npm run verify` — 42 test files / 691 tests passed
- production Vite build passed
- TypeScript contract checks passed
- published-package contract checks passed

## Risk

Low to medium. The change increases mesh subdivision only for categorical interval rendering. Numeric assay colouring and ordinary per-segment rendering retain their existing paths. Invalid intervals and unmatched depth slices retain fallback colouring.

## Reviewer

Claude Sonnet 5 reviewed the final diff and returned no findings after one P3 invariant issue was fixed.
