### PR TITLE
feat(viz): add axis-aligned sections and slabs

### DIFF
--- a/demo-viewer-react/app/src/pages/BlockModel.jsx
+++ b/demo-viewer-react/app/src/pages/BlockModel.jsx
@@ -150,6 +150,7 @@ function BlockModel() {
           onFit={() => sceneRef.current?.focusOnLastBounds(1.2)}
           sectionAxis={sectionAxis} sectionPosition={sectionPosition} sectionRange={rangeFor(sectionAxis)} onToggleSection={toggleSection} onSetSectionPosition={updateSection}
           sliceAxis={sliceAxis} slicePosition={slicePosition} sliceWidth={sliceWidth} sliceRange={rangeFor(sliceAxis)} onToggleSlice={toggleSlice} onSetSliceAxis={updateSliceAxis} onSetSlicePosition={updateSlice} onSetSliceWidth={updateSliceWidth}
+          overviewBounds={sceneRef.current?.lastBounds || null}
         />
 
         {blockData && (

--- a/demo-viewer-react/app/src/pages/BlockModel.jsx
+++ b/demo-viewer-react/app/src/pages/BlockModel.jsx
@@ -6,6 +6,8 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   Baselode3DScene,
   Baselode3DControls,
+  SectionHelper,
+  SliceHelper,
   BlockModelWidget,
   parseBlockModelCSV,
   calculatePropertyStats
@@ -17,6 +19,8 @@ function BlockModel() {
   const containerRef = useRef(null);
   const sceneRef = useRef(null);
   const opacityRef = useRef(1.0);
+  const sectionRef = useRef(null);
+  const sliceRef = useRef(null);
 
   const [blockData, setBlockData] = useState(null);
   const [properties, setProperties] = useState([]);
@@ -25,6 +29,11 @@ function BlockModel() {
   const [clickedBlock, setClickedBlock] = useState(null);
   const [error, setError] = useState('');
   const [controlMode, setControlMode] = useState('orbit');
+  const [sectionAxis, setSectionAxis] = useState(null);
+  const [sectionPosition, setSectionPosition] = useState(0);
+  const [sliceAxis, setSliceAxis] = useState(null);
+  const [slicePosition, setSlicePosition] = useState(0);
+  const [sliceWidth, setSliceWidth] = useState(50);
 
   opacityRef.current = opacity;
 
@@ -56,12 +65,16 @@ function BlockModel() {
     scene.init(containerRef.current);
     scene.setBlockClickHandler((blockRow) => setClickedBlock(blockRow));
     sceneRef.current = scene;
+    sectionRef.current = new SectionHelper(scene);
+    sliceRef.current = new SliceHelper(scene);
 
     const handleResize = () => scene.resize();
     window.addEventListener('resize', handleResize);
 
     return () => {
       window.removeEventListener('resize', handleResize);
+      sectionRef.current?.dispose();
+      sliceRef.current?.dispose();
       scene.dispose();
     };
   }, []);
@@ -88,6 +101,28 @@ function BlockModel() {
     setClickedBlock(null);
   };
 
+  const rangeFor = (axis) => {
+    const bounds = sceneRef.current?.lastBounds;
+    if (!bounds) return null;
+    return axis === 'y' ? { min: bounds.minY, max: bounds.maxY } : { min: bounds.minX, max: bounds.maxX };
+  };
+  const toggleSection = (axis) => {
+    if (sectionAxis === axis) { sectionRef.current?.disable(); setSectionAxis(null); return; }
+    sliceRef.current?.disable();
+    const range = rangeFor(axis); const position = range ? (range.min + range.max) / 2 : 0;
+    sectionRef.current?.enable(axis, position); setSectionAxis(axis); setSectionPosition(position); setSliceAxis(null);
+  };
+  const updateSection = (position) => { sectionRef.current?.setPosition(position); setSectionPosition(position); };
+  const toggleSlice = (axis) => {
+    if (sliceAxis) { sliceRef.current?.disable(); setSliceAxis(null); return; }
+    sectionRef.current?.disable();
+    const range = rangeFor(axis); const position = range ? (range.min + range.max) / 2 : 0;
+    sliceRef.current?.enable(axis, position, sliceWidth); setSliceAxis(axis); setSlicePosition(position); setSectionAxis(null);
+  };
+  const updateSliceAxis = (axis) => { const range = rangeFor(axis); const position = range ? (range.min + range.max) / 2 : 0; sliceRef.current?.enable(axis, position, sliceWidth); setSliceAxis(axis); setSlicePosition(position); };
+  const updateSlice = (position) => { sliceRef.current?.setPosition(position); setSlicePosition(position); };
+  const updateSliceWidth = (width) => { if (!Number.isFinite(width) || width <= 0) return; sliceRef.current?.setWidth(width); setSliceWidth(width); };
+
   return (
     <div className="blockmodel-container">
       <div className="blockmodel-header">
@@ -113,6 +148,8 @@ function BlockModel() {
           onRecenter={() => sceneRef.current?.recenterCameraToOrigin(2000)}
           onLookDown={() => sceneRef.current?.lookDown(3000)}
           onFit={() => sceneRef.current?.focusOnLastBounds(1.2)}
+          sectionAxis={sectionAxis} sectionPosition={sectionPosition} sectionRange={rangeFor(sectionAxis)} onToggleSection={toggleSection} onSetSectionPosition={updateSection}
+          sliceAxis={sliceAxis} slicePosition={slicePosition} sliceWidth={sliceWidth} sliceRange={rangeFor(sliceAxis)} onToggleSlice={toggleSlice} onSetSliceAxis={updateSliceAxis} onSetSlicePosition={updateSlice} onSetSliceWidth={updateSliceWidth}
         />
 
         {blockData && (

--- a/demo-viewer-react/app/src/pages/BlockModel.jsx
+++ b/demo-viewer-react/app/src/pages/BlockModel.jsx
@@ -42,6 +42,22 @@ function BlockModel() {
     return calculatePropertyStats(blockData, selectedProperty);
   }, [blockData, selectedProperty]);
 
+  const overviewPoints = useMemo(() => {
+    if (!blockData?.length) return [];
+    const coordinates = blockData.map((row) => ({ x: Number(row.x ?? row.center_x), y: Number(row.y ?? row.center_y) }))
+      .filter((point) => Number.isFinite(point.x) && Number.isFinite(point.y));
+    if (!coordinates.length) return [];
+    const minX = Math.min(...coordinates.map((point) => point.x));
+    const maxX = Math.max(...coordinates.map((point) => point.x));
+    const minY = Math.min(...coordinates.map((point) => point.y));
+    const maxY = Math.max(...coordinates.map((point) => point.y));
+    const offsetX = -(minX + maxX) / 2;
+    const offsetY = -(minY + maxY) / 2;
+    const stride = Math.max(1, Math.ceil(coordinates.length / 500));
+    return coordinates.filter((_, index) => index % stride === 0)
+      .map((point) => ({ x: point.x + offsetX, y: point.y + offsetY }));
+  }, [blockData]);
+
   // Load demo block model CSV on mount
   useEffect(() => {
     fetch('/data/blockmodel/demo_blockmodel.csv')
@@ -151,6 +167,7 @@ function BlockModel() {
           sectionAxis={sectionAxis} sectionPosition={sectionPosition} sectionRange={rangeFor(sectionAxis)} onToggleSection={toggleSection} onSetSectionPosition={updateSection}
           sliceAxis={sliceAxis} slicePosition={slicePosition} sliceWidth={sliceWidth} sliceRange={rangeFor(sliceAxis)} onToggleSlice={toggleSlice} onSetSliceAxis={updateSliceAxis} onSetSlicePosition={updateSlice} onSetSliceWidth={updateSliceWidth}
           overviewBounds={sceneRef.current?.lastBounds || null}
+          overviewPoints={overviewPoints}
         />
 
         {blockData && (

--- a/demo-viewer-react/app/src/pages/Drillhole.jsx
+++ b/demo-viewer-react/app/src/pages/Drillhole.jsx
@@ -6,6 +6,8 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   Baselode3DScene,
   Baselode3DControls,
+  SectionHelper,
+  SliceHelper,
   parseDrillholesCSV,
   parseSurveyCSV,
   minimumCurvatureDesurvey,
@@ -46,6 +48,8 @@ function Drillhole() {
   const renderedHolesRef = useRef(null);
   const restoredCameraRef = useRef(false);
   const zoomSliderPrevRef = useRef(50);
+  const sectionRef = useRef(null);
+  const sliceRef = useRef(null);
 
   const { collars, assayState, structureRows, geologyHoles } = useDemoData();
 
@@ -61,6 +65,11 @@ function Drillhole() {
   const [showStripLogs, setShowStripLogs] = useState(false);
   const [darkBackground, setDarkBackground] = useState(false);
   const [perspectiveLevel, setPerspectiveLevel] = useState(FOV_STEPS.length - 1);
+  const [sectionAxis, setSectionAxis] = useState(null);
+  const [sectionPosition, setSectionPosition] = useState(0);
+  const [sliceAxis, setSliceAxis] = useState(null);
+  const [slicePosition, setSlicePosition] = useState(0);
+  const [sliceWidth, setSliceWidth] = useState(50);
 
   const assayVariables = useMemo(() => {
     const numeric = (assayState?.numericProps || []).filter(Boolean);
@@ -225,6 +234,8 @@ function Drillhole() {
     let viewSaveInterval = null;
     scene.init(containerRef.current);
     scene.setDrillholeClickHandler((meta) => setSelectedHole(meta));
+    sectionRef.current = new SectionHelper(scene);
+    sliceRef.current = new SliceHelper(scene);
     scene.setControlMode(controlMode);
     if (typeof scene.setViewChangeHandler === 'function') {
       scene.setViewChangeHandler((viewState) => {
@@ -250,6 +261,8 @@ function Drillhole() {
       const viewState = getSceneViewState(scene);
       if (viewState) saveCachedCameraView(viewState);
       window.removeEventListener('resize', handleResize);
+      sectionRef.current?.dispose();
+      sliceRef.current?.dispose();
       scene.dispose();
     };
   }, []);
@@ -259,6 +272,29 @@ function Drillhole() {
       sceneRef.current.setControlMode(controlMode);
     }
   }, [controlMode]);
+
+  const rangeFor = (axis) => {
+    const bounds = sceneRef.current?.lastBounds;
+    if (!bounds) return null;
+    return axis === 'y' ? { min: bounds.minY, max: bounds.maxY } : { min: bounds.minX, max: bounds.maxX };
+  };
+
+  const toggleSection = (axis) => {
+    if (sectionAxis === axis) { sectionRef.current?.disable(); setSectionAxis(null); return; }
+    sliceRef.current?.disable();
+    const range = rangeFor(axis); const position = range ? (range.min + range.max) / 2 : 0;
+    sectionRef.current?.enable(axis, position); setSectionAxis(axis); setSectionPosition(position); setSliceAxis(null);
+  };
+  const updateSection = (position) => { sectionRef.current?.setPosition(position); setSectionPosition(position); };
+  const toggleSlice = (axis) => {
+    if (sliceAxis) { sliceRef.current?.disable(); setSliceAxis(null); return; }
+    sectionRef.current?.disable();
+    const range = rangeFor(axis); const position = range ? (range.min + range.max) / 2 : 0;
+    sliceRef.current?.enable(axis, position, sliceWidth); setSliceAxis(axis); setSlicePosition(position); setSectionAxis(null);
+  };
+  const updateSliceAxis = (axis) => { const range = rangeFor(axis); const position = range ? (range.min + range.max) / 2 : 0; sliceRef.current?.enable(axis, position, sliceWidth); setSliceAxis(axis); setSlicePosition(position); };
+  const updateSlice = (position) => { sliceRef.current?.setPosition(position); setSlicePosition(position); };
+  const updateSliceWidth = (width) => { if (!Number.isFinite(width) || width <= 0) return; sliceRef.current?.setWidth(width); setSliceWidth(width); };
 
   useEffect(() => {
     if (sceneRef.current && holes && holes.length) {
@@ -501,6 +537,8 @@ function Drillhole() {
           onFit={() => sceneRef.current?.focusOnLastBounds(1.2)}
           darkBackground={darkBackground}
           onToggleDarkBackground={(e) => setDarkBackground(e.target.checked)}
+          sectionAxis={sectionAxis} sectionPosition={sectionPosition} sectionRange={rangeFor(sectionAxis)} onToggleSection={toggleSection} onSetSectionPosition={updateSection}
+          sliceAxis={sliceAxis} slicePosition={slicePosition} sliceWidth={sliceWidth} sliceRange={rangeFor(sliceAxis)} onToggleSlice={toggleSlice} onSetSliceAxis={updateSliceAxis} onSetSlicePosition={updateSlice} onSetSliceWidth={updateSliceWidth}
         />
         {selectedHole && (
           <div className="selection-popup">

--- a/demo-viewer-react/app/src/pages/Drillhole.jsx
+++ b/demo-viewer-react/app/src/pages/Drillhole.jsx
@@ -81,6 +81,12 @@ function Drillhole() {
     return classifyColumns(geologyHoles.flatMap((h) => h.points || [])).categoricalCols;
   }, [geologyHoles]);
 
+  const overviewPaths = useMemo(() => (holes || []).map((hole) => {
+    const points = hole.points || [];
+    const stride = Math.max(1, Math.ceil(points.length / 100));
+    return points.filter((_, index) => index % stride === 0).map((point) => ({ x: Number(point.x), y: Number(point.y) }));
+  }), [holes]);
+
   const isCategorical = useMemo(
     () => geologyCategories.includes(colorByVariable),
     [geologyCategories, colorByVariable]
@@ -540,6 +546,7 @@ function Drillhole() {
           sectionAxis={sectionAxis} sectionPosition={sectionPosition} sectionRange={rangeFor(sectionAxis)} onToggleSection={toggleSection} onSetSectionPosition={updateSection}
           sliceAxis={sliceAxis} slicePosition={slicePosition} sliceWidth={sliceWidth} sliceRange={rangeFor(sliceAxis)} onToggleSlice={toggleSlice} onSetSliceAxis={updateSliceAxis} onSetSlicePosition={updateSlice} onSetSliceWidth={updateSliceWidth}
           overviewBounds={sceneRef.current?.lastBounds || null}
+          overviewPaths={overviewPaths}
         />
         {selectedHole && (
           <div className="selection-popup">

--- a/demo-viewer-react/app/src/pages/Drillhole.jsx
+++ b/demo-viewer-react/app/src/pages/Drillhole.jsx
@@ -539,6 +539,7 @@ function Drillhole() {
           onToggleDarkBackground={(e) => setDarkBackground(e.target.checked)}
           sectionAxis={sectionAxis} sectionPosition={sectionPosition} sectionRange={rangeFor(sectionAxis)} onToggleSection={toggleSection} onSetSectionPosition={updateSection}
           sliceAxis={sliceAxis} slicePosition={slicePosition} sliceWidth={sliceWidth} sliceRange={rangeFor(sliceAxis)} onToggleSlice={toggleSlice} onSetSliceAxis={updateSliceAxis} onSetSlicePosition={updateSlice} onSetSliceWidth={updateSliceWidth}
+          overviewBounds={sceneRef.current?.lastBounds || null}
         />
         {selectedHole && (
           <div className="selection-popup">

--- a/docs/guide/javascript.md
+++ b/docs/guide/javascript.md
@@ -62,6 +62,29 @@ order southwest → southeast → northeast → northwest → southwest.
 npm install react react-dom three three-viewport-gizmo plotly.js-dist-min papaparse
 ```
 
+## 3D sections and slabs
+
+`SectionHelper` provides an orthographic vertical cross-section aligned to X
+or Y. `SliceHelper` retains a finite, movable slab around an X or Y plane.
+Both operate on a `Baselode3DScene`, retain clipping planes supplied by the
+host application, and are mutually exclusive.
+
+```js
+import { SectionHelper, SliceHelper } from 'baselode';
+
+const section = new SectionHelper(scene).enable('x', 250);
+section.setPosition(275);
+section.disable();
+
+const slab = new SliceHelper(scene).enable('y', 500, 25);
+slab.setWidth(40);
+slab.step(10);
+slab.disable();
+```
+
+The demo’s Block Model and Drillhole pages include controls for both modes.
+Freehand knife-line slicing is intentionally not part of this API yet.
+
 ---
 
 ## Data Model

--- a/javascript/packages/baselode/src/index.js
+++ b/javascript/packages/baselode/src/index.js
@@ -426,6 +426,7 @@ export {
 export { default as Baselode3DScene } from './viz/baselode3dScene.js';
 export { default as Baselode3DControls } from './viz/Baselode3DControls.jsx';
 export { default as BlockModelWidget } from './viz/BlockModelWidget.jsx';
+export { SectionHelper, SliceHelper } from './viz/sectionSliceHelpers.js';
 
 export {
   DEFAULT_LOD_BREAKPOINTS,

--- a/javascript/packages/baselode/src/viz/Baselode3DControls.css
+++ b/javascript/packages/baselode/src/viz/Baselode3DControls.css
@@ -80,6 +80,8 @@
 .baselode-section-overview-title { font-weight: 600; margin-bottom: 2px; }
 .baselode-section-overview svg { display: block; width: 140px; height: 140px; }
 .baselode-section-overview-bounds { fill: #f8fafc; stroke: #94a3b8; stroke-width: 1; }
+.baselode-section-overview-point { fill: #64748b; opacity: 0.65; }
+.baselode-section-overview-trace { fill: none; stroke: #64748b; stroke-width: 1; opacity: 0.65; vector-effect: non-scaling-stroke; }
 .baselode-section-overview-slab { fill: rgba(37, 99, 235, 0.18); }
 .baselode-section-overview-line { stroke: #dc2626; stroke-width: 2; vector-effect: non-scaling-stroke; }
 .baselode-section-overview-axis { display: block; text-align: center; color: #64748b; }

--- a/javascript/packages/baselode/src/viz/Baselode3DControls.css
+++ b/javascript/packages/baselode/src/viz/Baselode3DControls.css
@@ -84,4 +84,5 @@
 .baselode-section-overview-trace { fill: none; stroke: #64748b; stroke-width: 1; opacity: 0.65; vector-effect: non-scaling-stroke; }
 .baselode-section-overview-slab { fill: rgba(37, 99, 235, 0.18); }
 .baselode-section-overview-line { stroke: #dc2626; stroke-width: 2; vector-effect: non-scaling-stroke; }
+.baselode-section-overview-camera { fill: #1e293b; }
 .baselode-section-overview-axis { display: block; text-align: center; color: #64748b; }

--- a/javascript/packages/baselode/src/viz/Baselode3DControls.css
+++ b/javascript/packages/baselode/src/viz/Baselode3DControls.css
@@ -62,3 +62,24 @@
 
 .baselode-3d-width-label { display: inline-flex; align-items: center; gap: 4px; font-size: 12px; }
 .baselode-3d-width-label input { width: 58px; }
+
+.baselode-section-overview {
+  position: absolute;
+  bottom: calc(100% + 12px);
+  left: 0;
+  width: 150px;
+  padding: 8px;
+  border: 1px solid #d0d0d0;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.94);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+  font-size: 11px;
+  color: #334155;
+}
+
+.baselode-section-overview-title { font-weight: 600; margin-bottom: 2px; }
+.baselode-section-overview svg { display: block; width: 140px; height: 140px; }
+.baselode-section-overview-bounds { fill: #f8fafc; stroke: #94a3b8; stroke-width: 1; }
+.baselode-section-overview-slab { fill: rgba(37, 99, 235, 0.18); }
+.baselode-section-overview-line { stroke: #dc2626; stroke-width: 2; vector-effect: non-scaling-stroke; }
+.baselode-section-overview-axis { display: block; text-align: center; color: #64748b; }

--- a/javascript/packages/baselode/src/viz/Baselode3DControls.css
+++ b/javascript/packages/baselode/src/viz/Baselode3DControls.css
@@ -45,3 +45,20 @@
   user-select: none;
   padding: 0 4px;
 }
+
+.baselode-3d-controls-group {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.baselode-3d-controls .ghost-button.active {
+  background: #1d4ed8;
+  border-color: #1d4ed8;
+  color: #fff;
+}
+
+.baselode-3d-slider { width: 115px; }
+
+.baselode-3d-width-label { display: inline-flex; align-items: center; gap: 4px; font-size: 12px; }
+.baselode-3d-width-label input { width: 58px; }

--- a/javascript/packages/baselode/src/viz/Baselode3DControls.jsx
+++ b/javascript/packages/baselode/src/viz/Baselode3DControls.jsx
@@ -4,6 +4,39 @@
  */
 import './Baselode3DControls.css';
 
+function SectionOverview({ bounds, sectionAxis, sectionPosition, sliceAxis, slicePosition, sliceWidth }) {
+  if (!bounds || (!sectionAxis && !sliceAxis)) return null;
+  const width = Number(bounds.maxX) - Number(bounds.minX);
+  const height = Number(bounds.maxY) - Number(bounds.minY);
+  if (!(width > 0) || !(height > 0)) return null;
+  const activeAxis = sectionAxis || sliceAxis;
+  const activePosition = sectionAxis ? sectionPosition : slicePosition;
+  const isSlab = Boolean(sliceAxis);
+  const toX = (value) => 10 + ((value - bounds.minX) / width) * 120;
+  const toY = (value) => 130 - ((value - bounds.minY) / height) * 120;
+  const isX = activeAxis === 'x';
+  const linePosition = isX ? toX(activePosition) : toY(activePosition);
+  const bandSize = isX ? (sliceWidth / width) * 120 : (sliceWidth / height) * 120;
+
+  return (
+    <div className="baselode-section-overview" aria-label="Top-down section overview">
+      <div className="baselode-section-overview-title">Top down</div>
+      <svg viewBox="0 0 140 140" role="img" aria-label={`${activeAxis.toUpperCase()} ${isSlab ? 'slab' : 'section'} position`}>
+        <rect x="10" y="10" width="120" height="120" className="baselode-section-overview-bounds" />
+        {isSlab && (isX
+          ? <rect x={linePosition - bandSize / 2} y="10" width={bandSize} height="120" className="baselode-section-overview-slab" />
+          : <rect x="10" y={linePosition - bandSize / 2} width="120" height={bandSize} className="baselode-section-overview-slab" />
+        )}
+        {isX
+          ? <line x1={linePosition} x2={linePosition} y1="10" y2="130" className="baselode-section-overview-line" />
+          : <line x1="10" x2="130" y1={linePosition} y2={linePosition} className="baselode-section-overview-line" />
+        }
+      </svg>
+      <span className="baselode-section-overview-axis">X → &nbsp; Y ↑</span>
+    </div>
+  );
+}
+
 /**
  * 3D scene control buttons component
  * Provides UI controls for camera manipulation in the 3D drillhole viewer
@@ -36,9 +69,18 @@ function Baselode3DControls({
   onSetSliceAxis = () => {},
   onSetSlicePosition = () => {},
   onSetSliceWidth = () => {},
+  overviewBounds = null,
 }) {
   return (
     <div className="baselode-3d-controls">
+      <SectionOverview
+        bounds={overviewBounds}
+        sectionAxis={sectionAxis}
+        sectionPosition={sectionPosition}
+        sliceAxis={sliceAxis}
+        slicePosition={slicePosition}
+        sliceWidth={sliceWidth}
+      />
       <button type="button" className="ghost-button" onClick={onRecenter}>
         Recenter to (0,0,0)
       </button>

--- a/javascript/packages/baselode/src/viz/Baselode3DControls.jsx
+++ b/javascript/packages/baselode/src/viz/Baselode3DControls.jsx
@@ -23,6 +23,19 @@ function Baselode3DControls({
   onFit = () => {},
   darkBackground = false,
   onToggleDarkBackground = () => {},
+  sectionAxis = null,
+  sectionPosition = 0,
+  sectionRange = null,
+  onToggleSection = () => {},
+  onSetSectionPosition = () => {},
+  sliceAxis = null,
+  slicePosition = 0,
+  sliceWidth = 50,
+  sliceRange = null,
+  onToggleSlice = () => {},
+  onSetSliceAxis = () => {},
+  onSetSlicePosition = () => {},
+  onSetSliceWidth = () => {},
 }) {
   return (
     <div className="baselode-3d-controls">
@@ -46,6 +59,31 @@ function Baselode3DControls({
         />
         Dark background
       </label>
+      <div className="baselode-3d-controls-group">
+        <button type="button" className={`ghost-button${sectionAxis === 'x' ? ' active' : ''}`} onClick={() => onToggleSection('x')}>Section X</button>
+        <button type="button" className={`ghost-button${sectionAxis === 'y' ? ' active' : ''}`} onClick={() => onToggleSection('y')}>Section Y</button>
+        {sectionAxis && sectionRange && (
+          <input
+            aria-label={`${sectionAxis.toUpperCase()} section position`}
+            className="baselode-3d-slider"
+            type="range"
+            min={sectionRange.min}
+            max={sectionRange.max}
+            step="any"
+            value={sectionPosition}
+            onChange={(event) => onSetSectionPosition(Number(event.target.value))}
+          />
+        )}
+      </div>
+      <div className="baselode-3d-controls-group">
+        <button type="button" className={`ghost-button${sliceAxis ? ' active' : ''}`} onClick={() => onToggleSlice(sliceAxis || 'x')}>Slab</button>
+        {sliceAxis && <>
+          <button type="button" className={`ghost-button${sliceAxis === 'x' ? ' active' : ''}`} onClick={() => onSetSliceAxis('x')}>X</button>
+          <button type="button" className={`ghost-button${sliceAxis === 'y' ? ' active' : ''}`} onClick={() => onSetSliceAxis('y')}>Y</button>
+          {sliceRange && <input aria-label={`${sliceAxis.toUpperCase()} slab position`} className="baselode-3d-slider" type="range" min={sliceRange.min} max={sliceRange.max} step="any" value={slicePosition} onChange={(event) => onSetSlicePosition(Number(event.target.value))} />}
+          <label className="baselode-3d-width-label">Width <input aria-label="Slab width" type="number" min="0.001" step="1" value={sliceWidth} onChange={(event) => onSetSliceWidth(Number(event.target.value))} /></label>
+        </>}
+      </div>
     </div>
   );
 }

--- a/javascript/packages/baselode/src/viz/Baselode3DControls.jsx
+++ b/javascript/packages/baselode/src/viz/Baselode3DControls.jsx
@@ -21,7 +21,7 @@ function SectionOverview({ bounds, sectionAxis, sectionPosition, sliceAxis, slic
   return (
     <div className="baselode-section-overview" aria-label="Top-down section overview">
       <div className="baselode-section-overview-title">Top down</div>
-      <svg viewBox="0 0 140 140" role="img" aria-label={`${activeAxis.toUpperCase()} ${isSlab ? 'slab' : 'section'} position`}>
+      <svg viewBox="0 0 140 140" role="img" aria-label={`${activeAxis.toUpperCase()} ${isSlab ? 'slice' : 'section'} position`}>
         <rect x="10" y="10" width="120" height="120" className="baselode-section-overview-bounds" />
         {isSlab && (isX
           ? <rect x={linePosition - bandSize / 2} y="10" width={bandSize} height="120" className="baselode-section-overview-slab" />
@@ -118,7 +118,7 @@ function Baselode3DControls({
         )}
       </div>
       <div className="baselode-3d-controls-group">
-        <button type="button" className={`ghost-button${sliceAxis ? ' active' : ''}`} onClick={() => onToggleSlice(sliceAxis || 'x')}>Slab</button>
+        <button type="button" className={`ghost-button${sliceAxis ? ' active' : ''}`} onClick={() => onToggleSlice(sliceAxis || 'x')}>Slice</button>
         {sliceAxis && <>
           <button type="button" className={`ghost-button${sliceAxis === 'x' ? ' active' : ''}`} onClick={() => onSetSliceAxis('x')}>X</button>
           <button type="button" className={`ghost-button${sliceAxis === 'y' ? ' active' : ''}`} onClick={() => onSetSliceAxis('y')}>Y</button>

--- a/javascript/packages/baselode/src/viz/Baselode3DControls.jsx
+++ b/javascript/packages/baselode/src/viz/Baselode3DControls.jsx
@@ -4,7 +4,7 @@
  */
 import './Baselode3DControls.css';
 
-function SectionOverview({ bounds, sectionAxis, sectionPosition, sliceAxis, slicePosition, sliceWidth }) {
+function SectionOverview({ bounds, sectionAxis, sectionPosition, sliceAxis, slicePosition, sliceWidth, overviewPoints = [], overviewPaths = [] }) {
   if (!bounds || (!sectionAxis && !sliceAxis)) return null;
   const width = Number(bounds.maxX) - Number(bounds.minX);
   const height = Number(bounds.maxY) - Number(bounds.minY);
@@ -17,12 +17,23 @@ function SectionOverview({ bounds, sectionAxis, sectionPosition, sliceAxis, slic
   const isX = activeAxis === 'x';
   const linePosition = isX ? toX(activePosition) : toY(activePosition);
   const bandSize = isX ? (sliceWidth / width) * 120 : (sliceWidth / height) * 120;
+  const pathPoints = (path) => path
+    .filter((point) => Number.isFinite(point.x) && Number.isFinite(point.y))
+    .map((point) => `${toX(point.x)},${toY(point.y)}`)
+    .join(' ');
 
   return (
     <div className="baselode-section-overview" aria-label="Top-down section overview">
       <div className="baselode-section-overview-title">Top down</div>
       <svg viewBox="0 0 140 140" role="img" aria-label={`${activeAxis.toUpperCase()} ${isSlab ? 'slice' : 'section'} position`}>
         <rect x="10" y="10" width="120" height="120" className="baselode-section-overview-bounds" />
+        {overviewPaths.map((path, index) => {
+          const points = pathPoints(path);
+          return points ? <polyline key={index} points={points} className="baselode-section-overview-trace" /> : null;
+        })}
+        {overviewPoints.map((point, index) => (
+          <circle key={index} cx={toX(point.x)} cy={toY(point.y)} r="1" className="baselode-section-overview-point" />
+        ))}
         {isSlab && (isX
           ? <rect x={linePosition - bandSize / 2} y="10" width={bandSize} height="120" className="baselode-section-overview-slab" />
           : <rect x="10" y={linePosition - bandSize / 2} width="120" height={bandSize} className="baselode-section-overview-slab" />
@@ -70,6 +81,8 @@ function Baselode3DControls({
   onSetSlicePosition = () => {},
   onSetSliceWidth = () => {},
   overviewBounds = null,
+  overviewPoints = [],
+  overviewPaths = [],
 }) {
   return (
     <div className="baselode-3d-controls">
@@ -80,6 +93,8 @@ function Baselode3DControls({
         sliceAxis={sliceAxis}
         slicePosition={slicePosition}
         sliceWidth={sliceWidth}
+        overviewPoints={overviewPoints}
+        overviewPaths={overviewPaths}
       />
       <button type="button" className="ghost-button" onClick={onRecenter}>
         Recenter to (0,0,0)

--- a/javascript/packages/baselode/src/viz/Baselode3DControls.jsx
+++ b/javascript/packages/baselode/src/viz/Baselode3DControls.jsx
@@ -42,8 +42,12 @@ function SectionOverview({ bounds, sectionAxis, sectionPosition, sliceAxis, slic
           ? <line x1={linePosition} x2={linePosition} y1="10" y2="130" className="baselode-section-overview-line" />
           : <line x1="10" x2="130" y1={linePosition} y2={linePosition} className="baselode-section-overview-line" />
         }
+        {isX
+          ? <path d={`M 10 ${70} l 8 -5 v 10 z`} className="baselode-section-overview-camera" />
+          : <path d={`M ${70} 130 l -5 -8 h 10 z`} className="baselode-section-overview-camera" />
+        }
       </svg>
-      <span className="baselode-section-overview-axis">X → &nbsp; Y ↑</span>
+      <span className="baselode-section-overview-axis">X → &nbsp; Y ↑ · camera ●</span>
     </div>
   );
 }

--- a/javascript/packages/baselode/src/viz/baselode3dScene.js
+++ b/javascript/packages/baselode/src/viz/baselode3dScene.js
@@ -217,7 +217,14 @@ class Baselode3DScene {
     if (!this.container || !this.camera || !this.renderer) return;
     const width = this.container.clientWidth;
     const height = this.container.clientHeight;
-    this.camera.aspect = width / height;
+    if (this.camera.isOrthographicCamera) {
+      const halfHeight = (this.camera.top - this.camera.bottom) / 2;
+      const halfWidth = halfHeight * (width / height);
+      this.camera.left = -halfWidth;
+      this.camera.right = halfWidth;
+    } else {
+      this.camera.aspect = width / height;
+    }
     this.camera.updateProjectionMatrix();
     this.renderer.setSize(width, height);
     if (this.gizmo) this.gizmo.update();

--- a/javascript/packages/baselode/src/viz/sectionSliceHelpers.js
+++ b/javascript/packages/baselode/src/viz/sectionSliceHelpers.js
@@ -48,7 +48,9 @@ export class SectionHelper {
     this.ctx._baselodeViewingHelper = this;
     this.savedLocalClippingEnabled = this.ctx.renderer?.localClippingEnabled || false;
     this._saveAndUseOrthographicCamera();
-    this.plane = new THREE.Plane(axisNormal(this.axis).negate(), this.position);
+    // View from the lower-coordinate side toward +X / +Y.  This places a Y
+    // section camera at the bottom of a conventional north-up locator map.
+    this.plane = new THREE.Plane(axisNormal(this.axis), -this.position);
     this._setSectionViewPosition();
     this._addPlanes([this.plane]);
     this.active = true;
@@ -112,7 +114,7 @@ export class SectionHelper {
     this.sectionTarget = target.clone();
     this.sectionCameraDistance = Math.max(distance, 1);
     ortho.up.set(0, 0, 1);
-    ortho.position.copy(target).addScaledVector(direction, this.sectionCameraDistance);
+    ortho.position.copy(target).addScaledVector(direction, -this.sectionCameraDistance);
     ortho.lookAt(target);
     ortho.updateProjectionMatrix();
     replaceCamera(this.ctx, ortho);
@@ -129,7 +131,7 @@ export class SectionHelper {
     this.sectionTarget[this.axis] = this.position;
     const direction = axisNormal(this.axis);
     controls.target.copy(this.sectionTarget);
-    camera.position.copy(this.sectionTarget).addScaledVector(direction, this.sectionCameraDistance);
+    camera.position.copy(this.sectionTarget).addScaledVector(direction, -this.sectionCameraDistance);
     camera.lookAt(this.sectionTarget);
     controls.update();
   }

--- a/javascript/packages/baselode/src/viz/sectionSliceHelpers.js
+++ b/javascript/packages/baselode/src/viz/sectionSliceHelpers.js
@@ -34,6 +34,8 @@ export class SectionHelper {
     this.plane = null;
     this.saved = null;
     this.savedLocalClippingEnabled = false;
+    this.sectionTarget = null;
+    this.sectionCameraDistance = 1;
   }
 
   enable(axis = 'x', position = this.position) {
@@ -47,6 +49,7 @@ export class SectionHelper {
     this.savedLocalClippingEnabled = this.ctx.renderer?.localClippingEnabled || false;
     this._saveAndUseOrthographicCamera();
     this.plane = new THREE.Plane(axisNormal(this.axis).negate(), this.position);
+    this._setSectionViewPosition();
     this._addPlanes([this.plane]);
     this.active = true;
     return this;
@@ -56,6 +59,7 @@ export class SectionHelper {
     if (!Number.isFinite(position)) return this;
     this.position = position;
     if (this.plane) this.plane.constant = position;
+    this._setSectionViewPosition();
     return this;
   }
 
@@ -78,6 +82,7 @@ export class SectionHelper {
     }
     if (this.ctx._baselodeViewingHelper === this) this.ctx._baselodeViewingHelper = null;
     this.plane = null;
+    this.sectionTarget = null;
     this.active = false;
     return this;
   }
@@ -104,8 +109,10 @@ export class SectionHelper {
     const ortho = new THREE.OrthographicCamera(-halfHeight * aspect, halfHeight * aspect, halfHeight, -halfHeight, 0.01, 10_000_000);
     const target = controls.target.clone();
     const direction = axisNormal(this.axis);
+    this.sectionTarget = target.clone();
+    this.sectionCameraDistance = Math.max(distance, 1);
     ortho.up.set(0, 0, 1);
-    ortho.position.copy(target).addScaledVector(direction, Math.max(distance, 1));
+    ortho.position.copy(target).addScaledVector(direction, this.sectionCameraDistance);
     ortho.lookAt(target);
     ortho.updateProjectionMatrix();
     replaceCamera(this.ctx, ortho);
@@ -113,6 +120,17 @@ export class SectionHelper {
     controls.enabled = true;
     if (this.ctx.flyControls) this.ctx.flyControls.enabled = false;
     this.ctx.controlMode = 'orbit';
+    controls.update();
+  }
+
+  _setSectionViewPosition() {
+    const { camera, controls } = this.ctx;
+    if (!camera?.isOrthographicCamera || !controls || !this.sectionTarget) return;
+    this.sectionTarget[this.axis] = this.position;
+    const direction = axisNormal(this.axis);
+    controls.target.copy(this.sectionTarget);
+    camera.position.copy(this.sectionTarget).addScaledVector(direction, this.sectionCameraDistance);
+    camera.lookAt(this.sectionTarget);
     controls.update();
   }
 

--- a/javascript/packages/baselode/src/viz/sectionSliceHelpers.js
+++ b/javascript/packages/baselode/src/viz/sectionSliceHelpers.js
@@ -147,7 +147,7 @@ export class SectionHelper {
     if (!renderer) return;
     const removed = new Set(planes.filter(Boolean));
     renderer.clippingPlanes = (renderer.clippingPlanes || []).filter((plane) => !removed.has(plane));
-    if (!renderer.clippingPlanes.length) renderer.localClippingEnabled = this.savedLocalClippingEnabled;
+    renderer.localClippingEnabled = this.savedLocalClippingEnabled;
   }
 }
 
@@ -211,7 +211,7 @@ export class SliceHelper {
     const removed = new Set(this.planes);
     if (renderer) {
       renderer.clippingPlanes = (renderer.clippingPlanes || []).filter((plane) => !removed.has(plane));
-      if (!renderer.clippingPlanes.length) renderer.localClippingEnabled = this.savedLocalClippingEnabled;
+      renderer.localClippingEnabled = this.savedLocalClippingEnabled;
     }
     if (this.ctx._baselodeViewingHelper === this) this.ctx._baselodeViewingHelper = null;
     this.planes = [];

--- a/javascript/packages/baselode/src/viz/sectionSliceHelpers.js
+++ b/javascript/packages/baselode/src/viz/sectionSliceHelpers.js
@@ -1,0 +1,210 @@
+/*
+ * Copyright (C) 2026 Darkmine Pty Ltd
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+import * as THREE from 'three';
+
+function axisNormal(axis) {
+  return axis === 'y' ? new THREE.Vector3(0, 1, 0) : new THREE.Vector3(1, 0, 0);
+}
+
+function replaceCamera(ctx, camera) {
+  ctx.camera = camera;
+  if (ctx.controls) ctx.controls.object = camera;
+  if (ctx.flyControls) ctx.flyControls.object = camera;
+  if (ctx.gizmo) ctx.gizmo.camera = camera;
+  for (const pass of ctx._composer?.passes || []) {
+    if (pass.camera) pass.camera = camera;
+  }
+}
+
+/**
+ * Orthographic X/Y cross-section viewer.
+ *
+ * The helper adds only its own clipping plane to the renderer and restores the
+ * original camera and interaction settings when disabled.  It does not own or
+ * replace clipping planes added by the host application.
+ */
+export class SectionHelper {
+  constructor(sceneCtx) {
+    this.ctx = sceneCtx;
+    this.active = false;
+    this.axis = 'x';
+    this.position = 0;
+    this.plane = null;
+    this.saved = null;
+    this.savedLocalClippingEnabled = false;
+  }
+
+  enable(axis = 'x', position = this.position) {
+    if (this.active) this.disable();
+    if (this.ctx._baselodeViewingHelper && this.ctx._baselodeViewingHelper !== this) {
+      this.ctx._baselodeViewingHelper.disable();
+    }
+    this.axis = axis === 'y' ? 'y' : 'x';
+    this.position = Number.isFinite(position) ? position : 0;
+    this.ctx._baselodeViewingHelper = this;
+    this.savedLocalClippingEnabled = this.ctx.renderer?.localClippingEnabled || false;
+    this._saveAndUseOrthographicCamera();
+    this.plane = new THREE.Plane(axisNormal(this.axis).negate(), this.position);
+    this._addPlanes([this.plane]);
+    this.active = true;
+    return this;
+  }
+
+  setPosition(position) {
+    if (!Number.isFinite(position)) return this;
+    this.position = position;
+    if (this.plane) this.plane.constant = position;
+    return this;
+  }
+
+  step(delta) { return this.setPosition(this.position + (Number(delta) || 0)); }
+
+  disable() {
+    if (!this.active && !this.saved) return this;
+    this._removePlanes([this.plane]);
+    if (this.saved) {
+      replaceCamera(this.ctx, this.saved.camera);
+      if (this.ctx.controls) {
+        this.ctx.controls.enableRotate = this.saved.enableRotate;
+        this.ctx.controls.enabled = this.saved.controlsEnabled;
+        this.ctx.controls.target.copy(this.saved.target);
+        this.ctx.controls.update();
+      }
+      if (this.ctx.flyControls) this.ctx.flyControls.enabled = this.saved.flyEnabled;
+      this.ctx.controlMode = this.saved.controlMode;
+      this.saved = null;
+    }
+    if (this.ctx._baselodeViewingHelper === this) this.ctx._baselodeViewingHelper = null;
+    this.plane = null;
+    this.active = false;
+    return this;
+  }
+
+  dispose() { return this.disable(); }
+
+  _saveAndUseOrthographicCamera() {
+    const { camera, controls, container } = this.ctx;
+    if (!camera || !controls) return;
+    this.saved = {
+      camera,
+      enableRotate: controls.enableRotate,
+      controlsEnabled: controls.enabled,
+      target: controls.target.clone(),
+      flyEnabled: this.ctx.flyControls?.enabled || false,
+      controlMode: this.ctx.controlMode,
+    };
+    const aspect = (container?.clientWidth || 1) / (container?.clientHeight || 1);
+    const distance = camera.position.distanceTo(controls.target);
+    const height = camera.isPerspectiveCamera
+      ? 2 * distance * Math.tan(THREE.MathUtils.degToRad(camera.fov) / 2)
+      : (camera.top - camera.bottom) / (camera.zoom || 1);
+    const halfHeight = Math.max(height / 2, 1);
+    const ortho = new THREE.OrthographicCamera(-halfHeight * aspect, halfHeight * aspect, halfHeight, -halfHeight, 0.01, 10_000_000);
+    const target = controls.target.clone();
+    const direction = axisNormal(this.axis);
+    ortho.up.set(0, 0, 1);
+    ortho.position.copy(target).addScaledVector(direction, Math.max(distance, 1));
+    ortho.lookAt(target);
+    ortho.updateProjectionMatrix();
+    replaceCamera(this.ctx, ortho);
+    controls.enableRotate = false;
+    controls.enabled = true;
+    if (this.ctx.flyControls) this.ctx.flyControls.enabled = false;
+    this.ctx.controlMode = 'orbit';
+    controls.update();
+  }
+
+  _addPlanes(planes) {
+    const renderer = this.ctx.renderer;
+    if (!renderer) return;
+    renderer.clippingPlanes = [...(renderer.clippingPlanes || []), ...planes];
+    renderer.localClippingEnabled = true;
+  }
+
+  _removePlanes(planes) {
+    const renderer = this.ctx.renderer;
+    if (!renderer) return;
+    const removed = new Set(planes.filter(Boolean));
+    renderer.clippingPlanes = (renderer.clippingPlanes || []).filter((plane) => !removed.has(plane));
+    if (!renderer.clippingPlanes.length) renderer.localClippingEnabled = this.savedLocalClippingEnabled;
+  }
+}
+
+/**
+ * Movable finite slab aligned to the X or Y axis.
+ *
+ * Slider changes mutate two existing clipping planes, avoiding geometry
+ * creation, data re-rendering, and shader recompilation during interaction.
+ */
+export class SliceHelper {
+  constructor(sceneCtx) {
+    this.ctx = sceneCtx;
+    this.active = false;
+    this.axis = 'x';
+    this.position = 0;
+    this.width = 50;
+    this.planes = [];
+    this.savedLocalClippingEnabled = false;
+  }
+
+  enable(axis = 'x', position = this.position, width = this.width) {
+    if (this.active) this.disable();
+    if (this.ctx._baselodeViewingHelper && this.ctx._baselodeViewingHelper !== this) {
+      this.ctx._baselodeViewingHelper.disable();
+    }
+    this.axis = axis === 'y' ? 'y' : 'x';
+    this.position = Number.isFinite(position) ? position : 0;
+    this.width = Math.max(0.001, Number(width) || 50);
+    const normal = axisNormal(this.axis);
+    this.planes = [new THREE.Plane(), new THREE.Plane()];
+    this._updatePlanes(normal);
+    const renderer = this.ctx.renderer;
+    if (renderer) {
+      this.savedLocalClippingEnabled = renderer.localClippingEnabled;
+      renderer.clippingPlanes = [...(renderer.clippingPlanes || []), ...this.planes];
+      renderer.localClippingEnabled = true;
+    }
+    this.ctx._baselodeViewingHelper = this;
+    this.active = true;
+    return this;
+  }
+
+  setPosition(position) {
+    if (!Number.isFinite(position)) return this;
+    this.position = position;
+    if (this.planes.length) this._updatePlanes(axisNormal(this.axis));
+    return this;
+  }
+
+  setWidth(width) {
+    if (!Number.isFinite(width)) return this;
+    this.width = Math.max(0.001, width);
+    if (this.planes.length) this._updatePlanes(axisNormal(this.axis));
+    return this;
+  }
+
+  step(delta) { return this.setPosition(this.position + (Number(delta) || 0)); }
+
+  disable() {
+    const renderer = this.ctx.renderer;
+    const removed = new Set(this.planes);
+    if (renderer) {
+      renderer.clippingPlanes = (renderer.clippingPlanes || []).filter((plane) => !removed.has(plane));
+      if (!renderer.clippingPlanes.length) renderer.localClippingEnabled = this.savedLocalClippingEnabled;
+    }
+    if (this.ctx._baselodeViewingHelper === this) this.ctx._baselodeViewingHelper = null;
+    this.planes = [];
+    this.active = false;
+    return this;
+  }
+
+  dispose() { return this.disable(); }
+
+  _updatePlanes(normal) {
+    const halfWidth = this.width / 2;
+    this.planes[0].set(normal, -(this.position - halfWidth));
+    this.planes[1].set(normal.clone().negate(), this.position + halfWidth);
+  }
+}

--- a/javascript/packages/baselode/src/viz/sectionSliceHelpers.js
+++ b/javascript/packages/baselode/src/viz/sectionSliceHelpers.js
@@ -34,7 +34,7 @@ export class SectionHelper {
     this.plane = null;
     this.saved = null;
     this.savedLocalClippingEnabled = false;
-    this.sectionTarget = null;
+    this.sectionAxisPosition = 0;
     this.sectionCameraDistance = 1;
   }
 
@@ -60,7 +60,7 @@ export class SectionHelper {
   setPosition(position) {
     if (!Number.isFinite(position)) return this;
     this.position = position;
-    if (this.plane) this.plane.constant = position;
+    if (this.plane) this.plane.constant = -position;
     this._setSectionViewPosition();
     return this;
   }
@@ -84,7 +84,6 @@ export class SectionHelper {
     }
     if (this.ctx._baselodeViewingHelper === this) this.ctx._baselodeViewingHelper = null;
     this.plane = null;
-    this.sectionTarget = null;
     this.active = false;
     return this;
   }
@@ -111,7 +110,7 @@ export class SectionHelper {
     const ortho = new THREE.OrthographicCamera(-halfHeight * aspect, halfHeight * aspect, halfHeight, -halfHeight, 0.01, 10_000_000);
     const target = controls.target.clone();
     const direction = axisNormal(this.axis);
-    this.sectionTarget = target.clone();
+    this.sectionAxisPosition = target[this.axis];
     this.sectionCameraDistance = Math.max(distance, 1);
     ortho.up.set(0, 0, 1);
     ortho.position.copy(target).addScaledVector(direction, -this.sectionCameraDistance);
@@ -127,12 +126,12 @@ export class SectionHelper {
 
   _setSectionViewPosition() {
     const { camera, controls } = this.ctx;
-    if (!camera?.isOrthographicCamera || !controls || !this.sectionTarget) return;
-    this.sectionTarget[this.axis] = this.position;
-    const direction = axisNormal(this.axis);
-    controls.target.copy(this.sectionTarget);
-    camera.position.copy(this.sectionTarget).addScaledVector(direction, -this.sectionCameraDistance);
-    camera.lookAt(this.sectionTarget);
+    if (!camera?.isOrthographicCamera || !controls) return;
+    const delta = this.position - this.sectionAxisPosition;
+    controls.target[this.axis] += delta;
+    camera.position[this.axis] += delta;
+    this.sectionAxisPosition = this.position;
+    camera.lookAt(controls.target);
     controls.update();
   }
 

--- a/javascript/packages/baselode/tests/sectionSliceHelpers.test.js
+++ b/javascript/packages/baselode/tests/sectionSliceHelpers.test.js
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2026 Darkmine Pty Ltd
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+import * as THREE from 'three';
+import { describe, expect, it } from 'vitest';
+import { SectionHelper, SliceHelper } from '../src/viz/sectionSliceHelpers.js';
+
+function makeContext() {
+  const camera = new THREE.PerspectiveCamera(40, 2, 0.1, 10000);
+  camera.position.set(100, 100, 100);
+  const externalPlane = new THREE.Plane(new THREE.Vector3(0, 0, 1), 5);
+  return {
+    camera,
+    container: { clientWidth: 800, clientHeight: 400 },
+    renderer: { clippingPlanes: [externalPlane], localClippingEnabled: false },
+    controls: { object: camera, target: new THREE.Vector3(), enableRotate: true, enabled: true, update() {} },
+    flyControls: { object: camera, enabled: false },
+    gizmo: { camera },
+    _composer: { passes: [{ camera }] },
+    controlMode: 'orbit',
+    externalPlane,
+  };
+}
+
+describe('section and slab helpers', () => {
+  it('uses an orthographic camera for an X section and restores the host view', () => {
+    const ctx = makeContext();
+    const helper = new SectionHelper(ctx).enable('x', 25);
+
+    expect(ctx.camera.isOrthographicCamera).toBe(true);
+    expect(ctx.controls.enableRotate).toBe(false);
+    expect(ctx.renderer.clippingPlanes).toHaveLength(2);
+    helper.setPosition(30);
+    expect(helper.plane.constant).toBe(30);
+
+    helper.disable();
+    expect(ctx.camera.isPerspectiveCamera).toBe(true);
+    expect(ctx.controls.enableRotate).toBe(true);
+    expect(ctx.renderer.clippingPlanes).toEqual([ctx.externalPlane]);
+    expect(ctx.renderer.localClippingEnabled).toBe(true);
+  });
+
+  it('keeps only the finite X/Y slab and mutates its existing planes', () => {
+    const ctx = makeContext();
+    const helper = new SliceHelper(ctx).enable('y', 20, 10);
+    const [lower, upper] = helper.planes;
+
+    expect(ctx.renderer.clippingPlanes).toHaveLength(3);
+    expect(lower.distanceToPoint(new THREE.Vector3(0, 14, 0))).toBeLessThan(0);
+    expect(upper.distanceToPoint(new THREE.Vector3(0, 26, 0))).toBeLessThan(0);
+    expect(lower.distanceToPoint(new THREE.Vector3(0, 20, 0))).toBeGreaterThanOrEqual(0);
+    expect(upper.distanceToPoint(new THREE.Vector3(0, 20, 0))).toBeGreaterThanOrEqual(0);
+    helper.setPosition(40).setWidth(20);
+    expect(helper.planes[0]).toBe(lower);
+    expect(helper.planes[1]).toBe(upper);
+    expect(lower.distanceToPoint(new THREE.Vector3(0, 30, 0))).toBe(0);
+    expect(upper.distanceToPoint(new THREE.Vector3(0, 50, 0))).toBe(0);
+  });
+
+  it('makes a section and a slab mutually exclusive', () => {
+    const ctx = makeContext();
+    const section = new SectionHelper(ctx).enable('x', 0);
+    const slab = new SliceHelper(ctx).enable('x', 0, 10);
+
+    expect(section.active).toBe(false);
+    expect(slab.active).toBe(true);
+    expect(ctx.camera.isPerspectiveCamera).toBe(true);
+  });
+});

--- a/javascript/packages/baselode/tests/sectionSliceHelpers.test.js
+++ b/javascript/packages/baselode/tests/sectionSliceHelpers.test.js
@@ -33,6 +33,8 @@ describe('section and slab helpers', () => {
     expect(ctx.renderer.clippingPlanes).toHaveLength(2);
     helper.setPosition(30);
     expect(helper.plane.constant).toBe(30);
+    expect(ctx.controls.target.x).toBe(30);
+    expect(ctx.camera.position.x).toBeGreaterThan(30);
 
     helper.disable();
     expect(ctx.camera.isPerspectiveCamera).toBe(true);

--- a/javascript/packages/baselode/tests/sectionSliceHelpers.test.js
+++ b/javascript/packages/baselode/tests/sectionSliceHelpers.test.js
@@ -44,7 +44,7 @@ describe('section and slab helpers', () => {
     expect(ctx.camera.isPerspectiveCamera).toBe(true);
     expect(ctx.controls.enableRotate).toBe(true);
     expect(ctx.renderer.clippingPlanes).toEqual([ctx.externalPlane]);
-    expect(ctx.renderer.localClippingEnabled).toBe(true);
+    expect(ctx.renderer.localClippingEnabled).toBe(false);
   });
 
   it('keeps only the finite X/Y slab and mutates its existing planes', () => {

--- a/javascript/packages/baselode/tests/sectionSliceHelpers.test.js
+++ b/javascript/packages/baselode/tests/sectionSliceHelpers.test.js
@@ -34,7 +34,7 @@ describe('section and slab helpers', () => {
     helper.setPosition(30);
     expect(helper.plane.constant).toBe(30);
     expect(ctx.controls.target.x).toBe(30);
-    expect(ctx.camera.position.x).toBeGreaterThan(30);
+    expect(ctx.camera.position.x).toBeLessThan(30);
 
     helper.disable();
     expect(ctx.camera.isPerspectiveCamera).toBe(true);

--- a/javascript/packages/baselode/tests/sectionSliceHelpers.test.js
+++ b/javascript/packages/baselode/tests/sectionSliceHelpers.test.js
@@ -31,10 +31,14 @@ describe('section and slab helpers', () => {
     expect(ctx.camera.isOrthographicCamera).toBe(true);
     expect(ctx.controls.enableRotate).toBe(false);
     expect(ctx.renderer.clippingPlanes).toHaveLength(2);
+    ctx.controls.target.y = 17;
+    ctx.camera.position.y = 17;
     helper.setPosition(30);
-    expect(helper.plane.constant).toBe(30);
+    expect(helper.plane.constant).toBe(-30);
     expect(ctx.controls.target.x).toBe(30);
     expect(ctx.camera.position.x).toBeLessThan(30);
+    expect(ctx.controls.target.y).toBe(17);
+    expect(ctx.camera.position.y).toBe(17);
 
     helper.disable();
     expect(ctx.camera.isPerspectiveCamera).toBe(true);


### PR DESCRIPTION
## Summary
- add public SectionHelper for X/Y orthographic cross-sections
- add public SliceHelper for movable finite X/Y slabs
- expose controls in the Block Model and Drillhole demos
- preserve host clipping planes and camera/control state; slider updates mutate existing clipping planes

## Scope
Implements TRK-384. Freehand knife-line slicing is explicitly deferred to TRK-385.

## Verification
- npm run verify (697 tests)
- npm run build in demo-viewer-react/app