### PR TITLE
TRK-389: add responsive dig block planner

### DIFF
--- a/.features/TRK-389-responsive-dig-blocks.md
+++ b/.features/TRK-389-responsive-dig-blocks.md
@@ -14,9 +14,10 @@ excavator entry face.
   from north; cross is the entry-face direction.
 - Divide the blast into forward bands sized from target tonnes and the desired
   face-width/depth ratio.
-- Use dynamic programming inside each band to choose contiguous cross-direction
-  cuts. Score tonnes error, tonnes-weighted Fe error, face geometry, geology
-  mixing and hardness variation.
+- Use a bounded-transition shortest-path search inside each band to choose
+  contiguous cross-direction cuts. Score tonnes error, tonnes-weighted Fe
+  error, face geometry, geology mixing and hardness variation. The fixed
+  candidate budget keeps solve cost approximately linear in source-cell count.
 - Intersect every direction-aligned rectangle with the blast polygon and return
   polygons, cell assignments, block physicals and aggregate score metrics.
 - Keep the solver pure and independent of React/Three.js.

--- a/.features/TRK-389-responsive-dig-blocks.md
+++ b/.features/TRK-389-responsive-dig-blocks.md
@@ -1,0 +1,48 @@
+# TRK-389 — Responsive dig-block optimisation
+
+## Intent
+
+Add a reusable, deterministic first-pass dig-block partitioner and a 2D demo
+that recomputes while planning controls move. The solve targets tonnes and Fe
+head grade while favouring contiguous, direction-aligned blocks with a wide
+excavator entry face.
+
+## Algorithm
+
+- Select block-model cells whose centres fall inside one convex blast polygon.
+- Rotate centres into mining coordinates: forward is the bearing clockwise
+  from north; cross is the entry-face direction.
+- Divide the blast into forward bands sized from target tonnes and the desired
+  face-width/depth ratio.
+- Use dynamic programming inside each band to choose contiguous cross-direction
+  cuts. Score tonnes error, tonnes-weighted Fe error, face geometry, geology
+  mixing and hardness variation.
+- Intersect every direction-aligned rectangle with the blast polygon and return
+  polygons, cell assignments, block physicals and aggregate score metrics.
+- Keep the solver pure and independent of React/Three.js.
+
+## Source-data decision
+
+MineLib Newman1 was evaluated as the user-suggested example. Its block file has
+`x`, `y`, `z`, type, grade and tonnes, but its own documentation says the block
+size and metal type are unknown. The download is also intended for academic use
+rather than redistribution. Baselode therefore documents the mapping but does
+not bundle or silently invent the missing physical dimensions; the demo uses a
+clearly labelled, redistributable synthetic iron-ore bench instead.
+
+## Demo
+
+- Generate a deterministic synthetic, single-bench iron-ore block model and an
+  approximately 200 kt convex blast outline.
+- Show grade-coloured source cells, generated dig polygons, dig direction,
+  labels, selection details and live outcome cards in an SVG plan.
+- Recompute immediately for target tonnes, target Fe, direction, objective
+  weights, face/depth ratio and minimum face width controls.
+
+## Verification
+
+- Unit-test deterministic output, assignment coverage/uniqueness, target
+  physicals, polygon containment, direction response and invalid input.
+- Run the JavaScript package verification and demo production build.
+- Manually exercise the new route at desktop width and confirm responsive
+  updates and readable selection/summary feedback.

--- a/.features/TRK-389-responsive-dig-blocks.md
+++ b/.features/TRK-389-responsive-dig-blocks.md
@@ -40,6 +40,8 @@ clearly labelled, redistributable synthetic iron-ore bench instead.
 - Classify generated blocks from their tonnes-weighted head grade: red at or
   above the target/cut-off grade and blue below it, with textual legend and
   selection details so the result does not rely on colour alone.
+- Provide red/blue and outline-only display modes so the source-cell grade
+  heatmap can be inspected without losing dig-block boundaries or selection.
 - Recompute immediately for target tonnes, target Fe, direction, objective
   weights, face/depth ratio and minimum face width controls.
 

--- a/.features/TRK-389-responsive-dig-blocks.md
+++ b/.features/TRK-389-responsive-dig-blocks.md
@@ -9,7 +9,10 @@ excavator entry face.
 
 ## Algorithm
 
-- Select block-model cells whose centres fall inside one convex blast polygon.
+- Intersect every axis-aligned source-cell footprint with the convex blast and
+  generated dig polygons. Prorate tonnes and physicals by exact area fraction;
+  multiply by `dz` for vertical-prism intersection volume. Preserve fractional
+  assignments when one cell crosses multiple dig-block boundaries.
 - Rotate centres into mining coordinates: forward is the bearing clockwise
   from north; cross is the entry-face direction.
 - Divide the blast into forward bands sized from target tonnes and the desired
@@ -47,8 +50,9 @@ clearly labelled, redistributable synthetic iron-ore bench instead.
 
 ## Verification
 
-- Unit-test deterministic output, assignment coverage/uniqueness, target
-  physicals, polygon containment, direction response and invalid input.
+- Unit-test deterministic output, fractional assignment conservation, exact
+  boundary area/volume/tonnes/grade, target physicals, direction response,
+  large shallow benches and invalid input.
 - Run the JavaScript package verification and demo production build.
 - Manually exercise the new route at desktop width and confirm responsive
   updates and readable selection/summary feedback.

--- a/.features/TRK-389-responsive-dig-blocks.md
+++ b/.features/TRK-389-responsive-dig-blocks.md
@@ -37,6 +37,9 @@ clearly labelled, redistributable synthetic iron-ore bench instead.
   approximately 200 kt convex blast outline.
 - Show grade-coloured source cells, generated dig polygons, dig direction,
   labels, selection details and live outcome cards in an SVG plan.
+- Classify generated blocks from their tonnes-weighted head grade: red at or
+  above the target/cut-off grade and blue below it, with textual legend and
+  selection details so the result does not rely on colour alone.
 - Recompute immediately for target tonnes, target Fe, direction, objective
   weights, face/depth ratio and minimum face width controls.
 

--- a/demo-viewer-react/app/src/App.jsx
+++ b/demo-viewer-react/app/src/App.jsx
@@ -11,6 +11,7 @@ import Drillhole2D from './pages/Drillhole2D';
 import StripLogGallery from './pages/StripLogGallery';
 import BlockModel from './pages/BlockModel';
 import PolygonBlocks from './pages/PolygonBlocks';
+import DigBlockPlanner from './pages/DigBlockPlanner';
 import Attribution from './pages/Attribution';
 import CorePhoto from './pages/CorePhoto';
 import ChatHelpers from './pages/ChatHelpers';
@@ -31,6 +32,7 @@ function App() {
         <Route path="/strip-log-gallery" element={<StripLogGallery />} />
         <Route path="/block-model" element={<BlockModel />} />
         <Route path="/polygon-blocks" element={<PolygonBlocks />} />
+        <Route path="/dig-block-planner" element={<DigBlockPlanner />} />
         <Route path="/attribution" element={<Attribution />} />
         <Route path="/core-photo" element={<CorePhoto />} />
         <Route path="/chat-helpers" element={<ChatHelpers />} />

--- a/demo-viewer-react/app/src/components/Sidebar.jsx
+++ b/demo-viewer-react/app/src/components/Sidebar.jsx
@@ -20,6 +20,7 @@ function Sidebar() {
     { path: '/strip-log-gallery', label: 'Strip Log Gallery' },
     { path: '/block-model', label: 'Block Models' },
     { path: '/polygon-blocks', label: 'Polygon Blocks' },
+    { path: '/dig-block-planner', label: 'Dig Block Planner' },
     { path: '/core-photo', label: 'Core Photos' },
     { path: '/analytics', label: 'Analytics Plots' },
     { path: '/idw-volume', label: 'IDW Volume' },

--- a/demo-viewer-react/app/src/pages/DigBlockPlanner.css
+++ b/demo-viewer-react/app/src/pages/DigBlockPlanner.css
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2026 Darkmine Pty Ltd
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+.dig-planner {
+  --dig-ink: #172033;
+  --dig-muted: #657086;
+  --dig-border: #dbe1ea;
+  min-height: 100vh;
+  margin-left: 220px;
+  padding: 28px;
+  overflow: auto;
+  background: #eef1f5;
+  color: var(--dig-ink);
+}
+
+.dig-header { display: flex; align-items: flex-start; justify-content: space-between; gap: 24px; max-width: 1500px; margin: 0 auto 20px; }
+.dig-header h1 { margin: 2px 0 5px; font-size: clamp(28px, 3vw, 42px); letter-spacing: -0.04em; }
+.dig-header p { margin: 0; color: var(--dig-muted); }
+.dig-eyebrow { color: #9a3412 !important; font-size: 12px; font-weight: 800; letter-spacing: .1em; text-transform: uppercase; }
+.dig-live-pill { flex: 0 0 auto; margin-top: 8px; padding: 9px 13px; border: 1px solid #bbf7d0; border-radius: 999px; background: #f0fdf4; color: #166534; font-size: 12px; font-weight: 700; }
+.dig-live-pill span { display: inline-block; width: 7px; height: 7px; margin-right: 7px; border-radius: 50%; background: #22c55e; box-shadow: 0 0 0 4px #dcfce7; }
+
+.dig-metrics { display: grid; grid-template-columns: repeat(5, minmax(130px, 1fr)); gap: 10px; max-width: 1500px; margin: 0 auto 14px; }
+.dig-metrics > div { padding: 13px 15px; border: 1px solid var(--dig-border); border-radius: 12px; background: #fff; }
+.dig-metrics span, .dig-selection span { display: block; color: var(--dig-muted); font-size: 11px; font-weight: 700; letter-spacing: .03em; text-transform: uppercase; }
+.dig-metrics strong { display: block; margin-top: 4px; font-size: 20px; }
+
+.dig-workspace { display: grid; grid-template-columns: minmax(560px, 1fr) 340px; gap: 14px; max-width: 1500px; margin: 0 auto; align-items: start; }
+.dig-canvas-card, .dig-controls-card { border: 1px solid var(--dig-border); border-radius: 16px; background: #fff; box-shadow: 0 8px 28px rgba(31, 41, 55, .06); }
+.dig-canvas-card { min-width: 0; overflow: hidden; }
+.dig-canvas-toolbar { display: flex; align-items: center; justify-content: space-between; gap: 16px; padding: 13px 17px; border-bottom: 1px solid var(--dig-border); font-size: 13px; }
+.dig-canvas-toolbar span { color: var(--dig-muted); }
+.dig-canvas-toolbar label { display: flex; align-items: center; gap: 7px; white-space: nowrap; color: var(--dig-muted); }
+.dig-canvas-wrap { position: relative; min-height: 520px; padding: 18px; background: #e6e9ed; }
+.dig-canvas { display: block; width: 100%; height: min(61vh, 690px); min-height: 485px; border-radius: 10px; background: #f8fafc; }
+.dig-blast-fill { fill: #e2e8f0; }
+.dig-source-cell { stroke: rgba(255,255,255,.55); stroke-width: .32; transition: opacity 90ms linear; }
+.dig-result-block { stroke: #172554; stroke-width: 1.25; vector-effect: non-scaling-stroke; cursor: pointer; transition: fill-opacity 80ms linear; }
+.dig-result-block:hover, .dig-result-block.selected { stroke: #fff; stroke-width: 3; filter: url(#selected-glow); }
+.dig-blast-outline { fill: none; stroke: #111827; stroke-width: 2.4; vector-effect: non-scaling-stroke; pointer-events: none; }
+.dig-block-label text { fill: #111827; text-anchor: middle; font-size: 3.3px; font-weight: 800; paint-order: stroke; stroke: rgba(255,255,255,.88); stroke-width: 1.2px; }
+.dig-block-label text + text { font-size: 2.6px; font-weight: 650; }
+.dig-direction-line { stroke: #172554; stroke-width: 2.4; stroke-dasharray: 4 2; vector-effect: non-scaling-stroke; pointer-events: none; }
+.dig-direction-label, .dig-north { fill: #172554; font-size: 4px; font-weight: 900; text-anchor: middle; paint-order: stroke; stroke: white; stroke-width: 1px; }
+.dig-legend { position: absolute; left: 29px; bottom: 28px; display: flex; gap: 12px; padding: 8px 10px; border: 1px solid rgba(203,213,225,.8); border-radius: 8px; background: rgba(255,255,255,.9); font-size: 11px; color: var(--dig-muted); backdrop-filter: blur(5px); }
+.dig-legend span { display: flex; align-items: center; gap: 5px; }
+.dig-legend i { width: 12px; height: 8px; display: inline-block; border-radius: 2px; }
+.grade-low { background: hsl(18 68% 58%); }
+.grade-high { background: hsl(123 68% 46%); }
+.block-line { border: 2px solid #172554; background: transparent; }
+
+.dig-selection { min-height: 66px; display: flex; align-items: center; gap: 25px; padding: 11px 17px; border-top: 1px solid var(--dig-border); }
+.dig-selection > div { min-width: 90px; }
+.dig-selection strong { display: block; margin-top: 3px; font-size: 14px; }
+.dig-selection p { margin: 0; color: var(--dig-muted); font-size: 13px; }
+.dig-selection button, .dig-controls-heading button { margin-left: auto; border: 1px solid var(--dig-border); border-radius: 7px; padding: 6px 9px; background: #fff; color: var(--dig-muted); cursor: pointer; }
+
+.dig-controls-card { overflow: hidden; }
+.dig-controls-heading { display: flex; justify-content: space-between; gap: 12px; padding: 16px 18px; border-bottom: 1px solid var(--dig-border); }
+.dig-controls-heading p { margin: 0; color: #9a3412; font-size: 10px; font-weight: 800; letter-spacing: .08em; text-transform: uppercase; }
+.dig-controls-heading h2 { margin: 3px 0 0; font-size: 18px; }
+.dig-control-group { padding: 15px 18px 6px; border-bottom: 1px solid #edf0f4; }
+.dig-control-group h3 { margin: 0 0 13px; font-size: 12px; letter-spacing: .04em; text-transform: uppercase; }
+.dig-control { display: block; margin-bottom: 14px; }
+.dig-control-label { display: flex; justify-content: space-between; gap: 12px; margin-bottom: 5px; font-size: 12px; color: var(--dig-muted); }
+.dig-control output { color: var(--dig-ink); font-variant-numeric: tabular-nums; font-weight: 750; }
+.dig-control input { width: 100%; accent-color: #9a3412; cursor: ew-resize; }
+.dig-method-note { margin: 15px; padding: 12px; border-radius: 10px; background: #f7f3ee; font-size: 11px; line-height: 1.5; }
+.dig-method-note p { margin: 4px 0 0; color: var(--dig-muted); }
+
+:root.dark .dig-planner { --dig-ink: #e5e7eb; --dig-muted: #9ca3af; --dig-border: #374151; background: #111318; }
+:root.dark .dig-canvas-card, :root.dark .dig-controls-card, :root.dark .dig-metrics > div { background: #1c2028; }
+:root.dark .dig-canvas-toolbar, :root.dark .dig-controls-heading { background: #1c2028; }
+:root.dark .dig-selection button, :root.dark .dig-controls-heading button { background: #242a34; color: #d1d5db; }
+:root.dark .dig-method-note { background: #29251f; }
+
+@media (max-width: 1050px) {
+  .dig-workspace { grid-template-columns: 1fr; }
+  .dig-controls-card { display: grid; grid-template-columns: repeat(3, 1fr); }
+  .dig-controls-heading, .dig-method-note { grid-column: 1 / -1; }
+  .dig-control-group { border-right: 1px solid var(--dig-border); }
+}
+
+@media (max-width: 760px) {
+  .dig-planner { margin-left: 0; padding: 16px; padding-top: 78px; }
+  .dig-header { display: block; }
+  .dig-live-pill { display: inline-block; }
+  .dig-metrics { grid-template-columns: repeat(2, 1fr); }
+  .dig-workspace { display: block; }
+  .dig-canvas-card { margin-bottom: 14px; }
+  .dig-canvas-wrap { min-height: 390px; padding: 8px; }
+  .dig-canvas { min-height: 370px; }
+  .dig-controls-card { display: block; }
+  .dig-selection { overflow-x: auto; }
+}

--- a/demo-viewer-react/app/src/pages/DigBlockPlanner.css
+++ b/demo-viewer-react/app/src/pages/DigBlockPlanner.css
@@ -33,11 +33,16 @@
 .dig-canvas-toolbar { display: flex; align-items: center; justify-content: space-between; gap: 16px; padding: 13px 17px; border-bottom: 1px solid var(--dig-border); font-size: 13px; }
 .dig-canvas-toolbar span { color: var(--dig-muted); }
 .dig-canvas-toolbar label { display: flex; align-items: center; gap: 7px; white-space: nowrap; color: var(--dig-muted); }
+.dig-canvas-actions { display: flex; align-items: center; gap: 12px; }
+.dig-display-toggle { display: flex; padding: 2px; border: 1px solid var(--dig-border); border-radius: 8px; background: #f1f5f9; }
+.dig-display-toggle button { border: 0; border-radius: 6px; padding: 5px 8px; background: transparent; color: var(--dig-muted); font: inherit; font-size: 11px; cursor: pointer; }
+.dig-display-toggle button.active { background: #fff; color: var(--dig-ink); box-shadow: 0 1px 3px rgba(15,23,42,.16); }
 .dig-canvas-wrap { position: relative; min-height: 520px; padding: 18px; background: #e6e9ed; }
 .dig-canvas { display: block; width: 100%; height: min(61vh, 690px); min-height: 485px; border-radius: 10px; background: #f8fafc; }
 .dig-blast-fill { fill: #e2e8f0; }
 .dig-source-cell { stroke: rgba(255,255,255,.55); stroke-width: .32; transition: opacity 90ms linear; }
 .dig-result-block { stroke: #172554; stroke-width: 1.25; vector-effect: non-scaling-stroke; cursor: pointer; transition: fill 80ms linear, fill-opacity 80ms linear; }
+.dig-result-block.outline-only { pointer-events: all; }
 .dig-result-block:hover, .dig-result-block.selected { stroke: #fff; stroke-width: 3; filter: url(#selected-glow); }
 .dig-blast-outline { fill: none; stroke: #111827; stroke-width: 2.4; vector-effect: non-scaling-stroke; pointer-events: none; }
 .dig-block-label text { fill: #111827; text-anchor: middle; font-size: 3.3px; font-weight: 800; paint-order: stroke; stroke: rgba(255,255,255,.88); stroke-width: 1.2px; }
@@ -49,6 +54,7 @@
 .dig-legend i { width: 12px; height: 8px; display: inline-block; border-radius: 2px; }
 .block-above { background: #dc2626; }
 .block-below { background: #2563eb; }
+.block-outline { border: 2px solid #172554; background: transparent; }
 .cell-grade-scale { background: linear-gradient(90deg, hsl(18 68% 58%), hsl(123 68% 46%)); }
 .cutoff-above { color: #b91c1c; }
 .cutoff-below { color: #1d4ed8; }
@@ -76,6 +82,8 @@
 :root.dark .dig-canvas-card, :root.dark .dig-controls-card, :root.dark .dig-metrics > div { background: #1c2028; }
 :root.dark .dig-canvas-toolbar, :root.dark .dig-controls-heading { background: #1c2028; }
 :root.dark .dig-selection button, :root.dark .dig-controls-heading button { background: #242a34; color: #d1d5db; }
+:root.dark .dig-display-toggle { background: #111827; }
+:root.dark .dig-display-toggle button.active { background: #374151; }
 :root.dark .dig-method-note { background: #29251f; }
 
 @media (max-width: 1050px) {
@@ -93,6 +101,8 @@
   .dig-workspace { display: block; }
   .dig-canvas-card { margin-bottom: 14px; }
   .dig-canvas-wrap { min-height: 390px; padding: 8px; }
+  .dig-canvas-toolbar { align-items: flex-start; }
+  .dig-canvas-actions { align-items: flex-end; flex-direction: column; }
   .dig-canvas { min-height: 370px; }
   .dig-controls-card { display: block; }
   .dig-selection { overflow-x: auto; }

--- a/demo-viewer-react/app/src/pages/DigBlockPlanner.css
+++ b/demo-viewer-react/app/src/pages/DigBlockPlanner.css
@@ -37,7 +37,7 @@
 .dig-canvas { display: block; width: 100%; height: min(61vh, 690px); min-height: 485px; border-radius: 10px; background: #f8fafc; }
 .dig-blast-fill { fill: #e2e8f0; }
 .dig-source-cell { stroke: rgba(255,255,255,.55); stroke-width: .32; transition: opacity 90ms linear; }
-.dig-result-block { stroke: #172554; stroke-width: 1.25; vector-effect: non-scaling-stroke; cursor: pointer; transition: fill-opacity 80ms linear; }
+.dig-result-block { stroke: #172554; stroke-width: 1.25; vector-effect: non-scaling-stroke; cursor: pointer; transition: fill 80ms linear, fill-opacity 80ms linear; }
 .dig-result-block:hover, .dig-result-block.selected { stroke: #fff; stroke-width: 3; filter: url(#selected-glow); }
 .dig-blast-outline { fill: none; stroke: #111827; stroke-width: 2.4; vector-effect: non-scaling-stroke; pointer-events: none; }
 .dig-block-label text { fill: #111827; text-anchor: middle; font-size: 3.3px; font-weight: 800; paint-order: stroke; stroke: rgba(255,255,255,.88); stroke-width: 1.2px; }
@@ -47,9 +47,11 @@
 .dig-legend { position: absolute; left: 29px; bottom: 28px; display: flex; gap: 12px; padding: 8px 10px; border: 1px solid rgba(203,213,225,.8); border-radius: 8px; background: rgba(255,255,255,.9); font-size: 11px; color: var(--dig-muted); backdrop-filter: blur(5px); }
 .dig-legend span { display: flex; align-items: center; gap: 5px; }
 .dig-legend i { width: 12px; height: 8px; display: inline-block; border-radius: 2px; }
-.grade-low { background: hsl(18 68% 58%); }
-.grade-high { background: hsl(123 68% 46%); }
-.block-line { border: 2px solid #172554; background: transparent; }
+.block-above { background: #dc2626; }
+.block-below { background: #2563eb; }
+.cell-grade-scale { background: linear-gradient(90deg, hsl(18 68% 58%), hsl(123 68% 46%)); }
+.cutoff-above { color: #b91c1c; }
+.cutoff-below { color: #1d4ed8; }
 
 .dig-selection { min-height: 66px; display: flex; align-items: center; gap: 25px; padding: 11px 17px; border-top: 1px solid var(--dig-border); }
 .dig-selection > div { min-width: 90px; }

--- a/demo-viewer-react/app/src/pages/DigBlockPlanner.jsx
+++ b/demo-viewer-react/app/src/pages/DigBlockPlanner.jsx
@@ -1,0 +1,238 @@
+/*
+ * Copyright (C) 2026 Darkmine Pty Ltd
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { useMemo, useState } from 'react';
+import { createSyntheticDigBlockModel, digDirectionAxes, optimizeDigBlocks } from 'baselode';
+import './DigBlockPlanner.css';
+
+const DEFAULT_CONTROLS = {
+  digDirectionDeg: 20,
+  targetTonnes: 10_000,
+  targetGrade: 57,
+  targetFaceToDepthRatio: 1.8,
+  minFaceWidth: 20,
+  weights: { tonnes: 1, grade: 0.8, shape: 0.65, material: 0.15, hardness: 0.1 },
+};
+
+const BLOCK_COLOURS = ['#8bd3c7', '#f2c14e', '#ef8354', '#83a6ed', '#b8de6f', '#d4a5ff', '#ff9fbd'];
+
+function formatKt(tonnes) {
+  return `${(tonnes / 1000).toFixed(tonnes >= 100_000 ? 0 : 1)} kt`;
+}
+
+function gradeColour(grade) {
+  const amount = Math.max(0, Math.min(1, (grade - 50) / 12));
+  const hue = 18 + amount * 105;
+  return `hsl(${hue} 68% ${58 - amount * 12}%)`;
+}
+
+function Control({ label, value, min, max, step, unit, onChange }) {
+  return (
+    <label className="dig-control">
+      <span className="dig-control-label">
+        <span>{label}</span>
+        <output>{Number(value).toFixed(step < 1 ? 1 : 0)}{unit}</output>
+      </span>
+      <input
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={(event) => onChange(Number(event.target.value))}
+      />
+    </label>
+  );
+}
+
+function DigBlockPlanner() {
+  const source = useMemo(() => createSyntheticDigBlockModel(), []);
+  const [controls, setControls] = useState(DEFAULT_CONTROLS);
+  const [selectedId, setSelectedId] = useState(null);
+  const [showSource, setShowSource] = useState(true);
+
+  const solution = useMemo(() => {
+    const started = performance.now();
+    const result = optimizeDigBlocks(source.cells, source.blastPolygon, controls);
+    return { ...result, solveMs: performance.now() - started };
+  }, [controls, source]);
+
+  const selected = solution.blocks.find((block) => block.id === selectedId) || null;
+  const selectedCells = new Set(selected?.cellIds || []);
+  const allPoints = source.blastPolygon;
+  const minX = Math.min(...allPoints.map(([x]) => x));
+  const maxX = Math.max(...allPoints.map(([x]) => x));
+  const minY = Math.min(...allPoints.map(([, y]) => y));
+  const maxY = Math.max(...allPoints.map(([, y]) => y));
+  const pad = 12;
+  const svgY = (y) => minY + maxY - y;
+  const polygonPoints = (ring) => ring.map(([x, y]) => `${x},${svgY(y)}`).join(' ');
+  const axes = digDirectionAxes(controls.digDirectionDeg);
+  const blastCentre = {
+    x: allPoints.reduce((sum, [x]) => sum + x, 0) / allPoints.length,
+    y: allPoints.reduce((sum, [, y]) => sum + y, 0) / allPoints.length,
+  };
+  const arrowStart = { x: blastCentre.x - axes.forward.x * 26, y: blastCentre.y - axes.forward.y * 26 };
+  const arrowEnd = { x: blastCentre.x + axes.forward.x * 26, y: blastCentre.y + axes.forward.y * 26 };
+
+  const update = (key, value) => setControls((current) => ({ ...current, [key]: value }));
+  const updateWeight = (key, value) => setControls((current) => ({
+    ...current,
+    weights: { ...current.weights, [key]: value },
+  }));
+
+  return (
+    <div className="dig-planner">
+      <header className="dig-header">
+        <div>
+          <p className="dig-eyebrow">Interactive grade control concept</p>
+          <h1>Dig Block Planner</h1>
+          <p>Subdivide a blast into practical mining shapes while balancing tonnes, grade and dig direction.</p>
+        </div>
+        <div className="dig-live-pill"><span /> Live solution · {solution.solveMs.toFixed(1)} ms</div>
+      </header>
+
+      <section className="dig-metrics" aria-label="Solution summary">
+        <div><span>Blast tonnes</span><strong>{formatKt(solution.metrics.totalTonnes)}</strong></div>
+        <div><span>Dig blocks</span><strong>{solution.metrics.blockCount}</strong></div>
+        <div><span>Average block</span><strong>{formatKt(solution.metrics.totalTonnes / solution.metrics.blockCount)}</strong></div>
+        <div><span>Head grade</span><strong>{solution.metrics.weightedGrade.toFixed(1)}% Fe</strong></div>
+        <div><span>Mean grade miss</span><strong>±{solution.metrics.meanGradeError.toFixed(1)}%</strong></div>
+      </section>
+
+      <div className="dig-workspace">
+        <main className="dig-canvas-card">
+          <div className="dig-canvas-toolbar">
+            <div>
+              <strong>Synthetic iron-ore bench</strong>
+              <span> · {source.cells.length} cells · 10 × 10 × 5 m</span>
+            </div>
+            <label><input type="checkbox" checked={showSource} onChange={(event) => setShowSource(event.target.checked)} /> Grade cells</label>
+          </div>
+
+          <div className="dig-canvas-wrap">
+            <svg
+              className="dig-canvas"
+              viewBox={`${minX - pad} ${minY - pad} ${maxX - minX + pad * 2} ${maxY - minY + pad * 2}`}
+              role="img"
+              aria-label="Plan view of a blast subdivided into generated dig blocks"
+            >
+              <defs>
+                <marker id="dig-arrow" markerWidth="6" markerHeight="6" refX="5" refY="3" orient="auto">
+                  <path d="M0,0 L6,3 L0,6 Z" fill="#172554" />
+                </marker>
+                <filter id="selected-glow" x="-30%" y="-30%" width="160%" height="160%">
+                  <feDropShadow dx="0" dy="0" stdDeviation="2" floodColor="#ffffff" floodOpacity="1" />
+                </filter>
+              </defs>
+
+              <polygon className="dig-blast-fill" points={polygonPoints(source.blastPolygon)} />
+              {showSource && source.cells.map((cell) => (
+                <rect
+                  key={cell.id}
+                  x={cell.x - cell.dx / 2}
+                  y={svgY(cell.y + cell.dy / 2)}
+                  width={cell.dx}
+                  height={cell.dy}
+                  fill={gradeColour(cell.fe)}
+                  opacity={selected && !selectedCells.has(cell.id) ? 0.14 : 0.72}
+                  className="dig-source-cell"
+                >
+                  <title>{cell.id}: {cell.fe.toFixed(1)}% Fe · {formatKt(cell.tonnes)} · {cell.geology}</title>
+                </rect>
+              ))}
+
+              {solution.blocks.map((block, index) => (
+                <polygon
+                  key={block.id}
+                  points={polygonPoints(block.polygon)}
+                  fill={BLOCK_COLOURS[index % BLOCK_COLOURS.length]}
+                  fillOpacity={selected ? (selected.id === block.id ? 0.55 : 0.08) : 0.18}
+                  className={`dig-result-block${selected?.id === block.id ? ' selected' : ''}`}
+                  onClick={() => setSelectedId((current) => current === block.id ? null : block.id)}
+                >
+                  <title>{block.id}: {formatKt(block.tonnes)} · {block.headGrade.toFixed(1)}% Fe</title>
+                </polygon>
+              ))}
+
+              {solution.blocks.map((block) => (
+                <g key={`${block.id}-label`} className="dig-block-label" pointerEvents="none">
+                  <text x={block.centroid.x} y={svgY(block.centroid.y) - 1.7}>{block.id.replace('DIG-', '')}</text>
+                  <text x={block.centroid.x} y={svgY(block.centroid.y) + 3.2}>{(block.tonnes / 1000).toFixed(1)}kt</text>
+                </g>
+              ))}
+
+              <polygon className="dig-blast-outline" points={polygonPoints(source.blastPolygon)} />
+              <line
+                className="dig-direction-line"
+                x1={arrowStart.x}
+                y1={svgY(arrowStart.y)}
+                x2={arrowEnd.x}
+                y2={svgY(arrowEnd.y)}
+                markerEnd="url(#dig-arrow)"
+              />
+              <text className="dig-direction-label" x={arrowStart.x} y={svgY(arrowStart.y) + 7}>DIG</text>
+              <text className="dig-north" x={maxX - 3} y={svgY(maxY - 4)}>N ↑</text>
+            </svg>
+
+            <div className="dig-legend">
+              <span><i className="grade-low" /> Lower Fe</span>
+              <span><i className="grade-high" /> Higher Fe</span>
+              <span><i className="block-line" /> Dig block</span>
+            </div>
+          </div>
+
+          <div className="dig-selection" aria-live="polite">
+            {selected ? (
+              <>
+                <div><span>Selected</span><strong>{selected.id}</strong></div>
+                <div><span>Tonnes</span><strong>{formatKt(selected.tonnes)}</strong></div>
+                <div><span>Head grade</span><strong>{selected.headGrade.toFixed(1)}% Fe</strong></div>
+                <div><span>Shape</span><strong>{selected.faceWidth.toFixed(0)} × {selected.advanceDepth.toFixed(0)} m</strong></div>
+                <div><span>Material</span><strong>{selected.dominantGeology}</strong></div>
+                <button type="button" onClick={() => setSelectedId(null)}>Clear</button>
+              </>
+            ) : <p>Select a generated block to inspect its tonnes, blended grade and digging shape.</p>}
+          </div>
+        </main>
+
+        <aside className="dig-controls-card">
+          <div className="dig-controls-heading">
+            <div><p>Design controls</p><h2>Shape the block-out</h2></div>
+            <button type="button" onClick={() => { setControls(DEFAULT_CONTROLS); setSelectedId(null); }}>Reset</button>
+          </div>
+
+          <div className="dig-control-group">
+            <h3>Production targets</h3>
+            <Control label="Target tonnes" value={controls.targetTonnes / 1000} min={6} max={20} step={0.5} unit=" kt" onChange={(value) => update('targetTonnes', value * 1000)} />
+            <Control label="Target head grade" value={controls.targetGrade} min={52} max={62} step={0.1} unit="% Fe" onChange={(value) => update('targetGrade', value)} />
+          </div>
+
+          <div className="dig-control-group">
+            <h3>Mining geometry</h3>
+            <Control label="Dig direction" value={controls.digDirectionDeg} min={0} max={359} step={1} unit="°" onChange={(value) => update('digDirectionDeg', value)} />
+            <Control label="Face : advance" value={controls.targetFaceToDepthRatio} min={0.8} max={3.5} step={0.1} unit=":1" onChange={(value) => update('targetFaceToDepthRatio', value)} />
+            <Control label="Minimum face width" value={controls.minFaceWidth} min={10} max={50} step={1} unit=" m" onChange={(value) => update('minFaceWidth', value)} />
+          </div>
+
+          <div className="dig-control-group">
+            <h3>Competing priorities</h3>
+            <Control label="Tonnes" value={controls.weights.tonnes} min={0} max={2} step={0.1} unit="" onChange={(value) => updateWeight('tonnes', value)} />
+            <Control label="Grade" value={controls.weights.grade} min={0} max={2} step={0.1} unit="" onChange={(value) => updateWeight('grade', value)} />
+            <Control label="Dig shape" value={controls.weights.shape} min={0} max={2} step={0.1} unit="" onChange={(value) => updateWeight('shape', value)} />
+            <Control label="Material mixing" value={controls.weights.material} min={0} max={1} step={0.05} unit="" onChange={(value) => updateWeight('material', value)} />
+          </div>
+
+          <div className="dig-method-note">
+            <strong>First-pass heuristic</strong>
+            <p>Cells rotate into mining coordinates, split into advancing bands, then use dynamic programming to choose contiguous face cuts with the lowest weighted penalty.</p>
+          </div>
+        </aside>
+      </div>
+    </div>
+  );
+}
+
+export default DigBlockPlanner;

--- a/demo-viewer-react/app/src/pages/DigBlockPlanner.jsx
+++ b/demo-viewer-react/app/src/pages/DigBlockPlanner.jsx
@@ -227,7 +227,7 @@ function DigBlockPlanner() {
 
           <div className="dig-method-note">
             <strong>First-pass heuristic</strong>
-            <p>Cells rotate into mining coordinates, split into advancing bands, then use dynamic programming to choose contiguous face cuts with the lowest weighted penalty.</p>
+            <p>Cells rotate into mining coordinates, split into advancing bands, then use a bounded shortest-path search to choose contiguous face cuts with the lowest weighted penalty.</p>
           </div>
         </aside>
       </div>

--- a/demo-viewer-react/app/src/pages/DigBlockPlanner.jsx
+++ b/demo-viewer-react/app/src/pages/DigBlockPlanner.jsx
@@ -53,6 +53,7 @@ function DigBlockPlanner() {
   const [controls, setControls] = useState(DEFAULT_CONTROLS);
   const [selectedId, setSelectedId] = useState(null);
   const [showSource, setShowSource] = useState(true);
+  const [blockDisplayMode, setBlockDisplayMode] = useState('cutoff');
 
   const solution = useMemo(() => {
     const started = performance.now();
@@ -110,7 +111,27 @@ function DigBlockPlanner() {
               <strong>Synthetic iron-ore bench</strong>
               <span> · {source.cells.length} cells · 10 × 10 × 5 m</span>
             </div>
-            <label><input type="checkbox" checked={showSource} onChange={(event) => setShowSource(event.target.checked)} /> Grade cells</label>
+            <div className="dig-canvas-actions">
+              <div className="dig-display-toggle" role="group" aria-label="Dig block display">
+                <button
+                  type="button"
+                  className={blockDisplayMode === 'cutoff' ? 'active' : ''}
+                  aria-pressed={blockDisplayMode === 'cutoff'}
+                  onClick={() => setBlockDisplayMode('cutoff')}
+                >
+                  Red / blue
+                </button>
+                <button
+                  type="button"
+                  className={blockDisplayMode === 'outline' ? 'active' : ''}
+                  aria-pressed={blockDisplayMode === 'outline'}
+                  onClick={() => setBlockDisplayMode('outline')}
+                >
+                  Outline only
+                </button>
+              </div>
+              <label><input type="checkbox" checked={showSource} onChange={(event) => setShowSource(event.target.checked)} /> Grade cells</label>
+            </div>
           </div>
 
           <div className="dig-canvas-wrap">
@@ -152,8 +173,8 @@ function DigBlockPlanner() {
                     key={block.id}
                     points={polygonPoints(block.polygon)}
                     fill={aboveCutoff ? ABOVE_CUTOFF_COLOUR : BELOW_CUTOFF_COLOUR}
-                    fillOpacity={selected ? (selected.id === block.id ? 0.88 : 0.12) : 0.68}
-                    className={`dig-result-block ${aboveCutoff ? 'above-cutoff' : 'below-cutoff'}${selected?.id === block.id ? ' selected' : ''}`}
+                    fillOpacity={blockDisplayMode === 'outline' ? 0 : selected ? (selected.id === block.id ? 0.88 : 0.12) : 0.68}
+                    className={`dig-result-block ${aboveCutoff ? 'above-cutoff' : 'below-cutoff'}${blockDisplayMode === 'outline' ? ' outline-only' : ''}${selected?.id === block.id ? ' selected' : ''}`}
                     aria-label={`${block.id}, ${aboveCutoff ? 'at or above' : 'below'} grade cut-off`}
                     onClick={() => setSelectedId((current) => current === block.id ? null : block.id)}
                   >
@@ -183,8 +204,12 @@ function DigBlockPlanner() {
             </svg>
 
             <div className="dig-legend">
-              <span><i className="block-above" /> ≥ {controls.targetGrade.toFixed(1)}% Fe</span>
-              <span><i className="block-below" /> &lt; {controls.targetGrade.toFixed(1)}% Fe</span>
+              {blockDisplayMode === 'cutoff' ? (
+                <>
+                  <span><i className="block-above" /> ≥ {controls.targetGrade.toFixed(1)}% Fe</span>
+                  <span><i className="block-below" /> &lt; {controls.targetGrade.toFixed(1)}% Fe</span>
+                </>
+              ) : <span><i className="block-outline" /> Dig-block outline</span>}
               <span><i className="cell-grade-scale" /> Source-cell Fe</span>
             </div>
           </div>

--- a/demo-viewer-react/app/src/pages/DigBlockPlanner.jsx
+++ b/demo-viewer-react/app/src/pages/DigBlockPlanner.jsx
@@ -16,7 +16,8 @@ const DEFAULT_CONTROLS = {
   weights: { tonnes: 1, grade: 0.8, shape: 0.65, material: 0.15, hardness: 0.1 },
 };
 
-const BLOCK_COLOURS = ['#8bd3c7', '#f2c14e', '#ef8354', '#83a6ed', '#b8de6f', '#d4a5ff', '#ff9fbd'];
+const ABOVE_CUTOFF_COLOUR = '#dc2626';
+const BELOW_CUTOFF_COLOUR = '#2563eb';
 
 function formatKt(tonnes) {
   return `${(tonnes / 1000).toFixed(tonnes >= 100_000 ? 0 : 1)} kt`;
@@ -144,18 +145,22 @@ function DigBlockPlanner() {
                 </rect>
               ))}
 
-              {solution.blocks.map((block, index) => (
-                <polygon
-                  key={block.id}
-                  points={polygonPoints(block.polygon)}
-                  fill={BLOCK_COLOURS[index % BLOCK_COLOURS.length]}
-                  fillOpacity={selected ? (selected.id === block.id ? 0.55 : 0.08) : 0.18}
-                  className={`dig-result-block${selected?.id === block.id ? ' selected' : ''}`}
-                  onClick={() => setSelectedId((current) => current === block.id ? null : block.id)}
-                >
-                  <title>{block.id}: {formatKt(block.tonnes)} · {block.headGrade.toFixed(1)}% Fe</title>
-                </polygon>
-              ))}
+              {solution.blocks.map((block) => {
+                const aboveCutoff = block.headGrade >= controls.targetGrade;
+                return (
+                  <polygon
+                    key={block.id}
+                    points={polygonPoints(block.polygon)}
+                    fill={aboveCutoff ? ABOVE_CUTOFF_COLOUR : BELOW_CUTOFF_COLOUR}
+                    fillOpacity={selected ? (selected.id === block.id ? 0.88 : 0.12) : 0.68}
+                    className={`dig-result-block ${aboveCutoff ? 'above-cutoff' : 'below-cutoff'}${selected?.id === block.id ? ' selected' : ''}`}
+                    aria-label={`${block.id}, ${aboveCutoff ? 'at or above' : 'below'} grade cut-off`}
+                    onClick={() => setSelectedId((current) => current === block.id ? null : block.id)}
+                  >
+                    <title>{block.id}: {formatKt(block.tonnes)} · {block.headGrade.toFixed(1)}% Fe · {aboveCutoff ? 'at or above' : 'below'} {controls.targetGrade.toFixed(1)}% cut-off</title>
+                  </polygon>
+                );
+              })}
 
               {solution.blocks.map((block) => (
                 <g key={`${block.id}-label`} className="dig-block-label" pointerEvents="none">
@@ -178,9 +183,9 @@ function DigBlockPlanner() {
             </svg>
 
             <div className="dig-legend">
-              <span><i className="grade-low" /> Lower Fe</span>
-              <span><i className="grade-high" /> Higher Fe</span>
-              <span><i className="block-line" /> Dig block</span>
+              <span><i className="block-above" /> ≥ {controls.targetGrade.toFixed(1)}% Fe</span>
+              <span><i className="block-below" /> &lt; {controls.targetGrade.toFixed(1)}% Fe</span>
+              <span><i className="cell-grade-scale" /> Source-cell Fe</span>
             </div>
           </div>
 
@@ -190,6 +195,12 @@ function DigBlockPlanner() {
                 <div><span>Selected</span><strong>{selected.id}</strong></div>
                 <div><span>Tonnes</span><strong>{formatKt(selected.tonnes)}</strong></div>
                 <div><span>Head grade</span><strong>{selected.headGrade.toFixed(1)}% Fe</strong></div>
+                <div>
+                  <span>Cut-off class</span>
+                  <strong className={selected.headGrade >= controls.targetGrade ? 'cutoff-above' : 'cutoff-below'}>
+                    {selected.headGrade >= controls.targetGrade ? 'At / above' : 'Below'} {controls.targetGrade.toFixed(1)}%
+                  </strong>
+                </div>
                 <div><span>Shape</span><strong>{selected.faceWidth.toFixed(0)} × {selected.advanceDepth.toFixed(0)} m</strong></div>
                 <div><span>Material</span><strong>{selected.dominantGeology}</strong></div>
                 <button type="button" onClick={() => setSelectedId(null)}>Clear</button>
@@ -207,7 +218,7 @@ function DigBlockPlanner() {
           <div className="dig-control-group">
             <h3>Production targets</h3>
             <Control label="Target tonnes" value={controls.targetTonnes / 1000} min={6} max={20} step={0.5} unit=" kt" onChange={(value) => update('targetTonnes', value * 1000)} />
-            <Control label="Target head grade" value={controls.targetGrade} min={52} max={62} step={0.1} unit="% Fe" onChange={(value) => update('targetGrade', value)} />
+            <Control label="Target / grade cut-off" value={controls.targetGrade} min={52} max={62} step={0.1} unit="% Fe" onChange={(value) => update('targetGrade', value)} />
           </div>
 
           <div className="dig-control-group">

--- a/demo-viewer-react/app/src/pages/DigBlockPlanner.jsx
+++ b/demo-viewer-react/app/src/pages/DigBlockPlanner.jsx
@@ -23,6 +23,10 @@ function formatKt(tonnes) {
   return `${(tonnes / 1000).toFixed(tonnes >= 100_000 ? 0 : 1)} kt`;
 }
 
+function formatVolume(volume) {
+  return `${Math.round(volume).toLocaleString()} m³`;
+}
+
 function gradeColour(grade) {
   const amount = Math.max(0, Math.min(1, (grade - 50) / 12));
   const hue = 18 + amount * 105;
@@ -101,7 +105,7 @@ function DigBlockPlanner() {
         <div><span>Dig blocks</span><strong>{solution.metrics.blockCount}</strong></div>
         <div><span>Average block</span><strong>{formatKt(solution.metrics.totalTonnes / solution.metrics.blockCount)}</strong></div>
         <div><span>Head grade</span><strong>{solution.metrics.weightedGrade.toFixed(1)}% Fe</strong></div>
-        <div><span>Mean grade miss</span><strong>±{solution.metrics.meanGradeError.toFixed(1)}%</strong></div>
+        <div><span>Intersected volume</span><strong>{formatVolume(solution.metrics.totalVolume)}</strong></div>
       </section>
 
       <div className="dig-workspace">
@@ -148,23 +152,30 @@ function DigBlockPlanner() {
                 <filter id="selected-glow" x="-30%" y="-30%" width="160%" height="160%">
                   <feDropShadow dx="0" dy="0" stdDeviation="2" floodColor="#ffffff" floodOpacity="1" />
                 </filter>
+                <clipPath id="dig-blast-clip">
+                  <polygon points={polygonPoints(source.blastPolygon)} />
+                </clipPath>
               </defs>
 
               <polygon className="dig-blast-fill" points={polygonPoints(source.blastPolygon)} />
-              {showSource && source.cells.map((cell) => (
-                <rect
-                  key={cell.id}
-                  x={cell.x - cell.dx / 2}
-                  y={svgY(cell.y + cell.dy / 2)}
-                  width={cell.dx}
-                  height={cell.dy}
-                  fill={gradeColour(cell.fe)}
-                  opacity={selected && !selectedCells.has(cell.id) ? 0.14 : 0.72}
-                  className="dig-source-cell"
-                >
-                  <title>{cell.id}: {cell.fe.toFixed(1)}% Fe · {formatKt(cell.tonnes)} · {cell.geology}</title>
-                </rect>
-              ))}
+              {showSource && (
+                <g clipPath="url(#dig-blast-clip)">
+                  {source.cells.map((cell) => (
+                    <rect
+                      key={cell.id}
+                      x={cell.x - cell.dx / 2}
+                      y={svgY(cell.y + cell.dy / 2)}
+                      width={cell.dx}
+                      height={cell.dy}
+                      fill={gradeColour(cell.fe)}
+                      opacity={selected && !selectedCells.has(cell.id) ? 0.14 : 0.72}
+                      className="dig-source-cell"
+                    >
+                      <title>{cell.id}: {cell.fe.toFixed(1)}% Fe · {formatKt(cell.tonnes)} · {cell.geology}</title>
+                    </rect>
+                  ))}
+                </g>
+              )}
 
               {solution.blocks.map((block) => {
                 const aboveCutoff = block.headGrade >= controls.targetGrade;
@@ -219,6 +230,7 @@ function DigBlockPlanner() {
               <>
                 <div><span>Selected</span><strong>{selected.id}</strong></div>
                 <div><span>Tonnes</span><strong>{formatKt(selected.tonnes)}</strong></div>
+                {selected.volume !== null && <div><span>Volume</span><strong>{formatVolume(selected.volume)}</strong></div>}
                 <div><span>Head grade</span><strong>{selected.headGrade.toFixed(1)}% Fe</strong></div>
                 <div>
                   <span>Cut-off class</span>

--- a/docs/api/javascript.md
+++ b/docs/api/javascript.md
@@ -194,8 +194,10 @@ clockwise from north (`0` is +Y, `90` is +X).
 
 #### `optimizeDigBlocks(cells, blastPolygon, options?)`
 
-Partition the cells whose centres lie inside a convex XY blast polygon. The
-solver returns:
+Partition axis-aligned vertical-prism cells intersecting a convex XY blast
+polygon. Footprint intersections are exact; tonnes and physicals are prorated
+by area fraction, which is also the volume fraction for each cell. The solver
+returns:
 
 ```js
 {
@@ -203,21 +205,30 @@ solver returns:
     id, polygon, geometry, centroid, cellIds,
     tonnes, headGrade, averageHardness,
     dominantGeology, geologyTonnes,
+    intersectionArea, volume,
     faceWidth, advanceDepth, faceToDepthRatio,
     score, miningOrder,
   }],
-  assignments: [{ cellId, digBlockId }],
+  assignments: [{
+    cellId, digBlockId,
+    intersectionArea, intersectionVolume,
+    cellFraction, blastFraction, tonnes,
+  }],
   blastPolygon,
   options,
   metrics: {
-    blockCount, assignedCellCount, totalTonnes, weightedGrade,
+    blockCount, assignedCellCount, intersectionCount, splitCellCount,
+    totalTonnes, totalVolume, weightedGrade,
     meanTonnesError, meanGradeError, totalScore,
   },
 }
 ```
 
 Required cell fields are `x`, `y`, positive `tonnes`, and `fe`. Optional fields
-are `id`, `dx`, `dy`, `geology`, and `hardness`. Options include
+are `id`, `dx`, `dy`, `dz`, `geology`, and `hardness`. `dx` and `dy`
+default to `1`; `totalVolume`, block `volume`, and assignment
+`intersectionVolume` are `null` when an intersecting cell omits positive `dz`.
+Options include
 `digDirectionDeg`, `targetTonnes`, `targetGrade`, `targetFaceToDepthRatio`,
 `minFaceWidth`, `gradeScale`, and non-negative `weights` for `tonnes`, `grade`,
 `shape`, `material`, and `hardness`.
@@ -225,7 +236,7 @@ are `id`, `dx`, `dy`, `geology`, and `hardness`. Options include
 #### `createSyntheticDigBlockModel()`
 
 Return deterministic `{ cells, blastPolygon }` demo input for an approximately
-206 kt, single-bench iron-ore blast.
+200 kt, single-bench iron-ore blast.
 
 ---
 

--- a/docs/api/javascript.md
+++ b/docs/api/javascript.md
@@ -185,6 +185,50 @@ Get the hex colour for a value from a color scale.
 
 ---
 
+### Dig-block optimisation
+
+#### `digDirectionAxes(bearingDeg)`
+
+Return orthogonal `forward` and `cross` unit vectors for a bearing measured
+clockwise from north (`0` is +Y, `90` is +X).
+
+#### `optimizeDigBlocks(cells, blastPolygon, options?)`
+
+Partition the cells whose centres lie inside a convex XY blast polygon. The
+solver returns:
+
+```js
+{
+  blocks: [{
+    id, polygon, geometry, centroid, cellIds,
+    tonnes, headGrade, averageHardness,
+    dominantGeology, geologyTonnes,
+    faceWidth, advanceDepth, faceToDepthRatio,
+    score, miningOrder,
+  }],
+  assignments: [{ cellId, digBlockId }],
+  blastPolygon,
+  options,
+  metrics: {
+    blockCount, assignedCellCount, totalTonnes, weightedGrade,
+    meanTonnesError, meanGradeError, totalScore,
+  },
+}
+```
+
+Required cell fields are `x`, `y`, positive `tonnes`, and `fe`. Optional fields
+are `id`, `dx`, `dy`, `geology`, and `hardness`. Options include
+`digDirectionDeg`, `targetTonnes`, `targetGrade`, `targetFaceToDepthRatio`,
+`minFaceWidth`, `gradeScale`, and non-negative `weights` for `tonnes`, `grade`,
+`shape`, `material`, and `hardness`.
+
+#### `createSyntheticDigBlockModel()`
+
+Return deterministic `{ cells, blastPolygon }` demo input for an approximately
+206 kt, single-bench iron-ore blast.
+
+---
+
 ### Grade block loaders
 
 #### `loadGradeBlocksFromJson(input)`

--- a/docs/guide/javascript.md
+++ b/docs/guide/javascript.md
@@ -201,6 +201,46 @@ const stats  = getBlockStats(blocks, 'au_ppm');
 const subset = filterBlocks(blocks, { property: 'au_ppm', min: 1.0 });
 ```
 
+### Dig-block optimisation
+
+`optimizeDigBlocks` creates a deterministic first-pass grade-control block-out
+for one bench. It rotates eligible block-model cells into mining coordinates,
+forms advancing bands, and uses dynamic programming to place contiguous cuts
+across the dig face. The score balances target tonnes, tonnes-weighted Fe
+grade, face shape, geology mixing, and hardness variation.
+
+```js
+import { optimizeDigBlocks } from 'baselode';
+
+const result = optimizeDigBlocks(cells, blastPolygon, {
+  digDirectionDeg: 20,       // bearing clockwise from north
+  targetTonnes: 10_000,
+  targetGrade: 57,           // Fe percent
+  targetFaceToDepthRatio: 1.8,
+  minFaceWidth: 20,
+  weights: { tonnes: 1, grade: 0.8, shape: 0.65, material: 0.15 },
+});
+
+console.log(result.blocks);       // polygons, physicals, cell ids, mining order
+console.log(result.assignments);  // source cell id -> dig block id
+console.log(result.metrics);      // whole-blast and objective summaries
+```
+
+Each input cell requires `x`, `y`, positive `tonnes`, and `fe`. Supply `dx` and
+`dy` for physical face widths; `geology` and `hardness` activate the optional
+mixing penalties. Cells are selected when their centre is inside the blast
+ring. The first pass expects a convex blast and does not replace production
+scheduling, blast-movement correction, or engineering sign-off.
+
+The demo route `/dig-block-planner` includes a deterministic ~206 kt iron-ore
+bench and recomputes interactively as targets and priorities move.
+
+MineLib's [Newman1](https://minelib.org/v1/newman1.xhtml) has compatible
+coordinates, type, grade, and tonnes columns, but its block dimensions and
+metal type are unspecified. It is therefore suitable only after the caller
+supplies site-specific `dx`, `dy`, and grade semantics; the licensed source data
+is not bundled with Baselode.
+
 ### Polygonal grade blocks
 
 Grade blocks are closed polyhedral meshes — grade shells, geologic domains, or any volumetric solid defined by triangulated vertices.  They are loaded from a structured JSON format:

--- a/docs/guide/javascript.md
+++ b/docs/guide/javascript.md
@@ -224,17 +224,22 @@ const result = optimizeDigBlocks(cells, blastPolygon, {
 });
 
 console.log(result.blocks);       // polygons, physicals, cell ids, mining order
-console.log(result.assignments);  // source cell id -> dig block id
+console.log(result.assignments);  // fractional cell/dig-block intersections
 console.log(result.metrics);      // whole-blast and objective summaries
 ```
 
 Each input cell requires `x`, `y`, positive `tonnes`, and `fe`. Supply `dx` and
-`dy` for physical face widths; `geology` and `hardness` activate the optional
-mixing penalties. Cells are selected when their centre is inside the blast
-ring. The first pass expects a convex blast and does not replace production
-scheduling, blast-movement correction, or engineering sign-off.
+`dy` for its axis-aligned footprint and `dz` for volume. The solver intersects
+every footprint exactly with the blast and generated dig polygons. Each
+assignment reports area, volume, cell fraction, and prorated tonnes; one source
+cell can contribute to multiple dig blocks. Tonnage-weighted Fe, hardness, and
+geology physicals are recalculated from those fractional contributions.
+Omitting `dx`/`dy` uses a unit-square footprint; omitting `dz` leaves volumes
+null. The first pass expects a convex, single-bench blast with vertical-prism
+cells and does not replace production scheduling, blast-movement correction,
+or engineering sign-off.
 
-The demo route `/dig-block-planner` includes a deterministic ~206 kt iron-ore
+The demo route `/dig-block-planner` includes a deterministic ~200 kt iron-ore
 bench and recomputes interactively as targets and priorities move. Generated
 dig blocks at or above the target/cut-off grade are red; blocks below it are
 blue. A display toggle switches the result to outline-only polygons when the

--- a/docs/guide/javascript.md
+++ b/docs/guide/javascript.md
@@ -205,9 +205,11 @@ const subset = filterBlocks(blocks, { property: 'au_ppm', min: 1.0 });
 
 `optimizeDigBlocks` creates a deterministic first-pass grade-control block-out
 for one bench. It rotates eligible block-model cells into mining coordinates,
-forms advancing bands, and uses dynamic programming to place contiguous cuts
-across the dig face. The score balances target tonnes, tonnes-weighted Fe
-grade, face shape, geology mixing, and hardness variation.
+forms advancing bands, and uses a bounded-transition shortest-path search to
+place contiguous cuts across the dig face. The fixed transition budget keeps
+interactive solve cost approximately linear in source-cell count. The score
+balances target tonnes, tonnes-weighted Fe grade, face shape, geology mixing,
+and hardness variation.
 
 ```js
 import { optimizeDigBlocks } from 'baselode';

--- a/docs/guide/javascript.md
+++ b/docs/guide/javascript.md
@@ -237,7 +237,8 @@ scheduling, blast-movement correction, or engineering sign-off.
 The demo route `/dig-block-planner` includes a deterministic ~206 kt iron-ore
 bench and recomputes interactively as targets and priorities move. Generated
 dig blocks at or above the target/cut-off grade are red; blocks below it are
-blue. The source cells retain a continuous Fe heatmap beneath the result.
+blue. A display toggle switches the result to outline-only polygons when the
+continuous source-cell Fe heatmap needs to remain unobscured.
 
 MineLib's [Newman1](https://minelib.org/v1/newman1.xhtml) has compatible
 coordinates, type, grade, and tonnes columns, but its block dimensions and

--- a/docs/guide/javascript.md
+++ b/docs/guide/javascript.md
@@ -235,7 +235,9 @@ ring. The first pass expects a convex blast and does not replace production
 scheduling, blast-movement correction, or engineering sign-off.
 
 The demo route `/dig-block-planner` includes a deterministic ~206 kt iron-ore
-bench and recomputes interactively as targets and priorities move.
+bench and recomputes interactively as targets and priorities move. Generated
+dig blocks at or above the target/cut-off grade are red; blocks below it are
+blue. The source cells retain a continuous Fe heatmap beneath the result.
 
 MineLib's [Newman1](https://minelib.org/v1/newman1.xhtml) has compatible
 coordinates, type, grade, and tonnes columns, but its block dimensions and

--- a/javascript/packages/baselode/src/grade_blocks/digBlockOptimizer.js
+++ b/javascript/packages/baselode/src/grade_blocks/digBlockOptimizer.js
@@ -14,6 +14,7 @@ const DEFAULT_OPTIONS = Object.freeze({
 });
 
 const EPSILON = 1e-9;
+const MAX_TRANSITION_CANDIDATES = 64;
 
 function clamp(value, min, max) {
   return Math.max(min, Math.min(max, value));
@@ -174,38 +175,68 @@ function scoreSegment(cells, prefix, categories, start, end, bandDepth, targetGr
     + options.weights.grade * gradePenalty
     + options.weights.shape * (ratioPenalty + 2 * widthPenalty)
     + options.weights.material * materialPenalty
-    + options.weights.hardness * hardnessPenalty;
+    + options.weights.hardness * hardnessPenalty
+    - 0.1 * options.weights.tonnes;
   return { score, tonnes, grade, hardnessMean, faceWidth, ratio, materialPenalty };
+}
+
+function lowerBound(values, target, end) {
+  let low = 0;
+  let high = end;
+  while (low < high) {
+    const middle = Math.floor((low + high) / 2);
+    if (values[middle] < target) low = middle + 1;
+    else high = middle;
+  }
+  return low;
+}
+
+function transitionCandidates(prefixTonnes, end, targetTonnes) {
+  const starts = new Set([0, end - 1]);
+  const total = prefixTonnes[end];
+  const ideal = clamp(lowerBound(prefixTonnes, total - targetTonnes, end), 0, end - 1);
+  for (let offset = -5; offset <= 5; offset += 1) starts.add(clamp(ideal + offset, 0, end - 1));
+
+  const tonnageMin = clamp(lowerBound(prefixTonnes, total - 3 * targetTonnes, end), 0, end - 1);
+  const tonnageMax = clamp(lowerBound(prefixTonnes, total - 0.25 * targetTonnes, end), 0, end - 1);
+  const tonnageSamples = Math.min(24, tonnageMax - tonnageMin + 1);
+  for (let index = 0; index < tonnageSamples; index += 1) {
+    const fraction = tonnageSamples === 1 ? 0 : index / (tonnageSamples - 1);
+    starts.add(Math.round(tonnageMin + fraction * (tonnageMax - tonnageMin)));
+  }
+
+  const globalSamples = Math.min(12, end);
+  for (let index = 0; index < globalSamples; index += 1) {
+    const fraction = globalSamples === 1 ? 0 : index / (globalSamples - 1);
+    starts.add(Math.round(fraction * (end - 1)));
+  }
+  return [...starts].sort((a, b) => a - b).slice(0, MAX_TRANSITION_CANDIDATES);
 }
 
 function partitionBand(cells, band, targetGrade, options, blastBounds, blastDig, axes, idOffset) {
   const sorted = cells.slice().sort((a, b) => a.cross - b.cross || a.id.localeCompare(b.id));
   const categories = [...new Set(sorted.map((cell) => cell.geology))].sort();
   const prefix = makePrefix(sorted, categories);
-  const totalTonnes = range(prefix.tonnes, 0, sorted.length);
-  const segmentCount = clamp(Math.round(totalTonnes / options.targetTonnes), 1, sorted.length);
   const depth = Math.max(band.max - band.min, EPSILON);
-  const dp = Array.from({ length: segmentCount + 1 }, () => Array(sorted.length + 1).fill(Infinity));
-  const previous = Array.from({ length: segmentCount + 1 }, () => Array(sorted.length + 1).fill(-1));
-  dp[0][0] = 0;
-  for (let segment = 1; segment <= segmentCount; segment += 1) {
-    for (let end = segment; end <= sorted.length; end += 1) {
-      for (let start = segment - 1; start < end; start += 1) {
-        if (!Number.isFinite(dp[segment - 1][start])) continue;
-        const candidate = scoreSegment(sorted, prefix, categories, start, end, depth, targetGrade, options);
-        const totalScore = dp[segment - 1][start] + candidate.score;
-        if (totalScore < dp[segment][end]) {
-          dp[segment][end] = totalScore;
-          previous[segment][end] = start;
-        }
+  const bestScore = Array(sorted.length + 1).fill(Infinity);
+  const previous = Array(sorted.length + 1).fill(-1);
+  bestScore[0] = 0;
+  for (let end = 1; end <= sorted.length; end += 1) {
+    for (const start of transitionCandidates(prefix.tonnes, end, options.targetTonnes)) {
+      if (!Number.isFinite(bestScore[start])) continue;
+      const candidate = scoreSegment(sorted, prefix, categories, start, end, depth, targetGrade, options);
+      const totalScore = bestScore[start] + candidate.score;
+      if (totalScore < bestScore[end]) {
+        bestScore[end] = totalScore;
+        previous[end] = start;
       }
     }
   }
 
   const ranges = [];
   let end = sorted.length;
-  for (let segment = segmentCount; segment > 0; segment -= 1) {
-    const start = previous[segment][end];
+  while (end > 0) {
+    const start = previous[end];
     ranges.unshift({ start, end });
     end = start;
   }

--- a/javascript/packages/baselode/src/grade_blocks/digBlockOptimizer.js
+++ b/javascript/packages/baselode/src/grade_blocks/digBlockOptimizer.js
@@ -1,0 +1,407 @@
+/*
+ * Copyright (C) 2026 Darkmine Pty Ltd
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+const DEFAULT_OPTIONS = Object.freeze({
+  digDirectionDeg: 0,
+  targetTonnes: 10_000,
+  targetGrade: null,
+  targetFaceToDepthRatio: 1.8,
+  minFaceWidth: 20,
+  gradeScale: 5,
+  weights: Object.freeze({ tonnes: 1, grade: 0.8, shape: 0.65, material: 0.15, hardness: 0.1 }),
+});
+
+const EPSILON = 1e-9;
+
+function clamp(value, min, max) {
+  return Math.max(min, Math.min(max, value));
+}
+
+function finiteNumber(value, fallback = null) {
+  if (value === null || value === undefined || value === '') return fallback;
+  const number = Number(value);
+  return Number.isFinite(number) ? number : fallback;
+}
+
+function normalizePolygon(polygon) {
+  const coordinates = polygon?.type === 'Polygon'
+    ? polygon.coordinates?.[0]
+    : polygon?.coordinates?.[0] || polygon;
+  if (!Array.isArray(coordinates)) throw new Error('blastPolygon must be a polygon coordinate array or GeoJSON Polygon');
+  const points = coordinates.map((point) => ({ x: Number(point?.[0] ?? point?.x), y: Number(point?.[1] ?? point?.y) }));
+  if (points.length > 1 && points[0].x === points.at(-1).x && points[0].y === points.at(-1).y) points.pop();
+  if (points.length < 3 || points.some((point) => !Number.isFinite(point.x) || !Number.isFinite(point.y))) {
+    throw new Error('blastPolygon must contain at least three finite XY points');
+  }
+  return points;
+}
+
+function pointInPolygon(point, polygon) {
+  let inside = false;
+  for (let i = 0, j = polygon.length - 1; i < polygon.length; j = i, i += 1) {
+    const a = polygon[i];
+    const b = polygon[j];
+    const intersects = ((a.y > point.y) !== (b.y > point.y))
+      && point.x < ((b.x - a.x) * (point.y - a.y)) / ((b.y - a.y) || EPSILON) + a.x;
+    if (intersects) inside = !inside;
+  }
+  return inside;
+}
+
+function polygonArea(points) {
+  let area = 0;
+  for (let index = 0; index < points.length; index += 1) {
+    const point = points[index];
+    const next = points[(index + 1) % points.length];
+    area += point.x * next.y - next.x * point.y;
+  }
+  return Math.abs(area) / 2;
+}
+
+function polygonCentroid(points) {
+  if (!points.length) return { x: 0, y: 0 };
+  const total = points.reduce((acc, point) => ({ x: acc.x + point.x, y: acc.y + point.y }), { x: 0, y: 0 });
+  return { x: total.x / points.length, y: total.y / points.length };
+}
+
+/**
+ * Return unit axes for a mining bearing measured clockwise from north.
+ *
+ * @param {number} bearingDeg - Bearing in degrees clockwise from north
+ * @returns {{forward: {x:number,y:number}, cross: {x:number,y:number}}}
+ */
+export function digDirectionAxes(bearingDeg) {
+  const radians = (finiteNumber(bearingDeg, 0) * Math.PI) / 180;
+  return {
+    forward: { x: Math.sin(radians), y: Math.cos(radians) },
+    cross: { x: Math.cos(radians), y: -Math.sin(radians) },
+  };
+}
+
+function toDigPoint(point, axes) {
+  return {
+    x: point.x * axes.cross.x + point.y * axes.cross.y,
+    y: point.x * axes.forward.x + point.y * axes.forward.y,
+  };
+}
+
+function fromDigPoint(point, axes) {
+  return {
+    x: point.x * axes.cross.x + point.y * axes.forward.x,
+    y: point.x * axes.cross.y + point.y * axes.forward.y,
+  };
+}
+
+function clipAgainst(points, inside, intersect) {
+  const output = [];
+  for (let index = 0; index < points.length; index += 1) {
+    const current = points[index];
+    const previous = points[(index + points.length - 1) % points.length];
+    const currentInside = inside(current);
+    const previousInside = inside(previous);
+    if (currentInside) {
+      if (!previousInside) output.push(intersect(previous, current));
+      output.push(current);
+    } else if (previousInside) {
+      output.push(intersect(previous, current));
+    }
+  }
+  return output;
+}
+
+function clipPolygonToRect(polygon, minCross, maxCross, minForward, maxForward) {
+  let output = polygon.slice();
+  const verticalIntersection = (edge) => (a, b) => {
+    const ratio = (edge - a.x) / ((b.x - a.x) || EPSILON);
+    return { x: edge, y: a.y + ratio * (b.y - a.y) };
+  };
+  const horizontalIntersection = (edge) => (a, b) => {
+    const ratio = (edge - a.y) / ((b.y - a.y) || EPSILON);
+    return { x: a.x + ratio * (b.x - a.x), y: edge };
+  };
+  output = clipAgainst(output, (point) => point.x >= minCross - EPSILON, verticalIntersection(minCross));
+  output = clipAgainst(output, (point) => point.x <= maxCross + EPSILON, verticalIntersection(maxCross));
+  output = clipAgainst(output, (point) => point.y >= minForward - EPSILON, horizontalIntersection(minForward));
+  output = clipAgainst(output, (point) => point.y <= maxForward + EPSILON, horizontalIntersection(maxForward));
+  return output;
+}
+
+function makePrefix(cells, categories) {
+  const prefix = {
+    tonnes: [0],
+    grade: [0],
+    hardness: [0],
+    hardnessSquared: [0],
+    area: [0],
+    categories: Object.fromEntries(categories.map((category) => [category, [0]])),
+  };
+  for (const cell of cells) {
+    const tonnes = cell.tonnes;
+    prefix.tonnes.push(prefix.tonnes.at(-1) + tonnes);
+    prefix.grade.push(prefix.grade.at(-1) + tonnes * cell.fe);
+    prefix.hardness.push(prefix.hardness.at(-1) + tonnes * cell.hardness);
+    prefix.hardnessSquared.push(prefix.hardnessSquared.at(-1) + tonnes * cell.hardness * cell.hardness);
+    prefix.area.push(prefix.area.at(-1) + cell.area);
+    for (const category of categories) {
+      prefix.categories[category].push(prefix.categories[category].at(-1) + (cell.geology === category ? tonnes : 0));
+    }
+  }
+  return prefix;
+}
+
+function range(prefix, start, end) {
+  return prefix[end] - prefix[start];
+}
+
+function scoreSegment(cells, prefix, categories, start, end, bandDepth, targetGrade, options) {
+  const tonnes = range(prefix.tonnes, start, end);
+  const grade = range(prefix.grade, start, end) / Math.max(tonnes, EPSILON);
+  const hardnessMean = range(prefix.hardness, start, end) / Math.max(tonnes, EPSILON);
+  const hardnessVariance = Math.max(0, range(prefix.hardnessSquared, start, end) / Math.max(tonnes, EPSILON) - hardnessMean ** 2);
+  const faceWidth = Math.max(cells[end - 1].crossMax - cells[start].crossMin, EPSILON);
+  const ratio = faceWidth / Math.max(bandDepth, EPSILON);
+  const tonnesPenalty = ((tonnes - options.targetTonnes) / options.targetTonnes) ** 2;
+  const gradePenalty = ((grade - targetGrade) / options.gradeScale) ** 2;
+  const ratioPenalty = Math.log(Math.max(ratio, 0.05) / options.targetFaceToDepthRatio) ** 2;
+  const widthPenalty = Math.max(0, (options.minFaceWidth - faceWidth) / options.minFaceWidth) ** 2;
+  let dominantTonnes = 0;
+  for (const category of categories) dominantTonnes = Math.max(dominantTonnes, range(prefix.categories[category], start, end));
+  const materialPenalty = tonnes ? 1 - dominantTonnes / tonnes : 0;
+  const hardnessPenalty = hardnessVariance / Math.max(hardnessMean ** 2, 1);
+  const score = options.weights.tonnes * tonnesPenalty
+    + options.weights.grade * gradePenalty
+    + options.weights.shape * (ratioPenalty + 2 * widthPenalty)
+    + options.weights.material * materialPenalty
+    + options.weights.hardness * hardnessPenalty;
+  return { score, tonnes, grade, hardnessMean, faceWidth, ratio, materialPenalty };
+}
+
+function partitionBand(cells, band, targetGrade, options, blastBounds, blastDig, axes, idOffset) {
+  const sorted = cells.slice().sort((a, b) => a.cross - b.cross || a.id.localeCompare(b.id));
+  const categories = [...new Set(sorted.map((cell) => cell.geology))].sort();
+  const prefix = makePrefix(sorted, categories);
+  const totalTonnes = range(prefix.tonnes, 0, sorted.length);
+  const segmentCount = clamp(Math.round(totalTonnes / options.targetTonnes), 1, sorted.length);
+  const depth = Math.max(band.max - band.min, EPSILON);
+  const dp = Array.from({ length: segmentCount + 1 }, () => Array(sorted.length + 1).fill(Infinity));
+  const previous = Array.from({ length: segmentCount + 1 }, () => Array(sorted.length + 1).fill(-1));
+  dp[0][0] = 0;
+  for (let segment = 1; segment <= segmentCount; segment += 1) {
+    for (let end = segment; end <= sorted.length; end += 1) {
+      for (let start = segment - 1; start < end; start += 1) {
+        if (!Number.isFinite(dp[segment - 1][start])) continue;
+        const candidate = scoreSegment(sorted, prefix, categories, start, end, depth, targetGrade, options);
+        const totalScore = dp[segment - 1][start] + candidate.score;
+        if (totalScore < dp[segment][end]) {
+          dp[segment][end] = totalScore;
+          previous[segment][end] = start;
+        }
+      }
+    }
+  }
+
+  const ranges = [];
+  let end = sorted.length;
+  for (let segment = segmentCount; segment > 0; segment -= 1) {
+    const start = previous[segment][end];
+    ranges.unshift({ start, end });
+    end = start;
+  }
+
+  const cuts = [blastBounds.minCross];
+  for (let index = 0; index < ranges.length - 1; index += 1) {
+    const left = sorted[ranges[index].end - 1].cross;
+    const right = sorted[ranges[index + 1].start].cross;
+    cuts.push((left + right) / 2);
+  }
+  cuts.push(blastBounds.maxCross);
+
+  return ranges.map((cellRange, index) => {
+    const members = sorted.slice(cellRange.start, cellRange.end);
+    const stats = scoreSegment(sorted, prefix, categories, cellRange.start, cellRange.end, depth, targetGrade, options);
+    const minCross = cuts[index];
+    const maxCross = cuts[index + 1];
+    const digPolygon = clipPolygonToRect(blastDig, minCross, maxCross, band.min, band.max);
+    const polygon = digPolygon.map((point) => fromDigPoint(point, axes));
+    const ring = polygon.map((point) => [point.x, point.y]);
+    if (ring.length) ring.push(ring[0]);
+    const geologyTonnes = {};
+    for (const member of members) geologyTonnes[member.geology] = (geologyTonnes[member.geology] || 0) + member.tonnes;
+    const dominantGeology = Object.entries(geologyTonnes).sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))[0]?.[0] || null;
+    const centroid = polygonCentroid(polygon);
+    return {
+      id: `DIG-${String(idOffset + index + 1).padStart(2, '0')}`,
+      polygon: ring,
+      geometry: { type: 'Polygon', coordinates: [ring] },
+      centroid,
+      cellIds: members.map((cell) => cell.id),
+      tonnes: stats.tonnes,
+      headGrade: stats.grade,
+      averageHardness: stats.hardnessMean,
+      dominantGeology,
+      geologyTonnes,
+      faceWidth: stats.faceWidth,
+      advanceDepth: depth,
+      faceToDepthRatio: stats.ratio,
+      score: stats.score,
+      miningOrder: idOffset + index + 1,
+    };
+  });
+}
+
+function normalizeOptions(options, cells) {
+  const targetTonnes = finiteNumber(options.targetTonnes, DEFAULT_OPTIONS.targetTonnes);
+  if (!(targetTonnes > 0)) throw new Error('targetTonnes must be greater than zero');
+  const weights = { ...DEFAULT_OPTIONS.weights, ...(options.weights || {}) };
+  const totalTonnes = cells.reduce((sum, cell) => sum + cell.tonnes, 0);
+  const averageGrade = cells.reduce((sum, cell) => sum + cell.tonnes * cell.fe, 0) / Math.max(totalTonnes, EPSILON);
+  return {
+    ...DEFAULT_OPTIONS,
+    ...options,
+    targetTonnes,
+    targetGrade: finiteNumber(options.targetGrade, averageGrade),
+    targetFaceToDepthRatio: Math.max(0.2, finiteNumber(options.targetFaceToDepthRatio, DEFAULT_OPTIONS.targetFaceToDepthRatio)),
+    minFaceWidth: Math.max(EPSILON, finiteNumber(options.minFaceWidth, DEFAULT_OPTIONS.minFaceWidth)),
+    gradeScale: Math.max(EPSILON, finiteNumber(options.gradeScale, DEFAULT_OPTIONS.gradeScale)),
+    weights: Object.fromEntries(Object.entries(weights).map(([key, value]) => [key, Math.max(0, finiteNumber(value, 0))])),
+  };
+}
+
+/**
+ * Partition a single-bench block model into direction-aligned dig blocks.
+ *
+ * Cells are selected by centre point. `tonnes` and `fe` are required numeric
+ * physicals; `geology` and `hardness` are optional scoring attributes.
+ *
+ * @param {Array<object>} inputCells - Block-model cells
+ * @param {Array<Array<number>>|object} blastPolygon - XY ring or GeoJSON Polygon
+ * @param {object} [inputOptions] - Optimisation controls
+ * @returns {object} Dig blocks, assignments and aggregate metrics
+ */
+export function optimizeDigBlocks(inputCells, blastPolygon, inputOptions = {}) {
+  if (!Array.isArray(inputCells) || !inputCells.length) throw new Error('cells must be a non-empty array');
+  const blast = normalizePolygon(blastPolygon);
+  const axes = digDirectionAxes(inputOptions.digDirectionDeg);
+  const blastDig = blast.map((point) => toDigPoint(point, axes));
+  const cells = inputCells.map((cell, index) => {
+    const x = finiteNumber(cell.x);
+    const y = finiteNumber(cell.y);
+    const tonnes = finiteNumber(cell.tonnes);
+    const fe = finiteNumber(cell.fe);
+    if (![x, y, tonnes, fe].every(Number.isFinite) || tonnes <= 0) {
+      throw new Error(`cell ${cell.id ?? index} requires finite x, y, positive tonnes and fe`);
+    }
+    const dig = toDigPoint({ x, y }, axes);
+    const dx = Math.abs(finiteNumber(cell.dx, 1));
+    const dy = Math.abs(finiteNumber(cell.dy, 1));
+    const projectedHalfCross = (dx * Math.abs(axes.cross.x) + dy * Math.abs(axes.cross.y)) / 2;
+    return {
+      ...cell,
+      id: String(cell.id ?? `CELL-${index + 1}`),
+      x,
+      y,
+      tonnes,
+      fe,
+      hardness: finiteNumber(cell.hardness, 1),
+      geology: String(cell.geology ?? 'Unclassified'),
+      cross: dig.x,
+      forward: dig.y,
+      crossMin: dig.x - projectedHalfCross,
+      crossMax: dig.x + projectedHalfCross,
+      area: dx * dy,
+    };
+  }).filter((cell) => pointInPolygon(cell, blast));
+  if (!cells.length) throw new Error('blastPolygon does not contain any cell centres');
+  const options = normalizeOptions(inputOptions, cells);
+  const minCross = Math.min(...blastDig.map((point) => point.x));
+  const maxCross = Math.max(...blastDig.map((point) => point.x));
+  const minForward = Math.min(...blastDig.map((point) => point.y));
+  const maxForward = Math.max(...blastDig.map((point) => point.y));
+  const totalTonnes = cells.reduce((sum, cell) => sum + cell.tonnes, 0);
+  const estimatedBlocks = Math.max(1, Math.round(totalTonnes / options.targetTonnes));
+  const targetArea = polygonArea(blastDig) / estimatedBlocks;
+  const targetDepth = Math.sqrt(targetArea / options.targetFaceToDepthRatio);
+  const bandCount = clamp(Math.round((maxForward - minForward) / Math.max(targetDepth, EPSILON)), 1, estimatedBlocks);
+  const bandDepth = (maxForward - minForward) / bandCount;
+  const bands = Array.from({ length: bandCount }, (_, index) => {
+    const min = minForward + index * bandDepth;
+    const max = index === bandCount - 1 ? maxForward : min + bandDepth;
+    return {
+      min,
+      max,
+      cells: cells.filter((cell) => cell.forward >= min - EPSILON
+        && (index === bandCount - 1 ? cell.forward <= max + EPSILON : cell.forward < max)),
+    };
+  }).filter((band) => band.cells.length);
+
+  const blocks = [];
+  for (const band of bands) {
+    blocks.push(...partitionBand(
+      band.cells,
+      band,
+      options.targetGrade,
+      options,
+      { minCross, maxCross },
+      blastDig,
+      axes,
+      blocks.length,
+    ));
+  }
+  const assignments = blocks.flatMap((block) => block.cellIds.map((cellId) => ({ cellId, digBlockId: block.id })));
+  const weightedGrade = blocks.reduce((sum, block) => sum + block.tonnes * block.headGrade, 0) / totalTonnes;
+  const meanTonnesError = blocks.reduce((sum, block) => sum + Math.abs(block.tonnes - options.targetTonnes) / options.targetTonnes, 0) / blocks.length;
+  const meanGradeError = blocks.reduce((sum, block) => sum + Math.abs(block.headGrade - options.targetGrade), 0) / blocks.length;
+  return {
+    blocks,
+    assignments,
+    blastPolygon: { type: 'Polygon', coordinates: [[...blast.map((point) => [point.x, point.y]), [blast[0].x, blast[0].y]]] },
+    options,
+    metrics: {
+      blockCount: blocks.length,
+      assignedCellCount: assignments.length,
+      totalTonnes,
+      weightedGrade,
+      meanTonnesError,
+      meanGradeError,
+      totalScore: blocks.reduce((sum, block) => sum + block.score, 0),
+    },
+  };
+}
+
+/**
+ * Create deterministic iron-ore bench cells and a convex ~200 kt blast.
+ *
+ * @returns {{cells:Array<object>, blastPolygon:Array<Array<number>>}}
+ */
+export function createSyntheticDigBlockModel() {
+  const blastPolygon = [[10, 0], [155, 0], [180, 20], [175, 78], [145, 100], [22, 95], [0, 75], [0, 20]];
+  const cells = [];
+  let index = 0;
+  for (let y = 5; y < 105; y += 10) {
+    for (let x = 5; x < 185; x += 10) {
+      if (!pointInPolygon({ x, y }, blastPolygon.map(([px, py]) => ({ x: px, y: py })))) continue;
+      const highGradeLens = 8 * Math.exp(-(((x - 65) / 38) ** 2 + ((y - 52) / 24) ** 2));
+      const secondLens = 5 * Math.exp(-(((x - 135) / 28) ** 2 + ((y - 35) / 30) ** 2));
+      const fe = 52 + highGradeLens + secondLens + 1.4 * Math.sin(x / 17) - 0.8 * Math.cos(y / 13);
+      const geology = x < 72 + 0.35 * y ? 'BIF' : y > 67 + 0.08 * x ? 'Shale' : 'Goethite';
+      const hardness = geology === 'BIF' ? 8.2 : geology === 'Goethite' ? 5.4 : 3.8;
+      const density = geology === 'BIF' ? 2.55 : geology === 'Goethite' ? 2.35 : 2.15;
+      cells.push({
+        id: `BM-${String(++index).padStart(3, '0')}`,
+        x,
+        y,
+        z: 100,
+        dx: 10,
+        dy: 10,
+        dz: 5,
+        tonnes: 10 * 10 * 5 * density,
+        fe,
+        geology,
+        hardness,
+      });
+    }
+  }
+  return { cells, blastPolygon };
+}

--- a/javascript/packages/baselode/src/grade_blocks/digBlockOptimizer.js
+++ b/javascript/packages/baselode/src/grade_blocks/digBlockOptimizer.js
@@ -39,18 +39,6 @@ function normalizePolygon(polygon) {
   return points;
 }
 
-function pointInPolygon(point, polygon) {
-  let inside = false;
-  for (let i = 0, j = polygon.length - 1; i < polygon.length; j = i, i += 1) {
-    const a = polygon[i];
-    const b = polygon[j];
-    const intersects = ((a.y > point.y) !== (b.y > point.y))
-      && point.x < ((b.x - a.x) * (point.y - a.y)) / ((b.y - a.y) || EPSILON) + a.x;
-    if (intersects) inside = !inside;
-  }
-  return inside;
-}
-
 function polygonArea(points) {
   let area = 0;
   for (let index = 0; index < points.length; index += 1) {
@@ -156,28 +144,41 @@ function range(prefix, start, end) {
   return prefix[end] - prefix[start];
 }
 
-function scoreSegment(cells, prefix, categories, start, end, bandDepth, targetGrade, options) {
-  const tonnes = range(prefix.tonnes, start, end);
-  const grade = range(prefix.grade, start, end) / Math.max(tonnes, EPSILON);
-  const hardnessMean = range(prefix.hardness, start, end) / Math.max(tonnes, EPSILON);
-  const hardnessVariance = Math.max(0, range(prefix.hardnessSquared, start, end) / Math.max(tonnes, EPSILON) - hardnessMean ** 2);
-  const faceWidth = Math.max(cells[end - 1].crossMax - cells[start].crossMin, EPSILON);
-  const ratio = faceWidth / Math.max(bandDepth, EPSILON);
-  const tonnesPenalty = ((tonnes - options.targetTonnes) / options.targetTonnes) ** 2;
-  const gradePenalty = ((grade - targetGrade) / options.gradeScale) ** 2;
+function scorePhysicals(stats, targetGrade, options) {
+  const tonnesPenalty = ((stats.tonnes - options.targetTonnes) / options.targetTonnes) ** 2;
+  const gradePenalty = ((stats.grade - targetGrade) / options.gradeScale) ** 2;
+  const ratio = stats.faceWidth / Math.max(stats.bandDepth, EPSILON);
   const ratioPenalty = Math.log(Math.max(ratio, 0.05) / options.targetFaceToDepthRatio) ** 2;
-  const widthPenalty = Math.max(0, (options.minFaceWidth - faceWidth) / options.minFaceWidth) ** 2;
-  let dominantTonnes = 0;
-  for (const category of categories) dominantTonnes = Math.max(dominantTonnes, range(prefix.categories[category], start, end));
-  const materialPenalty = tonnes ? 1 - dominantTonnes / tonnes : 0;
-  const hardnessPenalty = hardnessVariance / Math.max(hardnessMean ** 2, 1);
+  const widthPenalty = Math.max(0, (options.minFaceWidth - stats.faceWidth) / options.minFaceWidth) ** 2;
+  const dominantTonnes = Math.max(0, ...Object.values(stats.geologyTonnes));
+  const materialPenalty = stats.tonnes ? 1 - dominantTonnes / stats.tonnes : 0;
+  const hardnessPenalty = stats.hardnessVariance / Math.max(stats.hardnessMean ** 2, 1);
   const score = options.weights.tonnes * tonnesPenalty
     + options.weights.grade * gradePenalty
     + options.weights.shape * (ratioPenalty + 2 * widthPenalty)
     + options.weights.material * materialPenalty
     + options.weights.hardness * hardnessPenalty
     - 0.1 * options.weights.tonnes;
-  return { score, tonnes, grade, hardnessMean, faceWidth, ratio, materialPenalty };
+  return { score, ratio, materialPenalty };
+}
+
+function scoreSegment(cells, prefix, categories, start, end, bandDepth, targetGrade, options) {
+  const tonnes = range(prefix.tonnes, start, end);
+  const grade = range(prefix.grade, start, end) / Math.max(tonnes, EPSILON);
+  const hardnessMean = range(prefix.hardness, start, end) / Math.max(tonnes, EPSILON);
+  const hardnessVariance = Math.max(0, range(prefix.hardnessSquared, start, end) / Math.max(tonnes, EPSILON) - hardnessMean ** 2);
+  const faceWidth = Math.max(cells[end - 1].crossMax - cells[start].crossMin, EPSILON);
+  const geologyTonnes = Object.fromEntries(categories.map((category) => [category, range(prefix.categories[category], start, end)]));
+  const scored = scorePhysicals({
+    tonnes,
+    grade,
+    hardnessMean,
+    hardnessVariance,
+    faceWidth,
+    bandDepth,
+    geologyTonnes,
+  }, targetGrade, options);
+  return { ...scored, tonnes, grade, hardnessMean, hardnessVariance, faceWidth, geologyTonnes };
 }
 
 function lowerBound(values, target, end) {
@@ -282,6 +283,90 @@ function partitionBand(cells, band, targetGrade, options, blastBounds, blastDig,
   });
 }
 
+function applyExactCellIntersections(blocks, cells, targetGrade, options) {
+  const assignments = [];
+  const exactBlocks = blocks.map((block) => {
+    const polygon = block.polygon.slice(0, -1).map(([x, y]) => ({ x, y }));
+    const blockBounds = {
+      minX: Math.min(...polygon.map((point) => point.x)),
+      maxX: Math.max(...polygon.map((point) => point.x)),
+      minY: Math.min(...polygon.map((point) => point.y)),
+      maxY: Math.max(...polygon.map((point) => point.y)),
+    };
+    let tonnes = 0;
+    let gradeMass = 0;
+    let hardnessMass = 0;
+    let hardnessSquaredMass = 0;
+    let intersectionArea = 0;
+    let volume = 0;
+    let volumeComplete = true;
+    const geologyTonnes = {};
+    const cellIds = [];
+
+    for (const cell of cells) {
+      const minX = cell.x - cell.dx / 2;
+      const maxX = cell.x + cell.dx / 2;
+      const minY = cell.y - cell.dy / 2;
+      const maxY = cell.y + cell.dy / 2;
+      if (maxX <= blockBounds.minX + EPSILON || minX >= blockBounds.maxX - EPSILON
+        || maxY <= blockBounds.minY + EPSILON || minY >= blockBounds.maxY - EPSILON) continue;
+      const intersection = clipPolygonToRect(polygon, minX, maxX, minY, maxY);
+      const area = Math.min(cell.sourceArea, polygonArea(intersection));
+      if (area <= EPSILON) continue;
+      const cellFraction = clamp(area / cell.sourceArea, 0, 1);
+      const contributionTonnes = cell.sourceTonnes * cellFraction;
+      const contributionVolume = cell.dz === null ? null : area * cell.dz;
+      tonnes += contributionTonnes;
+      gradeMass += contributionTonnes * cell.fe;
+      hardnessMass += contributionTonnes * cell.hardness;
+      hardnessSquaredMass += contributionTonnes * cell.hardness * cell.hardness;
+      intersectionArea += area;
+      if (contributionVolume === null) volumeComplete = false;
+      else volume += contributionVolume;
+      geologyTonnes[cell.geology] = (geologyTonnes[cell.geology] || 0) + contributionTonnes;
+      cellIds.push(cell.id);
+      assignments.push({
+        cellId: cell.id,
+        digBlockId: block.id,
+        intersectionArea: area,
+        intersectionVolume: contributionVolume,
+        cellFraction,
+        blastFraction: cell.blastFraction,
+        tonnes: contributionTonnes,
+      });
+    }
+
+    const headGrade = gradeMass / Math.max(tonnes, EPSILON);
+    const averageHardness = hardnessMass / Math.max(tonnes, EPSILON);
+    const hardnessVariance = Math.max(0, hardnessSquaredMass / Math.max(tonnes, EPSILON) - averageHardness ** 2);
+    const dominantGeology = Object.entries(geologyTonnes)
+      .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))[0]?.[0] || null;
+    const scored = scorePhysicals({
+      tonnes,
+      grade: headGrade,
+      hardnessMean: averageHardness,
+      hardnessVariance,
+      faceWidth: block.faceWidth,
+      bandDepth: block.advanceDepth,
+      geologyTonnes,
+    }, targetGrade, options);
+    return {
+      ...block,
+      cellIds,
+      tonnes,
+      headGrade,
+      averageHardness,
+      dominantGeology,
+      geologyTonnes,
+      intersectionArea,
+      volume: volumeComplete ? volume : null,
+      faceToDepthRatio: scored.ratio,
+      score: scored.score,
+    };
+  });
+  return { blocks: exactBlocks, assignments };
+}
+
 function normalizeOptions(options, cells) {
   const targetTonnes = finiteNumber(options.targetTonnes, DEFAULT_OPTIONS.targetTonnes);
   if (!(targetTonnes > 0)) throw new Error('targetTonnes must be greater than zero');
@@ -303,8 +388,9 @@ function normalizeOptions(options, cells) {
 /**
  * Partition a single-bench block model into direction-aligned dig blocks.
  *
- * Cells are selected by centre point. `tonnes` and `fe` are required numeric
- * physicals; `geology` and `hardness` are optional scoring attributes.
+ * Axis-aligned cell footprints are intersected exactly in XY. Tonnage and
+ * grade contributions are prorated by intersection area; when `dz` is
+ * supplied the corresponding vertical-prism intersection volume is returned.
  *
  * @param {Array<object>} inputCells - Block-model cells
  * @param {Array<Array<number>>|object} blastPolygon - XY ring or GeoJSON Polygon
@@ -319,21 +405,32 @@ export function optimizeDigBlocks(inputCells, blastPolygon, inputOptions = {}) {
   const cells = inputCells.map((cell, index) => {
     const x = finiteNumber(cell.x);
     const y = finiteNumber(cell.y);
-    const tonnes = finiteNumber(cell.tonnes);
+    const sourceTonnes = finiteNumber(cell.tonnes);
     const fe = finiteNumber(cell.fe);
-    if (![x, y, tonnes, fe].every(Number.isFinite) || tonnes <= 0) {
-      throw new Error(`cell ${cell.id ?? index} requires finite x, y, positive tonnes and fe`);
-    }
-    const dig = toDigPoint({ x, y }, axes);
     const dx = Math.abs(finiteNumber(cell.dx, 1));
     const dy = Math.abs(finiteNumber(cell.dy, 1));
+    if (![x, y, sourceTonnes, fe, dx, dy].every(Number.isFinite) || sourceTonnes <= 0 || dx <= 0 || dy <= 0) {
+      throw new Error(`cell ${cell.id ?? index} requires finite x, y and fe plus positive tonnes, dx and dy`);
+    }
+    const sourceArea = dx * dy;
+    const blastIntersection = clipPolygonToRect(blast, x - dx / 2, x + dx / 2, y - dy / 2, y + dy / 2);
+    const blastIntersectionArea = Math.min(sourceArea, polygonArea(blastIntersection));
+    if (blastIntersectionArea <= EPSILON) return null;
+    const blastFraction = clamp(blastIntersectionArea / sourceArea, 0, 1);
+    const representative = polygonCentroid(blastIntersection);
+    const dig = toDigPoint(representative, axes);
     const projectedHalfCross = (dx * Math.abs(axes.cross.x) + dy * Math.abs(axes.cross.y)) / 2;
+    const inputDz = finiteNumber(cell.dz);
     return {
       ...cell,
       id: String(cell.id ?? `CELL-${index + 1}`),
       x,
       y,
-      tonnes,
+      dx,
+      dy,
+      dz: inputDz > 0 ? inputDz : null,
+      sourceTonnes,
+      tonnes: sourceTonnes * blastFraction,
       fe,
       hardness: finiteNumber(cell.hardness, 1),
       geology: String(cell.geology ?? 'Unclassified'),
@@ -341,17 +438,20 @@ export function optimizeDigBlocks(inputCells, blastPolygon, inputOptions = {}) {
       forward: dig.y,
       crossMin: dig.x - projectedHalfCross,
       crossMax: dig.x + projectedHalfCross,
-      area: dx * dy,
+      sourceArea,
+      area: blastIntersectionArea,
+      blastIntersectionArea,
+      blastFraction,
     };
-  }).filter((cell) => pointInPolygon(cell, blast));
-  if (!cells.length) throw new Error('blastPolygon does not contain any cell centres');
+  }).filter(Boolean);
+  if (!cells.length) throw new Error('blastPolygon does not intersect any cell footprints');
   const options = normalizeOptions(inputOptions, cells);
   const minCross = Math.min(...blastDig.map((point) => point.x));
   const maxCross = Math.max(...blastDig.map((point) => point.x));
   const minForward = Math.min(...blastDig.map((point) => point.y));
   const maxForward = Math.max(...blastDig.map((point) => point.y));
-  const totalTonnes = cells.reduce((sum, cell) => sum + cell.tonnes, 0);
-  const estimatedBlocks = Math.max(1, Math.round(totalTonnes / options.targetTonnes));
+  const estimatedTotalTonnes = cells.reduce((sum, cell) => sum + cell.tonnes, 0);
+  const estimatedBlocks = Math.max(1, Math.round(estimatedTotalTonnes / options.targetTonnes));
   const targetArea = polygonArea(blastDig) / estimatedBlocks;
   const targetDepth = Math.sqrt(targetArea / options.targetFaceToDepthRatio);
   const bandCount = clamp(Math.round((maxForward - minForward) / Math.max(targetDepth, EPSILON)), 1, estimatedBlocks);
@@ -367,9 +467,9 @@ export function optimizeDigBlocks(inputCells, blastPolygon, inputOptions = {}) {
     };
   }).filter((band) => band.cells.length);
 
-  const blocks = [];
+  const provisionalBlocks = [];
   for (const band of bands) {
-    blocks.push(...partitionBand(
+    provisionalBlocks.push(...partitionBand(
       band.cells,
       band,
       options.targetGrade,
@@ -377,13 +477,21 @@ export function optimizeDigBlocks(inputCells, blastPolygon, inputOptions = {}) {
       { minCross, maxCross },
       blastDig,
       axes,
-      blocks.length,
+      provisionalBlocks.length,
     ));
   }
-  const assignments = blocks.flatMap((block) => block.cellIds.map((cellId) => ({ cellId, digBlockId: block.id })));
+  const exact = applyExactCellIntersections(provisionalBlocks, cells, options.targetGrade, options);
+  const blocks = exact.blocks;
+  const assignments = exact.assignments;
+  const totalTonnes = blocks.reduce((sum, block) => sum + block.tonnes, 0);
   const weightedGrade = blocks.reduce((sum, block) => sum + block.tonnes * block.headGrade, 0) / totalTonnes;
   const meanTonnesError = blocks.reduce((sum, block) => sum + Math.abs(block.tonnes - options.targetTonnes) / options.targetTonnes, 0) / blocks.length;
   const meanGradeError = blocks.reduce((sum, block) => sum + Math.abs(block.headGrade - options.targetGrade), 0) / blocks.length;
+  const assignmentCounts = assignments.reduce((counts, assignment) => {
+    counts.set(assignment.cellId, (counts.get(assignment.cellId) || 0) + 1);
+    return counts;
+  }, new Map());
+  const volumesComplete = blocks.every((block) => block.volume !== null);
   return {
     blocks,
     assignments,
@@ -391,8 +499,11 @@ export function optimizeDigBlocks(inputCells, blastPolygon, inputOptions = {}) {
     options,
     metrics: {
       blockCount: blocks.length,
-      assignedCellCount: assignments.length,
+      assignedCellCount: assignmentCounts.size,
+      intersectionCount: assignments.length,
+      splitCellCount: [...assignmentCounts.values()].filter((count) => count > 1).length,
       totalTonnes,
+      totalVolume: volumesComplete ? blocks.reduce((sum, block) => sum + block.volume, 0) : null,
       weightedGrade,
       meanTonnesError,
       meanGradeError,
@@ -408,11 +519,13 @@ export function optimizeDigBlocks(inputCells, blastPolygon, inputOptions = {}) {
  */
 export function createSyntheticDigBlockModel() {
   const blastPolygon = [[10, 0], [155, 0], [180, 20], [175, 78], [145, 100], [22, 95], [0, 75], [0, 20]];
+  const blast = blastPolygon.map(([x, y]) => ({ x, y }));
   const cells = [];
   let index = 0;
   for (let y = 5; y < 105; y += 10) {
     for (let x = 5; x < 185; x += 10) {
-      if (!pointInPolygon({ x, y }, blastPolygon.map(([px, py]) => ({ x: px, y: py })))) continue;
+      const intersection = clipPolygonToRect(blast, x - 5, x + 5, y - 5, y + 5);
+      if (polygonArea(intersection) <= EPSILON) continue;
       const highGradeLens = 8 * Math.exp(-(((x - 65) / 38) ** 2 + ((y - 52) / 24) ** 2));
       const secondLens = 5 * Math.exp(-(((x - 135) / 28) ** 2 + ((y - 35) / 30) ** 2));
       const fe = 52 + highGradeLens + secondLens + 1.4 * Math.sin(x / 17) - 0.8 * Math.cos(y / 13);

--- a/javascript/packages/baselode/src/index.js
+++ b/javascript/packages/baselode/src/index.js
@@ -451,6 +451,12 @@ export {
   addGradeBlocksToScene,
 } from './grade_blocks/gradeBlockLoader.js';
 
+export {
+  optimizeDigBlocks,
+  createSyntheticDigBlockModel,
+  digDirectionAxes,
+} from './grade_blocks/digBlockOptimizer.js';
+
 // --- 3D IDW interpolation ---
 export {
   buildInterpSamplesFromAssays,

--- a/javascript/packages/baselode/tests/digBlockOptimizer.test.js
+++ b/javascript/packages/baselode/tests/digBlockOptimizer.test.js
@@ -57,6 +57,29 @@ describe('optimizeDigBlocks', () => {
     expect(small.blocks[0].polygon).not.toEqual(large.blocks[0].polygon);
   });
 
+  it('partitions thousands of cells in one shallow face band', () => {
+    const cells = Array.from({ length: 5_000 }, (_, index) => ({
+      id: `PERF-${index}`,
+      x: index + 0.5,
+      y: 0.5,
+      dx: 1,
+      dy: 1,
+      tonnes: 2,
+      fe: 55 + (index % 20) / 10,
+      geology: index % 2 ? 'A' : 'B',
+      hardness: 5,
+    }));
+    const result = optimizeDigBlocks(cells, [[0, 0], [5_000, 0], [5_000, 1], [0, 1]], {
+      targetTonnes: 100,
+      targetGrade: 56,
+      targetFaceToDepthRatio: 50,
+    });
+
+    expect(result.assignments).toHaveLength(5_000);
+    expect(result.blocks.length).toBeGreaterThan(50);
+    expect(result.blocks.length).toBeLessThan(150);
+  });
+
   it('rejects invalid physicals and empty selections', () => {
     expect(() => optimizeDigBlocks([{ x: 0, y: 0, tonnes: 1 }], [[-1, -1], [1, -1], [0, 1]]))
       .toThrow(/requires finite/);

--- a/javascript/packages/baselode/tests/digBlockOptimizer.test.js
+++ b/javascript/packages/baselode/tests/digBlockOptimizer.test.js
@@ -21,21 +21,57 @@ describe('digDirectionAxes', () => {
 describe('optimizeDigBlocks', () => {
   const fixture = createSyntheticDigBlockModel();
 
-  it('assigns every eligible cell exactly once', () => {
+  it('conserves exact footprint fractions across dig blocks', () => {
     const result = optimizeDigBlocks(fixture.cells, fixture.blastPolygon, {
       digDirectionDeg: 20,
       targetTonnes: 10_000,
       targetGrade: 58,
     });
     const assignedIds = result.assignments.map(({ cellId }) => cellId);
+    const fractionsByCell = result.assignments.reduce((fractions, assignment) => {
+      fractions.set(assignment.cellId, (fractions.get(assignment.cellId) || 0) + assignment.cellFraction);
+      return fractions;
+    }, new Map());
+    const blastFractionByCell = new Map(result.assignments.map((assignment) => [assignment.cellId, assignment.blastFraction]));
 
     expect(new Set(assignedIds).size).toBe(fixture.cells.length);
-    expect(assignedIds).toHaveLength(fixture.cells.length);
-    expect(result.metrics.totalTonnes).toBeGreaterThan(190_000);
-    expect(result.metrics.totalTonnes).toBeLessThan(220_000);
+    expect(result.assignments.length).toBeGreaterThan(fixture.cells.length);
+    for (const [cellId, fraction] of fractionsByCell) {
+      expect(fraction).toBeCloseTo(blastFractionByCell.get(cellId), 8);
+    }
+    expect(result.metrics.totalTonnes).toBeGreaterThan(195_000);
+    expect(result.metrics.totalTonnes).toBeLessThan(205_000);
+    expect(result.metrics.totalTonnes).toBeCloseTo(result.assignments.reduce((sum, assignment) => sum + assignment.tonnes, 0), 8);
+    expect(result.metrics.totalVolume).toBeCloseTo(result.assignments.reduce((sum, assignment) => sum + assignment.intersectionVolume, 0), 8);
+    expect(result.metrics.assignedCellCount).toBe(fixture.cells.length);
+    expect(result.metrics.intersectionCount).toBe(result.assignments.length);
+    expect(result.metrics.splitCellCount).toBeGreaterThan(0);
     expect(result.blocks).toHaveLength(result.metrics.blockCount);
     expect(result.blocks.every((block) => block.polygon[0][0] === block.polygon.at(-1)[0]
       && block.polygon[0][1] === block.polygon.at(-1)[1])).toBe(true);
+  });
+
+  it('prorates tonnes, grade and volume for a partial boundary cell', () => {
+    const cells = [
+      { id: 'A', x: 0.5, y: 0.5, dx: 1, dy: 1, dz: 2, tonnes: 10, fe: 50 },
+      { id: 'B', x: 1.5, y: 0.5, dx: 1, dy: 1, dz: 2, tonnes: 10, fe: 60 },
+    ];
+    const result = optimizeDigBlocks(cells, [[0.5, 0], [2, 0], [2, 1], [0.5, 1]], { targetTonnes: 100 });
+    const first = result.assignments.find((assignment) => assignment.cellId === 'A');
+    const second = result.assignments.find((assignment) => assignment.cellId === 'B');
+
+    expect(result.blocks).toHaveLength(1);
+    expect(first.cellFraction).toBeCloseTo(0.5);
+    expect(first.intersectionArea).toBeCloseTo(0.5);
+    expect(first.intersectionVolume).toBeCloseTo(1);
+    expect(first.tonnes).toBeCloseTo(5);
+    expect(second.cellFraction).toBeCloseTo(1);
+    expect(second.intersectionVolume).toBeCloseTo(2);
+    expect(second.tonnes).toBeCloseTo(10);
+    expect(result.blocks[0].tonnes).toBeCloseTo(15);
+    expect(result.blocks[0].headGrade).toBeCloseTo(56.6666667);
+    expect(result.blocks[0].volume).toBeCloseTo(3);
+    expect(result.metrics.totalVolume).toBeCloseTo(3);
   });
 
   it('is deterministic for the same controls', () => {
@@ -76,6 +112,7 @@ describe('optimizeDigBlocks', () => {
     });
 
     expect(result.assignments).toHaveLength(5_000);
+    expect(result.metrics.totalVolume).toBeNull();
     expect(result.blocks.length).toBeGreaterThan(50);
     expect(result.blocks.length).toBeLessThan(150);
   });
@@ -84,6 +121,6 @@ describe('optimizeDigBlocks', () => {
     expect(() => optimizeDigBlocks([{ x: 0, y: 0, tonnes: 1 }], [[-1, -1], [1, -1], [0, 1]]))
       .toThrow(/requires finite/);
     expect(() => optimizeDigBlocks(fixture.cells, [[500, 500], [510, 500], [500, 510]]))
-      .toThrow(/does not contain/);
+      .toThrow(/does not intersect/);
   });
 });

--- a/javascript/packages/baselode/tests/digBlockOptimizer.test.js
+++ b/javascript/packages/baselode/tests/digBlockOptimizer.test.js
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2026 Darkmine Pty Ltd
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  createSyntheticDigBlockModel,
+  digDirectionAxes,
+  optimizeDigBlocks,
+} from '../src/grade_blocks/digBlockOptimizer.js';
+
+describe('digDirectionAxes', () => {
+  it('uses bearings clockwise from north', () => {
+    expect(digDirectionAxes(0).forward).toEqual({ x: 0, y: 1 });
+    expect(digDirectionAxes(90).forward.x).toBeCloseTo(1);
+    expect(digDirectionAxes(90).forward.y).toBeCloseTo(0);
+  });
+});
+
+describe('optimizeDigBlocks', () => {
+  const fixture = createSyntheticDigBlockModel();
+
+  it('assigns every eligible cell exactly once', () => {
+    const result = optimizeDigBlocks(fixture.cells, fixture.blastPolygon, {
+      digDirectionDeg: 20,
+      targetTonnes: 10_000,
+      targetGrade: 58,
+    });
+    const assignedIds = result.assignments.map(({ cellId }) => cellId);
+
+    expect(new Set(assignedIds).size).toBe(fixture.cells.length);
+    expect(assignedIds).toHaveLength(fixture.cells.length);
+    expect(result.metrics.totalTonnes).toBeGreaterThan(190_000);
+    expect(result.metrics.totalTonnes).toBeLessThan(220_000);
+    expect(result.blocks).toHaveLength(result.metrics.blockCount);
+    expect(result.blocks.every((block) => block.polygon[0][0] === block.polygon.at(-1)[0]
+      && block.polygon[0][1] === block.polygon.at(-1)[1])).toBe(true);
+  });
+
+  it('is deterministic for the same controls', () => {
+    const options = { digDirectionDeg: 35, targetTonnes: 12_000, targetGrade: 57 };
+    expect(optimizeDigBlocks(fixture.cells, fixture.blastPolygon, options))
+      .toEqual(optimizeDigBlocks(fixture.cells, fixture.blastPolygon, options));
+  });
+
+  it('uses the weighted source grade when no target is supplied', () => {
+    const result = optimizeDigBlocks(fixture.cells, fixture.blastPolygon);
+    expect(result.options.targetGrade).toBeCloseTo(result.metrics.weightedGrade);
+  });
+
+  it('responds to target tonnes and mining direction', () => {
+    const small = optimizeDigBlocks(fixture.cells, fixture.blastPolygon, { targetTonnes: 8_000, digDirectionDeg: 0 });
+    const large = optimizeDigBlocks(fixture.cells, fixture.blastPolygon, { targetTonnes: 16_000, digDirectionDeg: 90 });
+
+    expect(small.blocks.length).toBeGreaterThan(large.blocks.length);
+    expect(small.blocks[0].polygon).not.toEqual(large.blocks[0].polygon);
+  });
+
+  it('rejects invalid physicals and empty selections', () => {
+    expect(() => optimizeDigBlocks([{ x: 0, y: 0, tonnes: 1 }], [[-1, -1], [1, -1], [0, 1]]))
+      .toThrow(/requires finite/);
+    expect(() => optimizeDigBlocks(fixture.cells, [[500, 500], [510, 500], [500, 510]]))
+      .toThrow(/does not contain/);
+  });
+});


### PR DESCRIPTION
## Summary
- add a reusable, deterministic dig-block optimiser for single-bench block models
- add a responsive 2D demo that balances target tonnes, Fe grade, mining direction, shape, geology mixing, and hardness
- classify generated blocks red at/above the target grade cut-off and blue below it
- provide a red/blue versus outline-only display toggle so the source-cell Fe heatmap can be inspected
- calculate exact blast/dig-polygon intersections with axis-aligned source cells, including prorated tonnes and area × cell-height volume
- expose fractional source-cell assignments so boundary and split-cell conservation can be audited
- add a ~200 kt synthetic iron-ore fixture, public API docs, and a 5,000-cell performance regression
- document why MineLib Newman1 is compatible only after caller-supplied block dimensions and grade semantics, and is not redistributed

## Ticket
TRK-389

## Test plan
- `npm run verify` in `javascript/packages/baselode` (705 tests plus build, types, package contracts)
- `npm run build` in `demo-viewer-react/app`
- local browser: `/dig-block-planner`, no console errors; target tonnes 10 kt → 16 kt recomputes from about 20 blocks to 12; block selection shows physicals
- local browser: grade cut-off updates red/blue classes and legend; outline-only mode clears all fills while preserving block selection and source-cell colours
- local browser: exact-intersection fixture reports about 200 kt and 82,138 m³; selected-block tonnes, grade, and volume update from fractional assignments

## Risk
First-pass heuristic only. It expects a convex single-bench blast and axis-aligned vertical-prism cells. Its final physicals use exact 2D polygon intersection and cell height, but it is not a general 3D polyhedron intersection, production scheduler, blast-movement correction, or engineering sign-off tool. Newman1 source data is not bundled because its physical block dimensions and metal semantics are unspecified.

## Reviewer
Claude Sonnet 5 reviewed the committed branch against `main`. One P2 performance finding was fixed with a bounded-transition shortest-path search and 5,000-cell regression; follow-up review reported no findings.

The later cutoff-colour, outline-toggle, and exact-intersection commits are package/build/browser verified. A requested Sonnet 5 re-review was blocked by the environment's external code-export guard and remains pending before merge.

Draft only: do not merge until bosmang has tested the demo.
