### PR TITLE
TRK-395: terrain surface primitive for Baselode3DScene

### DIFF
--- a/javascript/packages/baselode/src/index.js
+++ b/javascript/packages/baselode/src/index.js
@@ -394,6 +394,15 @@ export {
 } from './viz/rasterOverlayScene.js';
 
 export {
+  createTerrainSurface,
+  setTerrain,
+  clearTerrain,
+  setTerrainOpacity,
+  setTerrainVisibility,
+  getTerrain,
+} from './viz/terrainScene.js';
+
+export {
   buildViewSignature,
   getViewState,
   setViewState,

--- a/javascript/packages/baselode/src/viz/baselode3dScene.js
+++ b/javascript/packages/baselode/src/viz/baselode3dScene.js
@@ -46,6 +46,13 @@ import {
   listRasterOverlays as _listRasterOverlays,
   clearRasterOverlays as _clearRasterOverlays,
 } from './rasterOverlayScene.js';
+import {
+  setTerrain as _setTerrain,
+  clearTerrain as _clearTerrain,
+  setTerrainOpacity as _setTerrainOpacity,
+  setTerrainVisibility as _setTerrainVisibility,
+  getTerrain as _getTerrain,
+} from './terrainScene.js';
 
 /**
  * Baselode 3D Scene Manager
@@ -88,6 +95,7 @@ class Baselode3DScene {
     this._blockHighlightMesh = null;
     this._outlinePass = null;
     this.rasterOverlays = new Map();
+    this.terrain = null;
   }
 
   init(container) {
@@ -246,6 +254,7 @@ class Baselode3DScene {
     _clearStripLogs(this);
     _clearStructuralDiscs(this);
     _clearRasterOverlays(this);
+    _clearTerrain(this);
     disposeSelectionGlow(this);
     if (this.container && this._wheelRelay) {
       this.container.removeEventListener('wheel', this._wheelRelay);
@@ -444,6 +453,39 @@ class Baselode3DScene {
    * @returns {object[]}
    */
   listRasterOverlays() { return _listRasterOverlays(this); }
+
+  // ---------------------------------------------------------------------------
+  // Terrain surface API — delegate to terrainScene
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Set the scene's terrain layer, replacing and disposing any existing one.
+   * @param {object} layer - Layer descriptor returned by createTerrainSurface()
+   */
+  setTerrain(layer) { _setTerrain(this, layer); }
+
+  /**
+   * Remove the scene's terrain layer (if any) and dispose its GPU resources.
+   */
+  clearTerrain() { _clearTerrain(this); }
+
+  /**
+   * Set the terrain layer's opacity at runtime.
+   * @param {number} opacity - New opacity [0, 1]
+   */
+  setTerrainOpacity(opacity) { _setTerrainOpacity(this, opacity); }
+
+  /**
+   * Show or hide the terrain layer.
+   * @param {boolean} visible
+   */
+  setTerrainVisible(visible) { _setTerrainVisibility(this, visible); }
+
+  /**
+   * Return the scene's current terrain layer, or null if none is set.
+   * @returns {object|null}
+   */
+  getTerrain() { return _getTerrain(this); }
 }
 
 export default Baselode3DScene;

--- a/javascript/packages/baselode/src/viz/terrainScene.js
+++ b/javascript/packages/baselode/src/viz/terrainScene.js
@@ -35,6 +35,11 @@ function normalizeGrid(grid) {
     source = new Float32Array(width * height);
     for (let row = 0; row < height; row++) {
       const rowValues = grid.elevations[row];
+      if (!Array.isArray(rowValues) || rowValues.length !== width) {
+        throw new Error(
+          `terrain surface: grid.elevations is ragged — row ${row} has length ${rowValues?.length}, expected ${width}`
+        );
+      }
       for (let col = 0; col < width; col++) {
         source[row * width + col] = Number(rowValues[col]);
       }
@@ -85,15 +90,19 @@ function decimateGrid({ width, height, elevations }, maxDimension) {
     return { width, height, elevations };
   }
 
-  const stride = Math.ceil(longest / maxDimension);
-  const outWidth = Math.max(2, Math.ceil(width / stride));
-  const outHeight = Math.max(2, Math.ceil(height / stride));
+  const scale = maxDimension / longest;
+  const outWidth = Math.max(2, Math.round(width * scale));
+  const outHeight = Math.max(2, Math.round(height * scale));
   const out = new Float32Array(outWidth * outHeight);
 
+  // Evenly spaced source indices spanning the FULL source extent (0..dim-1),
+  // not a fixed stride — a fixed stride under-runs the far edge (e.g. a
+  // 1000-cell dimension with stride 4 stops at source cell 996), which
+  // stretches/misaligns the terrain against its declared bounds.
   for (let row = 0; row < outHeight; row++) {
-    const srcRow = Math.min(row * stride, height - 1);
+    const srcRow = outHeight > 1 ? Math.round((row * (height - 1)) / (outHeight - 1)) : 0;
     for (let col = 0; col < outWidth; col++) {
-      const srcCol = Math.min(col * stride, width - 1);
+      const srcCol = outWidth > 1 ? Math.round((col * (width - 1)) / (outWidth - 1)) : 0;
       out[row * outWidth + col] = elevations[srcRow * width + srcCol];
     }
   }

--- a/javascript/packages/baselode/src/viz/terrainScene.js
+++ b/javascript/packages/baselode/src/viz/terrainScene.js
@@ -32,6 +32,9 @@ function normalizeGrid(grid) {
   if (Array.isArray(grid.elevations) && Array.isArray(grid.elevations[0])) {
     height = grid.elevations.length;
     width = grid.elevations[0].length;
+    if (width < 2 || height < 2) {
+      throw new Error('terrain surface: grid.elevations must have at least 2 rows and 2 columns');
+    }
     source = new Float32Array(width * height);
     for (let row = 0; row < height; row++) {
       const rowValues = grid.elevations[row];

--- a/javascript/packages/baselode/src/viz/terrainScene.js
+++ b/javascript/packages/baselode/src/viz/terrainScene.js
@@ -259,7 +259,12 @@ export function createTerrainSurface(options = {}) {
   const id = options.id ?? `terrain-surface-${++_terrainIdCounter}`;
   const name = options.name ?? id;
   const verticalExaggeration = options.verticalExaggeration ?? 1;
-  const maxDimension = options.vertexBudget ?? DEFAULT_MAX_DIMENSION;
+  // A non-positive/non-finite budget (e.g. 0 from an unset slider) must not
+  // disable decimation — fall back to the default safety budget rather than
+  // letting decimateGrid's `!maxDimension` check treat it as "no limit".
+  const maxDimension = Number.isFinite(options.vertexBudget) && options.vertexBudget > 0
+    ? options.vertexBudget
+    : DEFAULT_MAX_DIMENSION;
   const skirt = options.skirt ?? false;
   const visible = options.visible ?? true;
   const renderOrder = options.renderOrder ?? -1;

--- a/javascript/packages/baselode/src/viz/terrainScene.js
+++ b/javascript/packages/baselode/src/viz/terrainScene.js
@@ -47,8 +47,8 @@ function normalizeGrid(grid) {
   } else {
     width = Number(grid.width);
     height = Number(grid.height);
-    if (!Number.isFinite(width) || !Number.isFinite(height) || width < 2 || height < 2) {
-      throw new Error('terrain surface: grid.width/grid.height must be >= 2 for a flat elevations array');
+    if (!Number.isInteger(width) || !Number.isInteger(height) || width < 2 || height < 2) {
+      throw new Error('terrain surface: grid.width/grid.height must be integers >= 2 for a flat elevations array');
     }
     source = Float32Array.from(grid.elevations, Number);
     if (source.length !== width * height) {

--- a/javascript/packages/baselode/src/viz/terrainScene.js
+++ b/javascript/packages/baselode/src/viz/terrainScene.js
@@ -1,0 +1,373 @@
+/*
+ * Copyright (C) 2026 Darkmine Pty Ltd
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+import * as THREE from 'three';
+
+const DEFAULT_MAX_DIMENSION = 300;
+
+let _terrainIdCounter = 0;
+
+/**
+ * Normalize a caller-supplied elevation grid to a flat row-major Float32Array
+ * plus width/height, with NoData cells converted to NaN.
+ *
+ * Accepts either a flat row-major array (grid.elevations + grid.width/height)
+ * or a nested number[][] (grid.elevations as rows of columns; width/height
+ * inferred from its shape). Row 0 is the north edge (maps to bounds.maxY),
+ * matching createRasterOverlay's image-top-row-is-north convention.
+ *
+ * This module has no CRS awareness — bounds and grid coordinates must already
+ * be in the same projected/local units the rest of the scene uses.
+ *
+ * @param {object} grid
+ * @returns {{ width: number, height: number, elevations: Float32Array }}
+ */
+function normalizeGrid(grid) {
+  if (!grid || !grid.elevations) {
+    throw new Error('terrain surface: grid.elevations is required');
+  }
+
+  let width, height, source;
+  if (Array.isArray(grid.elevations) && Array.isArray(grid.elevations[0])) {
+    height = grid.elevations.length;
+    width = grid.elevations[0].length;
+    source = new Float32Array(width * height);
+    for (let row = 0; row < height; row++) {
+      const rowValues = grid.elevations[row];
+      for (let col = 0; col < width; col++) {
+        source[row * width + col] = Number(rowValues[col]);
+      }
+    }
+  } else {
+    width = Number(grid.width);
+    height = Number(grid.height);
+    if (!Number.isFinite(width) || !Number.isFinite(height) || width < 2 || height < 2) {
+      throw new Error('terrain surface: grid.width/grid.height must be >= 2 for a flat elevations array');
+    }
+    source = Float32Array.from(grid.elevations, Number);
+    if (source.length !== width * height) {
+      throw new Error(
+        `terrain surface: grid.elevations length (${source.length}) does not match width*height (${width * height})`
+      );
+    }
+  }
+
+  // Compare against the nodata sentinel rounded to float32 — `source` is a
+  // Float32Array, so a float64 sentinel (e.g. -3.4e38) can silently fail to
+  // exact-match the already-rounded stored value otherwise.
+  const nodata = grid.nodata;
+  const nodataIsFinite = Number.isFinite(nodata);
+  const nodataF32 = nodataIsFinite ? Math.fround(nodata) : NaN;
+  for (let i = 0; i < source.length; i++) {
+    const value = source[i];
+    if (!Number.isFinite(value) || (nodataIsFinite && value === nodataF32)) {
+      source[i] = NaN;
+    }
+  }
+
+  return { width, height, elevations: source };
+}
+
+/**
+ * Decimate a grid to keep its longest dimension within maxDimension, using
+ * nearest-neighbour striding. Nearest-neighbour (rather than averaging) means
+ * a NoData source cell stays NoData in the output instead of being blended
+ * into a fabricated elevation.
+ *
+ * @param {{ width: number, height: number, elevations: Float32Array }} source
+ * @param {number} maxDimension
+ * @returns {{ width: number, height: number, elevations: Float32Array }}
+ */
+function decimateGrid({ width, height, elevations }, maxDimension) {
+  const longest = Math.max(width, height);
+  if (!maxDimension || longest <= maxDimension) {
+    return { width, height, elevations };
+  }
+
+  const stride = Math.ceil(longest / maxDimension);
+  const outWidth = Math.max(2, Math.ceil(width / stride));
+  const outHeight = Math.max(2, Math.ceil(height / stride));
+  const out = new Float32Array(outWidth * outHeight);
+
+  for (let row = 0; row < outHeight; row++) {
+    const srcRow = Math.min(row * stride, height - 1);
+    for (let col = 0; col < outWidth; col++) {
+      const srcCol = Math.min(col * stride, width - 1);
+      out[row * outWidth + col] = elevations[srcRow * width + srcCol];
+    }
+  }
+
+  return { width: outWidth, height: outHeight, elevations: out };
+}
+
+/**
+ * Append a vertical wall around the grid's outer rectangular perimeter,
+ * dropping from each valid perimeter vertex down to `skirtZ` (already scaled
+ * by verticalExaggeration). This is a render-only fill so the terrain sheet
+ * doesn't look paper-thin from a low camera angle at the survey window's
+ * edge — it is not sampled elevation data. It does not attempt to close
+ * interior NoData holes, only the outer rectangle.
+ */
+function appendPerimeterSkirt({ width, height, isValid, vertexIndex }, positions, indices, skirtZ) {
+  let nextIndex = positions.length / 3;
+
+  const addWallSegment = (row1, col1, row2, col2) => {
+    if (!isValid(row1, col1) || !isValid(row2, col2)) return;
+    const i1 = vertexIndex(row1, col1);
+    const i2 = vertexIndex(row2, col2);
+    const x1 = positions[i1 * 3], y1 = positions[i1 * 3 + 1];
+    const x2 = positions[i2 * 3], y2 = positions[i2 * 3 + 1];
+
+    const skirtA = nextIndex++;
+    positions.push(x1, y1, skirtZ);
+    const skirtB = nextIndex++;
+    positions.push(x2, y2, skirtZ);
+
+    indices.push(i1, i2, skirtB, i1, skirtB, skirtA);
+  };
+
+  for (let col = 0; col < width - 1; col++) {
+    addWallSegment(0, col, 0, col + 1);
+    addWallSegment(height - 1, col, height - 1, col + 1);
+  }
+  for (let row = 0; row < height - 1; row++) {
+    addWallSegment(row, 0, row + 1, 0);
+    addWallSegment(row, width - 1, row + 1, width - 1);
+  }
+}
+
+/**
+ * Build a THREE.BufferGeometry height-grid surface from a decimated,
+ * NoData-nulled elevation grid.
+ *
+ * Quads with any NaN corner are omitted entirely — real holes in the mesh,
+ * not fake elevations. Returns { geometry: null, elevationRange: null } when
+ * the grid has no valid data at all (e.g. a window entirely outside DEM
+ * coverage), so the caller can produce an empty terrain layer instead of
+ * throwing or rendering a garbage surface.
+ */
+function buildGeometry(gridData, bounds, { verticalExaggeration, skirt, skirtDepth }) {
+  const { width, height, elevations } = gridData;
+  const { minX, minY, maxX, maxY } = bounds;
+  const stepX = width > 1 ? (maxX - minX) / (width - 1) : 0;
+  const stepY = height > 1 ? (maxY - minY) / (height - 1) : 0;
+
+  const vertexIndex = (row, col) => row * width + col;
+  const isValid = (row, col) => Number.isFinite(elevations[vertexIndex(row, col)]);
+
+  const positions = [];
+  const indices = [];
+  let min = Infinity, max = -Infinity;
+
+  for (let row = 0; row < height; row++) {
+    for (let col = 0; col < width; col++) {
+      const elevation = elevations[vertexIndex(row, col)];
+      const x = minX + col * stepX;
+      // Row 0 is the north edge -> maps to maxY (matches createRasterOverlay's
+      // image-top-row-is-north convention).
+      const y = maxY - row * stepY;
+      const z = Number.isFinite(elevation) ? elevation * verticalExaggeration : 0;
+      positions.push(x, y, z);
+      if (Number.isFinite(elevation)) {
+        min = Math.min(min, elevation);
+        max = Math.max(max, elevation);
+      }
+    }
+  }
+
+  for (let row = 0; row < height - 1; row++) {
+    for (let col = 0; col < width - 1; col++) {
+      if (!isValid(row, col) || !isValid(row, col + 1) || !isValid(row + 1, col + 1) || !isValid(row + 1, col)) {
+        continue;
+      }
+      const a = vertexIndex(row, col);
+      const b = vertexIndex(row, col + 1);
+      const c = vertexIndex(row + 1, col + 1);
+      const d = vertexIndex(row + 1, col);
+      indices.push(a, b, c, a, c, d);
+    }
+  }
+
+  if (indices.length === 0 || !Number.isFinite(min)) {
+    return { geometry: null, elevationRange: null };
+  }
+
+  if (skirt) {
+    const depth = Number.isFinite(skirtDepth) ? skirtDepth : min - Math.max(max - min, 1) * 0.1;
+    appendPerimeterSkirt({ width, height, isValid, vertexIndex }, positions, indices, depth * verticalExaggeration);
+  }
+
+  const geometry = new THREE.BufferGeometry();
+  geometry.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3));
+  geometry.setIndex(indices);
+  geometry.computeVertexNormals();
+
+  return { geometry, elevationRange: { min, max } };
+}
+
+/**
+ * Create a terrain surface layer from a sampled elevation grid.
+ *
+ * The grid and bounds must already be in the same projected/local scene
+ * units as the rest of the scene (drillholes, blocks, etc.) — this package
+ * has no CRS awareness and does not reproject anything. Callers windowing a
+ * DEM COG must reproject and NoData-null the samples themselves before
+ * calling this.
+ *
+ * @param {object} options
+ * @param {string} [options.id] - Unique identifier; auto-generated if omitted
+ * @param {string} [options.name] - Human-readable display name
+ * @param {object} options.grid - { width, height, elevations, nodata } or { elevations: number[][], nodata }
+ * @param {object} options.bounds - { minX, minY, maxX, maxY } in scene units
+ * @param {number} [options.verticalExaggeration=1] - Explicit Z scale factor; never applied silently by this module
+ * @param {number} [options.vertexBudget] - Max vertices along the grid's longest dimension (default 300)
+ * @param {boolean} [options.skirt=false] - Add a render-only wall around the outer valid-data perimeter
+ * @param {number} [options.skirtDepth] - Absolute elevation for the skirt base; defaults to just below the sampled minimum
+ * @param {number} [options.opacity=1] - Initial opacity [0, 1]; clamped if out of range
+ * @param {boolean} [options.visible=true] - Initial visibility
+ * @param {number} [options.renderOrder=-1] - THREE.js renderOrder; terrain defaults to drawing before other layers
+ * @returns {object} Terrain surface layer descriptor. `mesh` is null (and `empty` is true) when the window has no valid data.
+ */
+export function createTerrainSurface(options = {}) {
+  const { grid, bounds } = options;
+  if (!grid) throw new Error('terrain surface: options.grid is required');
+  if (!bounds) throw new Error('terrain surface: options.bounds is required');
+
+  const minX = Number(bounds.minX);
+  const minY = Number(bounds.minY);
+  const maxX = Number(bounds.maxX);
+  const maxY = Number(bounds.maxY);
+  if (!(maxX - minX > 0) || !(maxY - minY > 0)) {
+    throw new Error(
+      `terrain surface: invalid bounds (minX=${minX}, maxX=${maxX}, minY=${minY}, maxY=${maxY})`
+    );
+  }
+
+  const id = options.id ?? `terrain-surface-${++_terrainIdCounter}`;
+  const name = options.name ?? id;
+  const verticalExaggeration = options.verticalExaggeration ?? 1;
+  const maxDimension = options.vertexBudget ?? DEFAULT_MAX_DIMENSION;
+  const skirt = options.skirt ?? false;
+  const visible = options.visible ?? true;
+  const renderOrder = options.renderOrder ?? -1;
+
+  let opacity = options.opacity ?? 1;
+  if (opacity < 0 || opacity > 1) {
+    console.warn(
+      `[baselode] terrain surface "${id}": opacity ${opacity} is outside [0, 1] — clamped`
+    );
+    opacity = Math.max(0, Math.min(1, opacity));
+  }
+
+  const normalized = normalizeGrid(grid);
+  const decimated = decimateGrid(normalized, maxDimension);
+  const { geometry, elevationRange } = buildGeometry(
+    decimated,
+    { minX, minY, maxX, maxY },
+    { verticalExaggeration, skirt, skirtDepth: options.skirtDepth }
+  );
+
+  const boundsOut = { minX, minY, maxX, maxY };
+
+  if (!geometry) {
+    // Window entirely outside DEM coverage / all-NoData: an empty layer, not
+    // a crash or a fabricated flat surface.
+    return {
+      id, name, mesh: null, bounds: boundsOut, elevationRange: null,
+      verticalExaggeration, opacity, visible, empty: true,
+    };
+  }
+
+  const material = new THREE.MeshLambertMaterial({
+    color: 0x8a8a7a,
+    transparent: opacity < 1,
+    opacity,
+    side: THREE.DoubleSide,
+  });
+
+  const mesh = new THREE.Mesh(geometry, material);
+  mesh.visible = visible;
+  mesh.renderOrder = renderOrder;
+
+  return {
+    id, name, mesh, bounds: boundsOut, elevationRange,
+    verticalExaggeration, opacity, visible, empty: false,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Scene-level helpers — all operate on a Baselode3DScene instance.
+// A scene has a single active terrain layer (v1); setting a new one replaces
+// and disposes the previous one, mirroring rasterOverlayScene's same-id
+// replace behaviour.
+// ---------------------------------------------------------------------------
+
+/**
+ * Set the scene's terrain layer, replacing and disposing any existing one.
+ *
+ * @param {object} sceneCtx - Baselode3DScene instance
+ * @param {object} layer - Layer returned by createTerrainSurface()
+ */
+export function setTerrain(sceneCtx, layer) {
+  if (!sceneCtx.scene) return;
+  clearTerrain(sceneCtx);
+  sceneCtx.terrain = layer ?? null;
+  if (layer?.mesh) {
+    sceneCtx.scene.add(layer.mesh);
+  }
+}
+
+/**
+ * Remove the scene's terrain layer (if any) and dispose its GPU resources.
+ *
+ * @param {object} sceneCtx - Baselode3DScene instance
+ */
+export function clearTerrain(sceneCtx) {
+  const layer = sceneCtx.terrain;
+  if (layer?.mesh) {
+    sceneCtx.scene?.remove(layer.mesh);
+    layer.mesh.geometry.dispose();
+    layer.mesh.material.dispose();
+  }
+  sceneCtx.terrain = null;
+}
+
+/**
+ * Set the terrain layer's opacity at runtime without recreating geometry.
+ *
+ * @param {object} sceneCtx - Baselode3DScene instance
+ * @param {number} opacity - New opacity [0, 1]; clamped if out of range
+ */
+export function setTerrainOpacity(sceneCtx, opacity) {
+  const layer = sceneCtx.terrain;
+  if (!layer?.mesh) return;
+  const clamped = Math.max(0, Math.min(1, Number(opacity)));
+  layer.opacity = clamped;
+  layer.mesh.material.opacity = clamped;
+  layer.mesh.material.transparent = clamped < 1;
+  layer.mesh.material.needsUpdate = true;
+}
+
+/**
+ * Show or hide the terrain layer without destroying it.
+ *
+ * @param {object} sceneCtx - Baselode3DScene instance
+ * @param {boolean} visible
+ */
+export function setTerrainVisibility(sceneCtx, visible) {
+  const layer = sceneCtx.terrain;
+  if (!layer) return;
+  layer.visible = Boolean(visible);
+  if (layer.mesh) layer.mesh.visible = layer.visible;
+}
+
+/**
+ * Return the scene's current terrain layer, or null if none is set.
+ *
+ * @param {object} sceneCtx - Baselode3DScene instance
+ * @returns {object|null}
+ */
+export function getTerrain(sceneCtx) {
+  return sceneCtx.terrain ?? null;
+}

--- a/javascript/packages/baselode/tests/terrainScene.test.js
+++ b/javascript/packages/baselode/tests/terrainScene.test.js
@@ -128,6 +128,13 @@ describe('createTerrainSurface — geometry', () => {
     expect(Math.sqrt(positionCount)).toBeLessThan(100);
   });
 
+  it('falls back to the default budget instead of disabling decimation when vertexBudget is 0', () => {
+    const grid = flatGrid(1000, 1000);
+    const layer = createTerrainSurface({ grid, bounds: BOUNDS, vertexBudget: 0 });
+    const positionCount = layer.mesh.geometry.getAttribute('position').count;
+    expect(Math.sqrt(positionCount)).toBeLessThan(400);
+  });
+
   it('decimated grids still span the full declared bounds edge-to-edge', () => {
     // Non-round dimensions that don't divide evenly into the vertex budget —
     // a fixed-stride decimation under-runs the far edge here.

--- a/javascript/packages/baselode/tests/terrainScene.test.js
+++ b/javascript/packages/baselode/tests/terrainScene.test.js
@@ -84,6 +84,15 @@ describe('createTerrainSurface — validation', () => {
     expect(layer.mesh).not.toBeNull();
   });
 
+  it('throws on a degenerate single-row nested grid instead of silently returning an empty terrain', () => {
+    expect(() =>
+      createTerrainSurface({
+        grid: { elevations: [[1, 2]] },
+        bounds: BOUNDS,
+      })
+    ).toThrow(/at least 2 rows/);
+  });
+
   it('throws on a ragged nested grid instead of silently truncating rows', () => {
     expect(() =>
       createTerrainSurface({

--- a/javascript/packages/baselode/tests/terrainScene.test.js
+++ b/javascript/packages/baselode/tests/terrainScene.test.js
@@ -57,6 +57,15 @@ describe('createTerrainSurface — validation', () => {
     ).toThrow(/invalid bounds/);
   });
 
+  it('throws on fractional flat-grid dimensions instead of silently producing an empty terrain', () => {
+    expect(() =>
+      createTerrainSurface({
+        grid: { width: 2.5, height: 2, elevations: [1, 2, 3, 4, 5] },
+        bounds: BOUNDS,
+      })
+    ).toThrow(/integers/);
+  });
+
   it('throws when flat elevations length does not match width*height', () => {
     expect(() =>
       createTerrainSurface({

--- a/javascript/packages/baselode/tests/terrainScene.test.js
+++ b/javascript/packages/baselode/tests/terrainScene.test.js
@@ -74,6 +74,15 @@ describe('createTerrainSurface — validation', () => {
     expect(layer.empty).toBe(false);
     expect(layer.mesh).not.toBeNull();
   });
+
+  it('throws on a ragged nested grid instead of silently truncating rows', () => {
+    expect(() =>
+      createTerrainSurface({
+        grid: { elevations: [[1, 2, 3], [4, 5]] },
+        bounds: BOUNDS,
+      })
+    ).toThrow(/ragged/);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -99,6 +108,26 @@ describe('createTerrainSurface — geometry', () => {
     const positionCount = layer.mesh.geometry.getAttribute('position').count;
     // decimated grid's longest dimension should be close to the budget, not 1000
     expect(Math.sqrt(positionCount)).toBeLessThan(100);
+  });
+
+  it('decimated grids still span the full declared bounds edge-to-edge', () => {
+    // Non-round dimensions that don't divide evenly into the vertex budget —
+    // a fixed-stride decimation under-runs the far edge here.
+    const width = 37, height = 41;
+    const grid = { width, height, elevations: new Array(width * height).fill(5) };
+    const layer = createTerrainSurface({ grid, bounds: BOUNDS, vertexBudget: 6 });
+    const position = layer.mesh.geometry.getAttribute('position');
+    let minXSeen = Infinity, maxXSeen = -Infinity, minYSeen = Infinity, maxYSeen = -Infinity;
+    for (let i = 0; i < position.count; i++) {
+      minXSeen = Math.min(minXSeen, position.getX(i));
+      maxXSeen = Math.max(maxXSeen, position.getX(i));
+      minYSeen = Math.min(minYSeen, position.getY(i));
+      maxYSeen = Math.max(maxYSeen, position.getY(i));
+    }
+    expect(minXSeen).toBeCloseTo(BOUNDS.minX);
+    expect(maxXSeen).toBeCloseTo(BOUNDS.maxX);
+    expect(minYSeen).toBeCloseTo(BOUNDS.minY);
+    expect(maxYSeen).toBeCloseTo(BOUNDS.maxY);
   });
 
   it('applies verticalExaggeration explicitly to Z, and defaults to 1 (no silent exaggeration)', () => {

--- a/javascript/packages/baselode/tests/terrainScene.test.js
+++ b/javascript/packages/baselode/tests/terrainScene.test.js
@@ -1,0 +1,235 @@
+/*
+ * Copyright (C) 2026 Darkmine Pty Ltd
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import {
+  createTerrainSurface,
+  setTerrain,
+  clearTerrain,
+  setTerrainOpacity,
+  setTerrainVisibility,
+  getTerrain,
+} from '../src/viz/terrainScene.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function flatGrid(width, height, elevation = 100) {
+  return { width, height, elevations: new Array(width * height).fill(elevation) };
+}
+
+function makeSceneCtx() {
+  const added = [];
+  const removed = [];
+  return {
+    scene: {
+      _added: added,
+      _removed: removed,
+      add(obj) { added.push(obj); },
+      remove(obj) { removed.push(obj); },
+    },
+    terrain: null,
+  };
+}
+
+const BOUNDS = { minX: 0, minY: 0, maxX: 100, maxY: 100 };
+
+// ---------------------------------------------------------------------------
+// createTerrainSurface — bounds/grid validation
+// ---------------------------------------------------------------------------
+
+describe('createTerrainSurface — validation', () => {
+  it('throws when grid is missing', () => {
+    expect(() => createTerrainSurface({ bounds: BOUNDS })).toThrow(/grid/);
+  });
+
+  it('throws when bounds is missing', () => {
+    expect(() => createTerrainSurface({ grid: flatGrid(4, 4) })).toThrow(/bounds/);
+  });
+
+  it('throws when bounds width is zero', () => {
+    expect(() =>
+      createTerrainSurface({ grid: flatGrid(4, 4), bounds: { minX: 5, minY: 0, maxX: 5, maxY: 10 } })
+    ).toThrow(/invalid bounds/);
+  });
+
+  it('throws when flat elevations length does not match width*height', () => {
+    expect(() =>
+      createTerrainSurface({
+        grid: { width: 4, height: 4, elevations: [1, 2, 3] },
+        bounds: BOUNDS,
+      })
+    ).toThrow(/does not match/);
+  });
+
+  it('accepts a nested number[][] grid and infers width/height', () => {
+    const layer = createTerrainSurface({
+      grid: { elevations: [[1, 2, 3], [4, 5, 6]] },
+      bounds: BOUNDS,
+    });
+    expect(layer.empty).toBe(false);
+    expect(layer.mesh).not.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createTerrainSurface — geometry
+// ---------------------------------------------------------------------------
+
+describe('createTerrainSurface — geometry', () => {
+  it('builds a mesh for a fully valid flat grid', () => {
+    const layer = createTerrainSurface({ grid: flatGrid(5, 5, 42), bounds: BOUNDS });
+    expect(layer.empty).toBe(false);
+    expect(layer.mesh).not.toBeNull();
+    expect(layer.elevationRange).toEqual({ min: 42, max: 42 });
+  });
+
+  it('computes vertex normals', () => {
+    const layer = createTerrainSurface({ grid: flatGrid(5, 5), bounds: BOUNDS });
+    expect(layer.mesh.geometry.getAttribute('normal')).toBeDefined();
+  });
+
+  it('respects vertexBudget by decimating large grids', () => {
+    const grid = flatGrid(1000, 1000);
+    const layer = createTerrainSurface({ grid, bounds: BOUNDS, vertexBudget: 50 });
+    const positionCount = layer.mesh.geometry.getAttribute('position').count;
+    // decimated grid's longest dimension should be close to the budget, not 1000
+    expect(Math.sqrt(positionCount)).toBeLessThan(100);
+  });
+
+  it('applies verticalExaggeration explicitly to Z, and defaults to 1 (no silent exaggeration)', () => {
+    const flat = createTerrainSurface({ grid: flatGrid(3, 3, 10), bounds: BOUNDS });
+    const flatZ = flat.mesh.geometry.getAttribute('position').getZ(0);
+    expect(flatZ).toBe(10);
+
+    const exaggerated = createTerrainSurface({
+      grid: flatGrid(3, 3, 10),
+      bounds: BOUNDS,
+      verticalExaggeration: 3,
+    });
+    const exaggeratedZ = exaggerated.mesh.geometry.getAttribute('position').getZ(0);
+    expect(exaggeratedZ).toBe(30);
+  });
+
+  it('omits quads touching a NoData cell instead of producing a spike', () => {
+    const width = 3, height = 3;
+    const elevations = [
+      0, 0, 0,
+      0, NaN, 0,
+      0, 0, 0,
+    ];
+    const layer = createTerrainSurface({ grid: { width, height, elevations }, bounds: BOUNDS });
+    // all 4 quads touch the centre NoData cell -> no triangles at all
+    expect(layer.empty).toBe(true);
+    expect(layer.mesh).toBeNull();
+  });
+
+  it('converts the declared nodata sentinel value to holes', () => {
+    const width = 2, height = 2;
+    const elevations = [-3.4e38, -3.4e38, -3.4e38, -3.4e38];
+    const layer = createTerrainSurface({
+      grid: { width, height, elevations, nodata: -3.4e38 },
+      bounds: BOUNDS,
+    });
+    expect(layer.empty).toBe(true);
+    expect(layer.mesh).toBeNull();
+  });
+
+  it('returns an empty (non-crashing) layer for an all-NoData grid', () => {
+    const layer = createTerrainSurface({
+      grid: { width: 4, height: 4, elevations: new Array(16).fill(NaN) },
+      bounds: BOUNDS,
+    });
+    expect(layer.empty).toBe(true);
+    expect(layer.mesh).toBeNull();
+    expect(layer.elevationRange).toBeNull();
+  });
+
+  it('adds skirt geometry beyond the base grid when skirt is requested', () => {
+    const withoutSkirt = createTerrainSurface({ grid: flatGrid(4, 4, 10), bounds: BOUNDS });
+    const withSkirt = createTerrainSurface({ grid: flatGrid(4, 4, 10), bounds: BOUNDS, skirt: true });
+    const baseVerts = withoutSkirt.mesh.geometry.getAttribute('position').count;
+    const skirtVerts = withSkirt.mesh.geometry.getAttribute('position').count;
+    expect(skirtVerts).toBeGreaterThan(baseVerts);
+  });
+
+  it('clamps out-of-range opacity with a warning, not a throw', () => {
+    const layer = createTerrainSurface({ grid: flatGrid(3, 3), bounds: BOUNDS, opacity: 5 });
+    expect(layer.opacity).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scene-level lifecycle
+// ---------------------------------------------------------------------------
+
+describe('setTerrain / clearTerrain', () => {
+  let ctx;
+  beforeEach(() => { ctx = makeSceneCtx(); });
+
+  it('adds the layer mesh to the scene and stores it on the context', () => {
+    const layer = createTerrainSurface({ grid: flatGrid(3, 3), bounds: BOUNDS });
+    setTerrain(ctx, layer);
+    expect(ctx.scene._added).toContain(layer.mesh);
+    expect(getTerrain(ctx)).toBe(layer);
+  });
+
+  it('does not add anything to the scene for an empty layer', () => {
+    const layer = createTerrainSurface({ grid: { width: 2, height: 2, elevations: [NaN, NaN, NaN, NaN] }, bounds: BOUNDS });
+    setTerrain(ctx, layer);
+    expect(ctx.scene._added).toHaveLength(0);
+    expect(getTerrain(ctx)).toBe(layer);
+  });
+
+  it('replaces and disposes the previous terrain layer', () => {
+    const first = createTerrainSurface({ grid: flatGrid(3, 3), bounds: BOUNDS });
+    const second = createTerrainSurface({ grid: flatGrid(3, 3), bounds: BOUNDS });
+    setTerrain(ctx, first);
+    setTerrain(ctx, second);
+    expect(getTerrain(ctx)).toBe(second);
+    expect(ctx.scene._removed).toContain(first.mesh);
+  });
+
+  it('clearTerrain removes and disposes the mesh', () => {
+    const layer = createTerrainSurface({ grid: flatGrid(3, 3), bounds: BOUNDS });
+    setTerrain(ctx, layer);
+    clearTerrain(ctx);
+    expect(ctx.scene._removed).toContain(layer.mesh);
+    expect(getTerrain(ctx)).toBeNull();
+  });
+
+  it('clearTerrain on an empty context is a no-op', () => {
+    expect(() => clearTerrain(ctx)).not.toThrow();
+  });
+});
+
+describe('setTerrainOpacity / setTerrainVisibility', () => {
+  let ctx;
+  beforeEach(() => { ctx = makeSceneCtx(); });
+
+  it('updates material opacity and clamps out-of-range values', () => {
+    const layer = createTerrainSurface({ grid: flatGrid(3, 3), bounds: BOUNDS });
+    setTerrain(ctx, layer);
+    setTerrainOpacity(ctx, 0.5);
+    expect(layer.mesh.material.opacity).toBe(0.5);
+    setTerrainOpacity(ctx, 4);
+    expect(layer.mesh.material.opacity).toBe(1);
+  });
+
+  it('is a no-op when there is no terrain layer', () => {
+    expect(() => setTerrainOpacity(ctx, 0.5)).not.toThrow();
+  });
+
+  it('toggles mesh visibility', () => {
+    const layer = createTerrainSurface({ grid: flatGrid(3, 3), bounds: BOUNDS });
+    setTerrain(ctx, layer);
+    setTerrainVisibility(ctx, false);
+    expect(layer.mesh.visible).toBe(false);
+    setTerrainVisibility(ctx, true);
+    expect(layer.mesh.visible).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `createTerrainSurface()` + `Baselode3DScene#setTerrain/clearTerrain/setTerrainOpacity/setTerrainVisible/getTerrain`, following the existing `rasterOverlayScene.js` pattern.
- Builds a THREE.BufferGeometry height grid from a plain elevation grid + bounds (already in the scene's projected/local units — this package has no CRS awareness and gains none here).
- Omits NoData quads as real holes (not fabricated elevations), supports an optional perimeter skirt, decimates to a vertex budget, and never applies vertical exaggeration silently (defaults to 1).
- Split out of TRK-394 (Explorer 3D terrain, darkmine-explorer) because the actual scene implementation lives in this package.

## Ticket
TRK-395 (tracker), split from TRK-394.

## Test plan
- `npx vitest run` — 724/724 pass, including 26 new tests in `tests/terrainScene.test.js`.
- `npm run build` — builds cleanly.
- `npm run test:types` / `npm run test:package` — pass.
- 5 rounds of `codex review --base main` — 4 rounds surfaced real correctness issues (nodata float32 rounding, decimation boundary drift, ragged/degenerate nested grids, non-positive vertexBudget disabling the safety budget), all fixed with regression tests; final round clean.

## Risk
Low — new, additive API surface; no existing exports/behaviour changed. No CRS logic added (kept out of scope per design).

## Reviewer
Codex (already reviewed inline across 5 rounds; final pass clean, no outstanding findings)