### PR TITLE
GH-96: desurvey from collar, midpoint tangent, survey QA fixes, Python 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,13 +6,19 @@ on:
 
 # To make this a required check on PRs, go to
 # Settings → Branches → Branch protection rules → main and add the
-# "Python tests" and "JavaScript tests" status checks below
+# "Python tests (3.10)", "Python tests (3.12)" and "JavaScript tests" status checks below
 # "Require status checks to pass before merging".
 
 jobs:
   test-python:
-    name: Python tests
+    name: Python tests (${{ matrix.python-version }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Oldest supported (requires-python in python/pyproject.toml) and
+        # the version the release workflow builds with.
+        python-version: ["3.10", "3.12"]
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -22,7 +28,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: ${{ matrix.python-version }}
 
       - name: Set up Node.js for cross-language parity
         uses: actions/setup-node@v5

--- a/docs/api/python.md
+++ b/docs/api/python.md
@@ -224,7 +224,9 @@ Desurvey all holes in `collars` using the matching rows in `surveys`.
 | `collars` | GeoDataFrame | — | Collar table |
 | `surveys` | DataFrame | — | Survey table |
 | `step` | float | `1.0` | Output vertex spacing (metres) |
-| `method` | str | `"minimum_curvature"` | `"minimum_curvature"`, `"tangential"`, or `"balanced_tangential"` |
+| `method` | str | `"minimum_curvature"` | `"minimum_curvature"`, `"tangential"`, `"balanced_tangential"`, or `"midpoint_tangential"` |
+
+Every trace starts at the collar (`md = 0`).  If the first survey station is deeper than the collar, its orientation is extended straight up to `md = 0` (Vulcan / Surpac convention), so single-station holes recorded at depth still produce a full trace.
 
 **Returns:** `pandas.DataFrame` with columns `hole_id`, `md`, `easting`, `northing`, `elevation`, `azimuth`, `dip`
 
@@ -278,6 +280,7 @@ python scripts/dev/regenerate_desurvey_fixtures.py
 | `minimum_curvature` | Matches wellpathpy to machine precision on every trajectory |
 | `tangential` | Matches wellpathpy `tan_method(choice="low")` to machine precision |
 | `balanced_tangential` | Matches wellpathpy `tan_method(choice="bal")` to ≤1 cm on every trajectory — including the strong-dogleg stress case. Uses the canonical Walstrom 1969 / Harvey & Eppink 1972 form (average of direction cosines) |
+| `midpoint_tangential` | No wellpathpy equivalent.  Vulcan's default "Tangent": each station is the midpoint of its straight segment (orientation changes halfway between stations).  Verified against analytic cases in `test/test_desurvey_collar_and_midpoint.py`; agrees with the other methods on straight holes |
 
 ---
 
@@ -504,7 +507,7 @@ Delegate to `baselode.drill.validate.validate_drillhole_db(collar, survey, inter
 
 #### `db.desurvey(method="minimum_curvature", step=1.0, force=False)`
 
-Run desurvey via the registered method (one of `"minimum_curvature"`, `"tangential"`, `"balanced_tangential"`).  Cached unless `force=True` or args change.
+Run desurvey via the registered method (one of `"minimum_curvature"`, `"tangential"`, `"balanced_tangential"`, `"midpoint_tangential"`).  Cached unless `force=True` or args change.
 
 **Returns:** `pandas.DataFrame` trace table.
 
@@ -677,7 +680,9 @@ Run the full drillhole-database validation suite.  Returns a structured report (
 | Check | Severity | Notes |
 |---|---|---|
 | `duplicate_hole_ids` | error | Collar table contains the same `hole_id` more than once |
-| `single_station_surveys` | warning | A hole has only one survey row — desurvey will fail.  Fix recipe points at `fix_single_station_surveys` |
+| `survey_null_orientation` | error | A survey row has a null / non-numeric `depth`, `azimuth` or `dip`.  Desurvey silently ignores such rows.  Fix recipe points at `drop_unusable_survey_rows` and `synthesise_collar_station` |
+| `survey_no_usable_stations` | warning | A hole has no usable survey row — every row unusable, or (for collar holes) no survey rows at all — so it silently drops out of the desurvey.  Skipped when the survey table is empty.  Fix recipe points at `synthesise_collar_station` |
+| `single_station_surveys` | warning | A hole has only one *usable* survey row — desurvey will fail.  Fix recipe points at `fix_single_station_surveys` |
 | `azimuth_range` | error | Survey azimuth outside `[0, 360)` |
 | `dip_range` | error | Survey dip outside `[-90, 90]` |
 | `orphan_intervals` | error | Interval `hole_id` not present in collar table |
@@ -696,9 +701,45 @@ fix_single_station_surveys(survey, collar=None,
                             hole_col=HOLE_ID, depth_col=DEPTH, max_depth_col=MAX_DEPTH)
 ```
 
-For any hole with exactly one survey row, append a synthetic second station with the same azimuth/dip at `collar.max_depth` (when available) or `depth + 1.0` otherwise.  Equivalent to PyGSLIB's `fix_survey_one_interval_err`.
+For any hole with exactly one usable survey row, append a synthetic second station with the same azimuth/dip at `collar.max_depth` (when available) or `depth + 1.0` otherwise.  Equivalent to PyGSLIB's `fix_survey_one_interval_err`.
 
 **Returns:** `pandas.DataFrame` — original survey rows plus synthetics, sorted by `hole_id`, `depth`, with the index reset.
+
+---
+
+### drop_unusable_survey_rows
+
+```python
+drop_unusable_survey_rows(survey, hole_col=HOLE_ID, depth_col=DEPTH,
+                          azimuth_col=AZIMUTH, dip_col=DIP)
+```
+
+Drop survey rows whose depth, azimuth or dip is null or non-numeric — the complement of the `survey_null_orientation` check.  Desurvey already ignores these rows, so no trace changes.
+
+**Returns:** `pandas.DataFrame` — filtered copy with the index reset.
+
+---
+
+### synthesise_collar_station
+
+```python
+synthesise_collar_station(survey, collar,
+                          hole_col=HOLE_ID, depth_col=DEPTH, azimuth_col=AZIMUTH, dip_col=DIP,
+                          collar_azimuth_col=AZIMUTH, collar_dip_col=DIP,
+                          return_diagnostics=False)
+```
+
+Build a survey station at the collar for every hole that has none — collar holes with no survey rows, and holes whose every row lacks a usable depth / azimuth / dip.  Each gets a row at depth `0` oriented from the collar table's `collar_azimuth_col` / `collar_dip_col` (matched case-insensitively; dip negative = down) when both are numeric, otherwise vertical (`azimuth 0`, `dip -90`).  The hole's existing unusable rows are dropped.  Holes with at least one usable station are untouched.
+
+Chain with `fix_single_station_surveys` to pad the synthetic station to `collar.max_depth`.
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `collar_azimuth_col` | str | `"azimuth"` | Collar column holding the planned azimuth |
+| `collar_dip_col` | str | `"dip"` | Collar column holding the planned dip |
+| `return_diagnostics` | bool | `False` | When `True`, return `(survey, report)` where `report` carries `holes_synthesised`, `from_collar`, `vertical_fallback`, `vertical_fallback_holes`, `rows_dropped` |
+
+**Returns:** `pandas.DataFrame` (or `(DataFrame, dict)`) — survey with synthetic stations, sorted by `hole_id`, `depth`, index reset.
 
 ---
 
@@ -745,16 +786,18 @@ fix_overlaps(table,
              hole_col=HOLE_ID, from_col=FROM, to_col=TO,
              value_cols=None,
              touching_tol=0.01, merge_tol=0.05, coverage_min=0.95,
+             precedence_col=None, precedence=None,
              return_diagnostics=False)
 ```
 
-Auto-resolve safe interval overlaps and surface only genuine value-conflicts for human review.  Handles three classes:
+Auto-resolve safe interval overlaps and surface only genuine value-conflicts for human review.  Handles three classes automatically, plus an opt-in fourth:
 
 | Class | Pattern | Action |
 |---|---|---|
 | **Touching** | `A.to > B.from` by less than `touching_tol` metres | Snap `A.to = B.from` (float-rounding cleanup) |
 | **Duplicate** | Identical `(hole_id, from, to)` *and* identical `value_cols` | Drop all but the first |
 | **Resampled superset** | A longer interval fully contains shorter ones whose length-weighted mean ≈ the longer's value within `merge_tol`, with coverage ≥ `coverage_min` | Drop the longer, keep the higher-resolution rows |
+| **Dataset precedence** (opt-in) | Two overlapping rows come from different datasets listed in `precedence` | Drop the row from the lower-ranked dataset; rows from unlisted datasets are never dropped this way |
 | **Conflict** | Anything else — partial overlap, same depth-zone with materially different values | Leave untouched, return in the `conflicts` frame |
 
 | Parameter | Type | Default | Description |
@@ -764,6 +807,8 @@ Auto-resolve safe interval overlaps and surface only genuine value-conflicts for
 | `touching_tol` | float | `0.01` | Max overlap (m) treated as a snap-me glitch |
 | `merge_tol` | float | `0.05` | Max relative diff between superset value and inner mean |
 | `coverage_min` | float | `0.95` | Min coverage of a superset by inner rows before it qualifies |
+| `precedence_col` | str | `None` | Column naming each row's dataset / campaign (e.g. `project_id`) |
+| `precedence` | iterable of str | `None` | Dataset values in priority order, highest first.  With `precedence_col`, enables the dataset-precedence class; audit rows carry `kind="precedence"` |
 | `return_diagnostics` | bool | `False` | When `True`, return `(fixed, conflicts, report)` instead of just `fixed` |
 
 **Returns:** `pandas.DataFrame`, or `(pandas.DataFrame, pandas.DataFrame, pandas.DataFrame)` when `return_diagnostics=True`.  The report has columns `hole_id, kind, action, from, to, note` — one row per resolved or flagged overlap.

--- a/docs/api/python.md
+++ b/docs/api/python.md
@@ -698,7 +698,8 @@ Run the full drillhole-database validation suite.  Returns a structured report (
 
 ```python
 fix_single_station_surveys(survey, collar=None,
-                            hole_col=HOLE_ID, depth_col=DEPTH, max_depth_col=MAX_DEPTH)
+                            hole_col=HOLE_ID, depth_col=DEPTH, max_depth_col=MAX_DEPTH,
+                            azimuth_col=AZIMUTH, dip_col=DIP)
 ```
 
 For any hole with exactly one usable survey row, append a synthetic second station with the same azimuth/dip at `collar.max_depth` (when available) or `depth + 1.0` otherwise.  Equivalent to PyGSLIB's `fix_survey_one_interval_err`.

--- a/docs/guide/javascript.md
+++ b/docs/guide/javascript.md
@@ -287,11 +287,18 @@ import {
   minimumCurvatureDesurvey,
   tangentialDesurvey,
   balancedTangentialDesurvey,
+  midpointTangentialDesurvey,
   buildTraces
 } from 'baselode';
 
-// minimumCurvatureDesurvey is the industry standard (default)
+// minimumCurvatureDesurvey is the industry standard (default);
+// midpointTangentialDesurvey is Vulcan's default "Tangent" for like-for-like comparisons.
 const trace = minimumCurvatureDesurvey(collarRows, surveyRows, { step: 1.0 });
+```
+
+Every trace starts at the collar (`md = 0`): a first station below the collar has its orientation extended straight up, matching Vulcan / Surpac and the Python package.
+
+```js
 ```
 
 ### Attaching assay positions to 3D traces
@@ -365,12 +372,14 @@ const report = validateDrillholeDb({
 const errors = report.issues.filter((issue) => issue.severity === 'error');
 ```
 
-Checks covered (severity, what triggers): `duplicate_hole_ids` (error), `single_station_surveys` (warning), `azimuth_range` / `dip_range` (error), `orphan_intervals` (error), `negative_lengths` (error), `intervals_beyond_max_depth` (warning), `interval_gaps` (info), `interval_overlaps` (warning), `below_detection_limit` (info).
+Checks covered (severity, what triggers): `duplicate_hole_ids` (error), `survey_null_orientation` (error — a row's depth / azimuth / dip is null or non-numeric, so desurvey ignores it), `survey_no_usable_stations` (warning — a hole has no usable row and drops out of the desurvey), `single_station_surveys` (warning, usable rows only), `azimuth_range` / `dip_range` (error), `orphan_intervals` (error), `negative_lengths` (error), `intervals_beyond_max_depth` (warning), `interval_gaps` (info), `interval_overlaps` (warning), `below_detection_limit` (info).
 
 ### Fix helpers
 
 ```js
-const surveyFixed    = fixSingleStationSurveys(surveyRows, collarRows);
+const surveyUsable   = dropUnusableSurveyRows(surveyRows);            // null / non-numeric depth, azimuth, dip
+const { survey: surveyRebuilt, report } = synthesiseCollarStation(surveyUsable, collarRows);  // collar station for holes with none
+const surveyFixed    = fixSingleStationSurveys(surveyRebuilt, collarRows);
 const surveyWrapped  = normalizeAzimuth(surveyRows);  // 360 → 0, -30 → 330, idempotent
 const assaysMatched  = dropOrphanIntervals(assayRows, collarRows);
 const assaysSwapped  = swapInvertedIntervals(assayRows);  // fixes to<from typos

--- a/docs/guide/python.md
+++ b/docs/guide/python.md
@@ -2,7 +2,7 @@
 
 The `baselode` Python package provides domain-aware data loaders, desurveying algorithms, and Plotly-based visualisation helpers for drillhole and spatial datasets.
 
-**Requires:** Python 3.12+
+**Requires:** Python 3.10+
 
 ```bash
 pip install baselode
@@ -199,6 +199,9 @@ import baselode.drill.desurvey as desurvey
 | `minimum_curvature` | Industry-standard method — most accurate (default) |
 | `tangential` | Simple first-order method |
 | `balanced_tangential` | Average of start/end orientations per segment |
+| `midpoint_tangential` | Vulcan-style "Tangent" — each station is the midpoint of its straight segment, so orientation changes halfway between stations.  Use for like-for-like comparisons against Vulcan |
+
+Every trace starts at the collar (`md = 0`).  When a hole's first survey station sits below the collar, that station's orientation is extended straight up to `md = 0` — the convention Vulcan and Surpac use — so a hole with a single station at 135 m yields a full 135 m trace rather than a single point.
 
 ### desurvey_holes
 
@@ -297,7 +300,9 @@ errors = [issue for issue in report["issues"] if issue["severity"] == "error"]
 | Check | Severity | Drives |
 |---|---|---|
 | `duplicate_hole_ids` | error | Collar table integrity |
-| `single_station_surveys` | warning | Desurvey reliability — fix recipe is `fix_single_station_surveys` |
+| `survey_null_orientation` | error | Survey row with a null / non-numeric depth, azimuth or dip — desurvey silently ignores it.  Fix recipe is `drop_unusable_survey_rows` |
+| `survey_no_usable_stations` | warning | Hole with no usable survey row (or no survey rows at all) — it silently drops out of the desurvey.  Fix recipe is `synthesise_collar_station` |
+| `single_station_surveys` | warning | Desurvey reliability — counts usable rows only; fix recipe is `fix_single_station_surveys` |
 | `azimuth_range`, `dip_range` | error | Survey angle sanity |
 | `orphan_intervals` | error | Interval `hole_id` must exist in collar |
 | `negative_lengths` | error | `to <= from` |
@@ -309,8 +314,17 @@ errors = [issue for issue in report["issues"] if issue["severity"] == "error"]
 ### Fix helpers
 
 ```python
+# Drop survey rows desurvey can't use (null / non-numeric depth, azimuth, dip)
+survey_usable = validate.drop_unusable_survey_rows(survey)
+
+# Build a collar station for holes left with no usable survey, oriented from
+# the collar's azimuth / dip columns (vertical fallback, counted in the report)
+survey_rebuilt, report = validate.synthesise_collar_station(
+    survey_usable, collar, return_diagnostics=True,
+)
+
 # Synthesize a second station for single-station holes so desurvey can run
-survey_fixed = validate.fix_single_station_surveys(survey, collar)
+survey_fixed = validate.fix_single_station_surveys(survey_rebuilt, collar)
 
 # Wrap azimuths into [0, 360); converts 360 to 0, normalizes negatives
 survey_wrapped = validate.normalize_azimuth(survey)
@@ -325,6 +339,12 @@ assays_swapped = validate.swap_inverted_intervals(assays)
 # superset) and surface only the genuine value-conflicts for review.
 assays_clean, conflicts, report = validate.fix_overlaps(
     assays, return_diagnostics=True,
+)
+
+# Two sampling campaigns interleaved over the same depths?  Rank them and
+# the lower-ranked rows are dropped wherever they overlap a higher-ranked one.
+assays_clean = validate.fix_overlaps(
+    assays, precedence_col="project_id", precedence=["campaign_0.5m", "campaign_1m"],
 )
 
 # Substitute below-detection sentinels with half-MDL — handles both

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ features:
     details: Import and normalise drillhole collars, surveys, assays, structural measurements, and geotechnical intervals from CSV, Parquet, or SQL sources. A smart column-mapping layer handles common naming variations automatically.
   - icon: 🧮
     title: Desurveying
-    details: Convert depth-based survey tables into 3D space. Supports industry-standard Minimum Curvature, as well as Tangential and Balanced Tangential methods.
+    details: Convert depth-based survey tables into 3D space. Supports industry-standard Minimum Curvature, as well as Tangential, Balanced Tangential, and Vulcan-style Midpoint Tangential methods.
   - icon: 🗺️
     title: Map Visualisation
     details: Plot collar locations on an interactive map. The Python library uses Folium/Plotly; the JavaScript library uses MapLibre GL JS.

--- a/javascript/packages/baselode/src/data/desurveyMethods.js
+++ b/javascript/packages/baselode/src/data/desurveyMethods.js
@@ -121,6 +121,41 @@ function segmentDisplacement(deltaMd, az0, dip0, az1, dip1, method = 'minimum_cu
   };
 }
 
+/**
+ * Prepend a virtual station at md 0 when the first real station is deeper.
+ *
+ * A survey's first reading often sits below the collar.  Without this the
+ * trace would start at that depth (or, for a single deep station, be a
+ * single point).  Vulcan and Surpac extend the first station's orientation
+ * straight up to the collar; mirror baselode.drill.desurvey and do the same.
+ * @private
+ */
+function extrapolateToCollar(stations) {
+  if (!stations.length || stations[0].from <= 0) return stations;
+  return [{ ...stations[0], from: 0 }, ...stations];
+}
+
+/**
+ * Re-cut stations so each orientation applies to the segment centred on it.
+ *
+ * Vulcan's default "Tangent" desurvey treats each reading as the midpoint of
+ * a straight segment: orientation changes halfway between consecutive
+ * stations.  Expressed as an equivalent station list for the top-of-segment
+ * tangential integrator.
+ * @private
+ */
+function midpointTangentialStations(stations) {
+  if (stations.length < 2) return stations;
+  const recut = [stations[0]];
+  for (let idx = 0; idx < stations.length - 1; idx += 1) {
+    const s0 = stations[idx];
+    const s1 = stations[idx + 1];
+    recut.push({ ...s1, from: 0.5 * (s0.from + s1.from) });
+  }
+  recut.push(stations[stations.length - 1]);
+  return recut;
+}
+
 function desurvey(rowsCollars = [], rowsSurveys = [], options = {}) {
   const {
     step = 1,
@@ -131,6 +166,8 @@ function desurvey(rowsCollars = [], rowsSurveys = [], options = {}) {
   // A null step emits survey-station vertices only. Consumers such as the
   // demo use it to avoid generating unnecessary intermediate scene points.
   const safeStep = Number.isFinite(Number(step)) && Number(step) > 0 ? Number(step) : null;
+  // midpoint_tangential is the tangential integrator over a re-cut station list.
+  const segmentMethod = method === 'midpoint_tangential' ? 'tangential' : method;
 
   const collarsCanonical = canonicalizeHoleIdRows(rowsCollars, holeIdCol);
   const surveysCanonical = canonicalizeHoleIdRows(rowsSurveys, holeIdCol || collarsCanonical.aliasCol);
@@ -169,14 +206,17 @@ function desurvey(rowsCollars = [], rowsSurveys = [], options = {}) {
 
     if (!sorted.length) return;
 
+    let stationList = extrapolateToCollar(sorted);
+    if (method === 'midpoint_tangential') stationList = midpointTangentialStations(stationList);
+
     // Accept Baselode's canonical projected collar fields. x/y/z remain
     // supported aliases because the emitted trace uses those scene names.
     let x = toNumber(collar.easting ?? collar.x, 0);
     let y = toNumber(collar.northing ?? collar.y, 0);
     let z = toNumber(collar.elevation ?? collar.z, 0);
-    let mdCursor = sorted[0].from;
-    const azPrev = sorted[0].azimuth;
-    const dipPrev = sorted[0].dip;
+    let mdCursor = stationList[0].from;
+    const azPrev = stationList[0].azimuth;
+    const dipPrev = stationList[0].dip;
 
     const firstRecord = {
       hole_id: collar.__hole_id_original || holeId,
@@ -196,9 +236,9 @@ function desurvey(rowsCollars = [], rowsSurveys = [], options = {}) {
     }
     out.push(firstRecord);
 
-    for (let idx = 0; idx < sorted.length - 1; idx += 1) {
-      const s0 = sorted[idx];
-      const s1 = sorted[idx + 1];
+    for (let idx = 0; idx < stationList.length - 1; idx += 1) {
+      const s0 = stationList[idx];
+      const s1 = stationList[idx + 1];
       const md0 = s0.from;
       const md1 = s1.from;
       const deltaMd = md1 - md0;
@@ -213,7 +253,7 @@ function desurvey(rowsCollars = [], rowsSurveys = [], options = {}) {
         const azInterp = s0.azimuth + weight * (s1.azimuth - s0.azimuth);
         const dipInterp = s0.dip + weight * (s1.dip - s0.dip);
 
-        const disp = segmentDisplacement(mdIncrement, s0.azimuth, s0.dip, s1.azimuth, s1.dip, method);
+        const disp = segmentDisplacement(mdIncrement, s0.azimuth, s0.dip, s1.azimuth, s1.dip, segmentMethod);
         x += disp.dx;
         y += disp.dy;
         z += disp.dz;
@@ -227,8 +267,8 @@ function desurvey(rowsCollars = [], rowsSurveys = [], options = {}) {
           easting: x,
           northing: y,
           elevation: z,
-          azimuth: method === 'minimum_curvature' ? azInterp : disp.azimuth,
-          dip: method === 'minimum_curvature' ? dipInterp : disp.dip
+          azimuth: segmentMethod === 'minimum_curvature' ? azInterp : disp.azimuth,
+          dip: segmentMethod === 'minimum_curvature' ? dipInterp : disp.dip
         };
 
         if (collarsCanonical.aliasCol !== 'hole_id' && collar[collarsCanonical.aliasCol] !== undefined) {
@@ -276,6 +316,21 @@ export function tangentialDesurvey(collars, surveys, options = {}) {
  */
 export function balancedTangentialDesurvey(collars, surveys, options = {}) {
   return desurvey(collars, surveys, { ...options, method: 'balanced_tangential' });
+}
+
+/**
+ * Desurvey drillholes using the Vulcan-style midpoint tangent method.
+ *
+ * Each survey station is the midpoint of a straight segment, so orientation
+ * changes halfway between consecutive stations rather than at the stations
+ * themselves.  Like-for-like with Vulcan's default "Tangent" desurvey.
+ * @param {Array<Object>} collars - Collar data
+ * @param {Array<Object>} surveys - Survey data
+ * @param {Object} options - Desurvey options
+ * @returns {Array<Object>} Desurveyed trace points
+ */
+export function midpointTangentialDesurvey(collars, surveys, options = {}) {
+  return desurvey(collars, surveys, { ...options, method: 'midpoint_tangential' });
 }
 
 /**

--- a/javascript/packages/baselode/src/data/drillholeSet.js
+++ b/javascript/packages/baselode/src/data/drillholeSet.js
@@ -21,12 +21,14 @@ import {
   minimumCurvatureDesurvey,
   tangentialDesurvey,
   balancedTangentialDesurvey,
+  midpointTangentialDesurvey,
 } from './desurveyMethods.js';
 
 const DESURVEY_METHODS = {
   minimum_curvature: minimumCurvatureDesurvey,
   tangential: tangentialDesurvey,
   balanced_tangential: balancedTangentialDesurvey,
+  midpoint_tangential: midpointTangentialDesurvey,
 };
 
 // The JS desurvey helpers (kept compatible with their existing callers)

--- a/javascript/packages/baselode/src/data/validateDrillholeDb.js
+++ b/javascript/packages/baselode/src/data/validateDrillholeDb.js
@@ -72,9 +72,89 @@ function checkDuplicateHoleIds(collar, holeCol) {
   return issues;
 }
 
-function checkSingleStationSurveys(survey, holeCol) {
+function isFiniteNumber(value) {
+  if (value == null || value === '') return false;
+  return Number.isFinite(Number(value));
+}
+
+/**
+ * True when a survey row has numeric depth, azimuth and dip — exactly the
+ * row filter the desurvey applies, so "usable" means "contributes to a trace".
+ * @private
+ */
+function isUsableStation(row, depthCol, azimuthCol, dipCol) {
+  return Boolean(row)
+    && isFiniteNumber(row[depthCol])
+    && isFiniteNumber(row[azimuthCol])
+    && isFiniteNumber(row[dipCol]);
+}
+
+function checkSurveyNullOrientation(survey, holeCol, depthCol, azimuthCol, dipCol) {
   if (!survey || !survey.length) return [];
-  const grouped = groupBy(survey, holeCol);
+  const issues = [];
+  survey.forEach((row, rowIndex) => {
+    if (!row) return;
+    const missing = [depthCol, azimuthCol, dipCol].filter((col) => !isFiniteNumber(row[col]));
+    if (!missing.length) return;
+    const holeId = row[holeCol];
+    issues.push(makeIssue({
+      check: 'survey_null_orientation',
+      severity: SEVERITY_ERROR,
+      holeId: holeId != null ? String(holeId) : null,
+      table: 'survey',
+      rowIndex,
+      message: `Survey row for hole '${holeId}' has no usable ${missing.join(' / ')}; desurvey ignores this row`,
+      fix: 'Fill the value from the source survey, or call dropUnusableSurveyRows(survey); '
+        + 'holes left without a station can be rebuilt with synthesiseCollarStation(survey, collar)',
+    }));
+  });
+  return issues;
+}
+
+function checkSurveyNoUsableStations(collar, survey, holeCol, depthCol, azimuthCol, dipCol) {
+  if (!survey || !survey.length) return [];
+  const rowCounts = new Map();
+  const usableCounts = new Map();
+  for (const row of survey) {
+    const holeId = row && row[holeCol];
+    if (holeId == null) continue;
+    rowCounts.set(holeId, (rowCounts.get(holeId) || 0) + 1);
+    if (isUsableStation(row, depthCol, azimuthCol, dipCol)) {
+      usableCounts.set(holeId, (usableCounts.get(holeId) || 0) + 1);
+    }
+  }
+  const candidates = [...rowCounts.keys()];
+  const seen = new Set(candidates);
+  for (const row of collar || []) {
+    const holeId = row && row[holeCol];
+    if (holeId == null || seen.has(holeId)) continue;
+    candidates.push(holeId);
+    seen.add(holeId);
+  }
+  const issues = [];
+  for (const holeId of candidates) {
+    if ((usableCounts.get(holeId) || 0) > 0) continue;
+    const rowCount = rowCounts.get(holeId) || 0;
+    const message = rowCount
+      ? `Hole '${holeId}' has ${rowCount} survey row(s) but none with usable depth / azimuth / dip; it will be dropped by desurvey`
+      : `Hole '${holeId}' has no survey rows; it will be dropped by desurvey`;
+    issues.push(makeIssue({
+      check: 'survey_no_usable_stations',
+      severity: SEVERITY_WARNING,
+      holeId: String(holeId),
+      table: 'survey',
+      message,
+      fix: 'Call synthesiseCollarStation(survey, collar) to build a station at the collar '
+        + 'from the collar azimuth/dip columns (vertical fallback)',
+    }));
+  }
+  return issues;
+}
+
+function checkSingleStationSurveys(survey, holeCol, depthCol, azimuthCol, dipCol) {
+  if (!survey || !survey.length) return [];
+  const usable = survey.filter((row) => isUsableStation(row, depthCol, azimuthCol, dipCol));
+  const grouped = groupBy(usable, holeCol);
   const issues = [];
   for (const [holeId, group] of grouped) {
     if (group.length === 1) {
@@ -85,7 +165,7 @@ function checkSingleStationSurveys(survey, holeCol) {
         holeId: String(holeId),
         table: 'survey',
         rowIndex,
-        message: `Hole '${holeId}' has only one survey station; desurvey will fail`,
+        message: `Hole '${holeId}' has only one usable survey station; desurvey will fail`,
         fix: 'Call fixSingleStationSurveys(survey, collar) to add a synthetic station',
       }));
     }
@@ -280,7 +360,9 @@ export function validateDrillholeDb(
 ) {
   const issues = [];
   issues.push(...checkDuplicateHoleIds(collar, holeCol));
-  issues.push(...checkSingleStationSurveys(survey, holeCol));
+  issues.push(...checkSurveyNullOrientation(survey, holeCol, depthCol, azimuthCol, dipCol));
+  issues.push(...checkSurveyNoUsableStations(collar, survey, holeCol, depthCol, azimuthCol, dipCol));
+  issues.push(...checkSingleStationSurveys(survey, holeCol, depthCol, azimuthCol, dipCol));
   issues.push(...checkAzimuthRange(survey, holeCol, azimuthCol, allowFullCircle));
   issues.push(...checkDipRange(survey, holeCol, dipCol));
 
@@ -317,12 +399,17 @@ export function validateDrillholeDb(
 export function fixSingleStationSurveys(
   survey,
   collar,
-  { holeCol = HOLE_ID, depthCol = DEPTH, maxDepthCol = MAX_DEPTH } = {},
+  {
+    holeCol = HOLE_ID, depthCol = DEPTH, maxDepthCol = MAX_DEPTH, azimuthCol = AZIMUTH, dipCol = DIP,
+  } = {},
 ) {
   if (!survey || !survey.length) return [];
 
   const maxDepthLookup = collar ? buildMaxDepthLookup(collar, holeCol, maxDepthCol) : new Map();
-  const grouped = groupBy(survey, holeCol);
+  const grouped = groupBy(
+    survey.filter((row) => isUsableStation(row, depthCol, azimuthCol, dipCol)),
+    holeCol,
+  );
   const additions = [];
   for (const [holeId, group] of grouped) {
     if (group.length !== 1) continue;
@@ -342,6 +429,117 @@ export function fixSingleStationSurveys(
     if (firstHole !== secondHole) return firstHole < secondHole ? -1 : 1;
     return Number(first[depthCol]) - Number(second[depthCol]);
   });
+}
+
+/**
+ * Drop survey rows whose depth, azimuth or dip is null or non-numeric.
+ *
+ * Mirrors `baselode.drill.validate.drop_unusable_survey_rows` — the
+ * complement of the `survey_null_orientation` check.  Desurvey already
+ * ignores these rows, so no trace changes.
+ *
+ * @returns {Array<Object>} new array containing only usable rows
+ */
+export function dropUnusableSurveyRows(
+  survey,
+  { depthCol = DEPTH, azimuthCol = AZIMUTH, dipCol = DIP } = {},
+) {
+  if (!survey || !survey.length) return [];
+  return survey.filter((row) => isUsableStation(row, depthCol, azimuthCol, dipCol));
+}
+
+function resolveColumn(rows, name) {
+  if (name == null) return null;
+  const wanted = String(name).trim().toLowerCase();
+  for (const row of rows || []) {
+    if (!row) continue;
+    if (Object.prototype.hasOwnProperty.call(row, name)) return name;
+    const match = Object.keys(row).find((key) => key.trim().toLowerCase() === wanted);
+    if (match) return match;
+  }
+  return null;
+}
+
+/**
+ * Build a survey station at the collar for every hole that has none.
+ *
+ * Mirrors `baselode.drill.validate.synthesise_collar_station`.  Targets
+ * collar holes with no survey rows and holes whose every row lacks a
+ * usable depth / azimuth / dip.  Each gets a station at depth 0 oriented
+ * from the collar's `collarAzimuthCol` / `collarDipCol` (matched
+ * case-insensitively) when both are numeric, otherwise vertical
+ * (azimuth 0, dip -90).  The hole's unusable rows are dropped.
+ *
+ * Pair with `fixSingleStationSurveys` afterwards to pad the synthetic
+ * station to `collar.max_depth`.
+ *
+ * @returns {{survey: Array<Object>, report: Object}} new survey rows sorted
+ *   by hole / depth, plus counts: `holesSynthesised`, `fromCollar`,
+ *   `verticalFallback`, `verticalFallbackHoles`, `rowsDropped`.
+ */
+export function synthesiseCollarStation(
+  survey,
+  collar,
+  {
+    holeCol = HOLE_ID,
+    depthCol = DEPTH,
+    azimuthCol = AZIMUTH,
+    dipCol = DIP,
+    collarAzimuthCol = AZIMUTH,
+    collarDipCol = DIP,
+  } = {},
+) {
+  const report = {
+    holesSynthesised: 0,
+    fromCollar: 0,
+    verticalFallback: 0,
+    verticalFallbackHoles: [],
+    rowsDropped: 0,
+  };
+  const rows = (survey || []).filter(Boolean);
+  if (!collar || !collar.length) return { survey: rows.map((row) => ({ ...row })), report };
+
+  const holesWithStation = new Set(
+    rows.filter((row) => isUsableStation(row, depthCol, azimuthCol, dipCol)).map((row) => row[holeCol]),
+  );
+  const azSource = resolveColumn(collar, collarAzimuthCol);
+  const dipSource = resolveColumn(collar, collarDipCol);
+
+  const additions = [];
+  const seen = new Set();
+  for (const collarRow of collar) {
+    const holeId = collarRow && collarRow[holeCol];
+    if (holeId == null || seen.has(holeId)) continue;
+    seen.add(holeId);
+    if (holesWithStation.has(holeId)) continue;
+    let azimuth = azSource != null && isFiniteNumber(collarRow[azSource]) ? Number(collarRow[azSource]) : null;
+    let dip = dipSource != null && isFiniteNumber(collarRow[dipSource]) ? Number(collarRow[dipSource]) : null;
+    if (azimuth != null && dip != null) {
+      report.fromCollar += 1;
+    } else {
+      azimuth = 0;
+      dip = -90;
+      report.verticalFallback += 1;
+      report.verticalFallbackHoles.push(holeId);
+    }
+    report.holesSynthesised += 1;
+    additions.push({ [holeCol]: holeId, [depthCol]: 0, [azimuthCol]: azimuth, [dipCol]: dip });
+  }
+
+  const synthesisedHoles = new Set(additions.map((row) => row[holeCol]));
+  const kept = rows.filter((row) => {
+    const drop = synthesisedHoles.has(row[holeCol]) && !isUsableStation(row, depthCol, azimuthCol, dipCol);
+    if (drop) report.rowsDropped += 1;
+    return !drop;
+  }).map((row) => ({ ...row }));
+
+  const extended = [...kept, ...additions].sort((first, second) => {
+    const firstHole = String(first[holeCol] ?? '');
+    const secondHole = String(second[holeCol] ?? '');
+    if (firstHole !== secondHole) return firstHole < secondHole ? -1 : 1;
+    return Number(first[depthCol]) - Number(second[depthCol]);
+  });
+  return { survey: extended, report };
 }
 
 /**

--- a/javascript/packages/baselode/src/index.js
+++ b/javascript/packages/baselode/src/index.js
@@ -119,6 +119,7 @@ export {
   minimumCurvatureDesurvey,
   tangentialDesurvey,
   balancedTangentialDesurvey,
+  midpointTangentialDesurvey,
   attachAssayPositions,
   buildTraces,
   interpolateTrajectory
@@ -222,6 +223,8 @@ export {
 export {
   validateDrillholeDb,
   fixSingleStationSurveys,
+  dropUnusableSurveyRows,
+  synthesiseCollarStation,
   normalizeAzimuth,
   dropOrphanIntervals,
   swapInvertedIntervals,

--- a/javascript/packages/baselode/tests/desurveyMethods.test.js
+++ b/javascript/packages/baselode/tests/desurveyMethods.test.js
@@ -8,6 +8,7 @@ import { describe, expect, it } from 'vitest';
 import {
   attachAssayPositions,
   balancedTangentialDesurvey,
+  midpointTangentialDesurvey,
   minimumCurvatureDesurvey,
   tangentialDesurvey
 } from '../src/data/desurveyMethods.js';
@@ -27,7 +28,9 @@ describe('desurveyMethods parity helpers', () => {
   ];
 
   it('returns trace rows with expected keys for all methods', () => {
-    const methods = [minimumCurvatureDesurvey, tangentialDesurvey, balancedTangentialDesurvey];
+    const methods = [
+      minimumCurvatureDesurvey, tangentialDesurvey, balancedTangentialDesurvey, midpointTangentialDesurvey
+    ];
 
     methods.forEach((run) => {
       const traces = run(collars, surveys, { step: 10 });
@@ -116,5 +119,97 @@ describe('desurveyMethods parity helpers', () => {
         expect(Math.abs((collar.elevation - row.elevation) - expected.tvd)).toBeLessThanOrEqual(tolerance);
       });
     });
+  });
+});
+
+describe('desurvey collar extrapolation (GH-96)', () => {
+  const collar = [{ hole_id: 'T1', easting: 1000, northing: 2000, elevation: 300 }];
+  const methods = {
+    minimumCurvatureDesurvey, tangentialDesurvey, balancedTangentialDesurvey, midpointTangentialDesurvey
+  };
+
+  Object.entries(methods).forEach(([name, run]) => {
+    it(`${name}: a single deep station is extended straight up to the collar`, () => {
+      const traces = run(collar, [{ hole_id: 'T1', depth: 135, azimuth: 90, dip: -60 }], { step: 5 });
+      expect(traces[0].md).toBe(0);
+      expect(traces[0].easting).toBe(1000);
+      expect(traces[0].elevation).toBe(300);
+      const toe = traces.at(-1);
+      expect(toe.md).toBeCloseTo(135, 9);
+      expect(toe.easting).toBeCloseTo(1000 + 135 * Math.cos(Math.PI / 3), 6);
+      expect(toe.northing).toBeCloseTo(2000, 6);
+      expect(toe.elevation).toBeCloseTo(300 - 135 * Math.sin(Math.PI / 3), 6);
+    });
+  });
+
+  it('keeps the first station orientation from md 0 down to that station', () => {
+    const traces = minimumCurvatureDesurvey(
+      collar,
+      [
+        { hole_id: 'T1', depth: 10, azimuth: 0, dip: -90 },
+        { hole_id: 'T1', depth: 20, azimuth: 90, dip: -45 }
+      ],
+      { step: 1 }
+    );
+    const at10 = traces.find((row) => Math.abs(row.md - 10) < 1e-9);
+    expect(at10.easting).toBeCloseTo(1000, 9);
+    expect(at10.elevation).toBeCloseTo(290, 9);
+  });
+
+  it('leaves a survey that already starts at md 0 unchanged', () => {
+    const traces = minimumCurvatureDesurvey(
+      collar,
+      [{ hole_id: 'T1', depth: 0, azimuth: 0, dip: -90 }, { hole_id: 'T1', depth: 10, azimuth: 0, dip: -90 }],
+      { step: 1 }
+    );
+    expect(traces).toHaveLength(11);
+    expect(traces[0].md).toBe(0);
+  });
+});
+
+describe('midpointTangentialDesurvey (GH-96)', () => {
+  const collar = [{ hole_id: 'M1', easting: 1000, northing: 2000, elevation: 300 }];
+
+  it('switches orientation halfway between stations', () => {
+    const traces = midpointTangentialDesurvey(
+      collar,
+      [{ hole_id: 'M1', depth: 0, azimuth: 0, dip: -90 }, { hole_id: 'M1', depth: 50, azimuth: 90, dip: 0 }],
+      { step: 5 }
+    );
+    const at25 = traces.find((row) => Math.abs(row.md - 25) < 1e-9);
+    expect(at25.elevation).toBeCloseTo(275, 9);
+    expect(at25.easting).toBeCloseTo(1000, 9);
+    const toe = traces.at(-1);
+    expect(toe.md).toBeCloseTo(50, 9);
+    expect(toe.elevation).toBeCloseTo(275, 9);
+    expect(toe.easting).toBeCloseTo(1025, 9);
+    expect(traces.filter((row) => row.md <= 25 + 1e-9).every((row) => row.dip === -90)).toBe(true);
+    expect(traces.filter((row) => row.md > 25 + 1e-9).every((row) => row.dip === 0)).toBe(true);
+  });
+
+  it('differs from top-of-segment tangential on a dogleg', () => {
+    const surveys = [
+      { hole_id: 'M1', depth: 0, azimuth: 0, dip: -90 }, { hole_id: 'M1', depth: 50, azimuth: 90, dip: 0 }
+    ];
+    expect(tangentialDesurvey(collar, surveys, { step: 5 }).at(-1).elevation).toBeCloseTo(250, 9);
+    expect(midpointTangentialDesurvey(collar, surveys, { step: 5 }).at(-1).elevation).toBeCloseTo(275, 9);
+  });
+
+  it('runs the last orientation from the last midpoint to the end of hole', () => {
+    const traces = midpointTangentialDesurvey(
+      collar,
+      [
+        { hole_id: 'M1', depth: 0, azimuth: 0, dip: -90 },
+        { hole_id: 'M1', depth: 20, azimuth: 0, dip: -90 },
+        { hole_id: 'M1', depth: 40, azimuth: 0, dip: 0 }
+      ],
+      { step: 10 }
+    );
+    const at30 = traces.find((row) => Math.abs(row.md - 30) < 1e-9);
+    expect(at30.elevation).toBeCloseTo(270, 9);
+    expect(at30.northing).toBeCloseTo(2000, 9);
+    const toe = traces.at(-1);
+    expect(toe.elevation).toBeCloseTo(270, 9);
+    expect(toe.northing).toBeCloseTo(2010, 9);
   });
 });

--- a/javascript/packages/baselode/tests/validateDrillholeDb.test.js
+++ b/javascript/packages/baselode/tests/validateDrillholeDb.test.js
@@ -7,6 +7,8 @@ import { describe, expect, it } from 'vitest';
 import {
   validateDrillholeDb,
   fixSingleStationSurveys,
+  dropUnusableSurveyRows,
+  synthesiseCollarStation,
   normalizeAzimuth,
   dropOrphanIntervals,
   swapInvertedIntervals,
@@ -285,5 +287,117 @@ describe('replaceBelowDetectionLimit', () => {
       { columns: ['au_ppm'], sentinelFactor: 1.0 },
     );
     expect(result[0].au_ppm).toBe(0.01);
+  });
+});
+
+describe('survey usability checks (GH-96)', () => {
+  it('flags rows with null azimuth or dip as errors with a fix recipe', () => {
+    const report = validateDrillholeDb({
+      collar: [collarRow('A')],
+      survey: [surveyRow('A', 0), { hole_id: 'A', depth: 50, azimuth: null, dip: -90 }, { hole_id: 'A', depth: 100, azimuth: 0, dip: undefined }],
+    });
+    const issues = checksWith(report, 'survey_null_orientation');
+    expect(issues.map((issue) => issue.row_index)).toEqual([1, 2]);
+    expect(issues.every((issue) => issue.severity === 'error')).toBe(true);
+    expect(issues[0].message).toContain('azimuth');
+    expect(issues[1].message).toContain('dip');
+    expect(issues[0].fix).toContain('dropUnusableSurveyRows');
+    expect(issues[0].fix).toContain('synthesiseCollarStation');
+    expect(checksWith(report, 'survey_no_usable_stations')).toEqual([]);
+  });
+
+  it('warns for a hole whose only survey rows are unusable', () => {
+    const report = validateDrillholeDb({
+      collar: [collarRow('A'), collarRow('B')],
+      survey: [surveyRow('A', 0), surveyRow('A', 50), { hole_id: 'B', depth: 0, azimuth: null, dip: null }],
+    });
+    const warnings = checksWith(report, 'survey_no_usable_stations');
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].hole_id).toBe('B');
+    expect(warnings[0].severity).toBe('warning');
+    expect(warnings[0].message).toContain('1 survey row(s)');
+    expect(warnings[0].fix).toContain('synthesiseCollarStation');
+  });
+
+  it('warns for a collar hole with no survey rows at all', () => {
+    const report = validateDrillholeDb({
+      collar: [collarRow('A'), collarRow('C')],
+      survey: [surveyRow('A', 0), surveyRow('A', 50)],
+    });
+    const warnings = checksWith(report, 'survey_no_usable_stations');
+    expect(warnings.map((issue) => issue.hole_id)).toEqual(['C']);
+    expect(warnings[0].message).toContain('no survey rows');
+  });
+
+  it('skips the no-usable-station check when the survey table is empty', () => {
+    const report = validateDrillholeDb({ collar: [collarRow('A')], survey: [] });
+    expect(checksWith(report, 'survey_no_usable_stations')).toEqual([]);
+  });
+
+  it('counts only usable rows for the single-station check', () => {
+    const report = validateDrillholeDb({
+      collar: [collarRow('A')],
+      survey: [surveyRow('A', 0), { hole_id: 'A', depth: 50, azimuth: null, dip: -90 }],
+    });
+    const single = checksWith(report, 'single_station_surveys');
+    expect(single).toHaveLength(1);
+    expect(single[0].row_index).toBe(0);
+  });
+});
+
+describe('dropUnusableSurveyRows', () => {
+  it('removes rows with null or non-numeric depth / azimuth / dip', () => {
+    const survey = [
+      surveyRow('A', 0),
+      { hole_id: 'A', depth: 50, azimuth: null, dip: -90 },
+      { hole_id: 'A', depth: 'bad', azimuth: 0, dip: -90 },
+      { hole_id: 'B', depth: 0, azimuth: 10, dip: 'x' },
+    ];
+    const result = dropUnusableSurveyRows(survey);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe(survey[0]);
+    expect(survey).toHaveLength(4);
+  });
+});
+
+describe('synthesiseCollarStation', () => {
+  it('builds a station from the collar orientation and drops the unusable rows', () => {
+    const collar = [
+      { ...collarRow('A'), azimuth: 45, dip: -60 },
+      { ...collarRow('B', 80), azimuth: 90, dip: -70 },
+    ];
+    const survey = [surveyRow('A', 0), surveyRow('A', 50), { hole_id: 'B', depth: 30, azimuth: null, dip: null }];
+    const { survey: result, report } = synthesiseCollarStation(survey, collar);
+    expect(report).toEqual({
+      holesSynthesised: 1, fromCollar: 1, verticalFallback: 0, verticalFallbackHoles: [], rowsDropped: 1,
+    });
+    const bRows = result.filter((row) => row.hole_id === 'B');
+    expect(bRows).toEqual([{ hole_id: 'B', depth: 0, azimuth: 90, dip: -70 }]);
+    expect(result.filter((row) => row.hole_id === 'A')).toHaveLength(2);
+  });
+
+  it('falls back to vertical and reports which holes', () => {
+    const collar = [collarRow('A'), collarRow('B', 80)];
+    const survey = [surveyRow('A', 0), surveyRow('A', 50)];
+    const { survey: result, report } = synthesiseCollarStation(survey, collar);
+    expect(report.holesSynthesised).toBe(1);
+    expect(report.verticalFallback).toBe(1);
+    expect(report.verticalFallbackHoles).toEqual(['B']);
+    expect(result.find((row) => row.hole_id === 'B')).toEqual({ hole_id: 'B', depth: 0, azimuth: 0, dip: -90 });
+  });
+
+  it('matches collar orientation columns case-insensitively', () => {
+    const collar = [{ ...collarRow('B', 80), Azimuth: 120, DIP: -55 }];
+    const { survey: result } = synthesiseCollarStation([], collar);
+    expect(result).toEqual([{ hole_id: 'B', depth: 0, azimuth: 120, dip: -55 }]);
+  });
+
+  it('pads to max_depth when chained with fixSingleStationSurveys', () => {
+    const collar = [{ ...collarRow('B', 80), azimuth: 90, dip: -60 }];
+    const { survey: synthesised } = synthesiseCollarStation([{ hole_id: 'B', depth: 40, azimuth: null, dip: null }], collar);
+    const padded = fixSingleStationSurveys(synthesised, collar);
+    expect(padded.map((row) => row.depth)).toEqual([0, 80]);
+    const report = validateDrillholeDb({ collar, survey: padded });
+    expect(report.summary).toEqual({ error: 0, warning: 0, info: 0 });
   });
 });

--- a/python/README.md
+++ b/python/README.md
@@ -12,7 +12,7 @@ Version 0.1.0 focuses on domain-aware data models and validation utilities for d
 pip install baselode
 ```
 
-**Requires:** Python 3.12+
+**Requires:** Python 3.10+
 
 ---
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -7,7 +7,7 @@ name = "baselode"
 dynamic = ["version"]
 description = "Domain-aware data models and utilities for exploration and mining datasets."
 readme = "README.md"
-requires-python = ">=3.12"
+requires-python = ">=3.10"
 license = "GPL-3.0-or-later"
 license-files = ["LICENSE"]
 authors = [{ name = "Tamara Vasey" }]
@@ -17,7 +17,10 @@ classifiers = [
   "Development Status :: 3 - Alpha",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Operating System :: OS Independent",
   "Topic :: Scientific/Engineering",
 ]

--- a/python/src/baselode/drill/data.py
+++ b/python/src/baselode/drill/data.py
@@ -484,7 +484,10 @@ def load_geophysics(source, source_column_map=None, keep_all=True, null_sentinel
         if col not in df.columns:
             raise ValueError(f"Geophysics table missing column: {col}")
 
-    df[HOLE_ID] = df[HOLE_ID].astype(str).str.strip()
+    # Blank hole_id must stay blank: ``astype(str)`` on older pandas turns
+    # NaN into the literal "nan", which would then pass the invalid-row
+    # filter below.
+    df[HOLE_ID] = df[HOLE_ID].where(df[HOLE_ID].notna(), "").astype(str).str.strip()
     df = _normalize_interval_bounds(df)
 
     invalid = (

--- a/python/src/baselode/drill/desurvey.py
+++ b/python/src/baselode/drill/desurvey.py
@@ -23,10 +23,17 @@ Supports multiple methods that trade simplicity for accuracy:
 - minimum_curvature (default): standard industry approach.
 - tangential: keeps the initial station orientation through the segment.
 - balanced_tangential: averages start/end orientations per segment.
+- midpoint_tangential: Vulcan-style "Tangent" — each station is the midpoint
+  of its straight segment, so orientation changes halfway between stations.
 
 All methods output a trace table with x, y, z coordinates at chosen step size,
 plus measured depth and azimuth/dip per vertex. Dependencies are limited to
 pandas and numpy for portability.
+
+Every trace starts at the collar (md 0). When a hole's first survey station
+sits below the collar, that station's orientation is extended straight up to
+md 0 — the convention Vulcan and Surpac use — so a hole with a single station
+at 135 m still produces a full-length trace instead of a zero-length one.
 
 Rows missing a hole identifier, usable collar coordinates, or usable survey
 measurements are ignored. Missing collar elevation defaults to zero. This lets
@@ -136,35 +143,79 @@ def _prepare_desurvey_inputs(collars, surveys):
     return prepared_collars, prepared_surveys
 
 
+def _station_list(hole_surveys):
+    """Return one hole's stations as a depth-sorted list of ``(md, azimuth, dip)``."""
+    ordered = hole_surveys.sort_values(DEPTH)
+    return [
+        (float(md), float(azimuth), float(dip))
+        for md, azimuth, dip in zip(ordered[DEPTH], ordered[AZIMUTH], ordered[DIP])
+    ]
+
+
+def _extrapolate_to_collar(stations):
+    """Prepend a virtual station at md 0 when the first real station is deeper.
+
+    A survey's first reading often sits below the collar (a downhole
+    camera's first shot at a few metres, or a single station recorded at
+    depth).  Without this the trace would start at that depth and the top
+    of the hole would be missing — or, for a single deep station, the
+    trace would be a single point.  Vulcan and Surpac extend the first
+    station's orientation straight up to the collar; do the same.
+    """
+    first_md, first_azimuth, first_dip = stations[0]
+    if first_md <= 0.0:
+        return stations
+    return [(0.0, first_azimuth, first_dip), *stations]
+
+
+def _midpoint_tangential_stations(stations):
+    """Re-cut stations so each orientation applies to the segment centred on it.
+
+    Vulcan's default "Tangent" desurvey treats each survey reading as the
+    midpoint of a straight segment: orientation changes halfway between
+    consecutive stations rather than at the stations themselves.  Express
+    that as an equivalent station list for the top-of-segment tangential
+    method — the first orientation holds from the collar to the first
+    midpoint, each interior orientation from midpoint to midpoint, and the
+    last orientation from the last midpoint to the end of the hole.
+    """
+    if len(stations) < 2:
+        return stations
+    recut = [stations[0]]
+    for (md0, _, _), (md1, azimuth1, dip1) in zip(stations, stations[1:]):
+        recut.append((0.5 * (md0 + md1), azimuth1, dip1))
+    recut.append(stations[-1])
+    return recut
+
+
 def _desurvey(collars, surveys, step=1.0, method="minimum_curvature"):
     collars, surveys = _prepare_desurvey_inputs(collars, surveys)
     if collars.empty or surveys.empty:
         return pd.DataFrame(columns=_TRACE_COLUMNS)
 
+    # midpoint_tangential is the tangential integrator run over a re-cut
+    # station list (see _midpoint_tangential_stations).
+    segment_method = "tangential" if method == "midpoint_tangential" else method
+
     traces = []
     collars_by_hole = collars.set_index(HOLE_ID)
     for hole_id, hole_surveys in surveys.groupby(HOLE_ID, sort=False):
         collar_row = collars_by_hole.loc[hole_id]
-        hole_surveys = hole_surveys.sort_values(DEPTH)
+        stations = _extrapolate_to_collar(_station_list(hole_surveys))
+        if method == "midpoint_tangential":
+            stations = _midpoint_tangential_stations(stations)
+
         x = float(collar_row[EASTING])
         y = float(collar_row[NORTHING])
         z = float(collar_row[ELEVATION])
-        md_cursor = float(hole_surveys.iloc[0][DEPTH])
-        az_prev = float(hole_surveys.iloc[0][AZIMUTH])
-        dip_prev = float(hole_surveys.iloc[0][DIP])
+        md_cursor, az_prev, dip_prev = stations[0]
         first_record = {HOLE_ID: hole_id, "md": md_cursor, EASTING: x, NORTHING: y, ELEVATION: z, AZIMUTH: az_prev, DIP: dip_prev}
         traces.append(first_record)
 
-        for idx in range(len(hole_surveys) - 1):
-            s0 = hole_surveys.iloc[idx]
-            s1 = hole_surveys.iloc[idx + 1]
-            md0 = float(s0[DEPTH])
-            md1 = float(s1[DEPTH])
+        for (md0, az0, dip0), (md1, az1, dip1) in zip(stations, stations[1:]):
             delta_md = md1 - md0
             if delta_md <= 0:
                 continue
-            az0, dip0 = float(s0[AZIMUTH]), float(s0[DIP])
-            az1, dip1 = float(s1[AZIMUTH]), float(s1[DIP])
 
             segment_steps = max(1, int(math.ceil(delta_md / step)))
             md_increment = delta_md / segment_steps
@@ -179,7 +230,7 @@ def _desurvey(collars, surveys, step=1.0, method="minimum_curvature"):
                     dip0=dip0,
                     az1=az1,
                     dip1=dip1,
-                    method=method,
+                    method=segment_method,
                 )
                 x += dx
                 y += dy
@@ -190,8 +241,8 @@ def _desurvey(collars, surveys, step=1.0, method="minimum_curvature"):
                     EASTING: x,
                     NORTHING: y,
                     ELEVATION: z,
-                    AZIMUTH: az_interp if method == "minimum_curvature" else az_for_record,
-                    DIP: dip_interp if method == "minimum_curvature" else dip_for_record,
+                    AZIMUTH: az_interp if segment_method == "minimum_curvature" else az_for_record,
+                    DIP: dip_interp if segment_method == "minimum_curvature" else dip_for_record,
                 }
                 traces.append(record)
     out = pd.DataFrame(traces)
@@ -211,6 +262,19 @@ def tangential_desurvey(collars, surveys, step=1.0,):
 def balanced_tangential_desurvey(collars, surveys, step=1.0):
     """Use averaged endpoint orientations, ignoring incomplete input rows."""
     return _desurvey(collars=collars, surveys=surveys, step=step, method="balanced_tangential")
+
+
+def midpoint_tangential_desurvey(collars, surveys, step=1.0):
+    """Vulcan-style tangent: each station is the midpoint of a straight segment.
+
+    Orientation changes halfway between consecutive stations instead of at
+    the stations themselves, so the first station's reading holds from the
+    collar to the first midpoint and the last station's reading from the
+    last midpoint to the end of the hole.  This is the like-for-like method
+    for comparing against Vulcan's default "Tangent" desurvey output.
+    Incomplete input rows are ignored.
+    """
+    return _desurvey(collars=collars, surveys=surveys, step=step, method="midpoint_tangential")
 
 
 def interpolate_trajectory(

--- a/python/src/baselode/drill/drillhole_set.py
+++ b/python/src/baselode/drill/drillhole_set.py
@@ -34,6 +34,7 @@ def _desurvey_methods():
         "minimum_curvature": desurvey.minimum_curvature_desurvey,
         "tangential": desurvey.tangential_desurvey,
         "balanced_tangential": desurvey.balanced_tangential_desurvey,
+        "midpoint_tangential": desurvey.midpoint_tangential_desurvey,
     }
 
 
@@ -127,7 +128,7 @@ class DrillholeSet:
         ----------
         method : str
             One of ``"minimum_curvature"``, ``"tangential"``,
-            ``"balanced_tangential"``.
+            ``"balanced_tangential"``, ``"midpoint_tangential"``.
         step : float
             Output sample spacing (metres).
         force : bool

--- a/python/src/baselode/drill/validate.py
+++ b/python/src/baselode/drill/validate.py
@@ -141,6 +141,13 @@ def validate_drillhole_db(
     ``hole_id`` / ``table`` / ``row_index``, a human-readable ``message``,
     and a ``fix`` recipe when one is available.
 
+    Survey rows are "usable" when ``depth``, ``azimuth`` and ``dip`` are all
+    numeric.  Desurvey silently ignores anything else, so the survey checks
+    flag them here: ``survey_null_orientation`` (error, per row) and
+    ``survey_no_usable_stations`` (warning, per hole — the hole will drop
+    out of the desurvey entirely).  ``single_station_surveys`` counts only
+    usable rows.
+
     Parameters
     ----------
     collar : pd.DataFrame
@@ -169,7 +176,9 @@ def validate_drillhole_db(
     """
     issues = []
     issues.extend(_check_duplicate_hole_ids(collar, hole_col))
-    issues.extend(_check_single_station_surveys(survey, hole_col, depth_col))
+    issues.extend(_check_survey_null_orientation(survey, hole_col, depth_col, azimuth_col, dip_col))
+    issues.extend(_check_survey_no_usable_stations(collar, survey, hole_col, depth_col, azimuth_col, dip_col))
+    issues.extend(_check_single_station_surveys(survey, hole_col, depth_col, azimuth_col, dip_col))
     issues.extend(_check_azimuth_range(survey, hole_col, depth_col, azimuth_col, allow_full_circle))
     issues.extend(_check_dip_range(survey, hole_col, depth_col, dip_col))
 
@@ -225,8 +234,9 @@ def fix_single_station_surveys(survey, collar=None, hole_col=HOLE_ID, depth_col=
         return survey.copy()
 
     max_depth_lookup = _build_max_depth_lookup(collar, hole_col, max_depth_col) if collar is not None else {}
+    usable = _usable_station_mask(survey, depth_col, AZIMUTH, DIP)
     new_rows = []
-    for hole_id, group in survey.groupby(hole_col):
+    for hole_id, group in survey[usable].groupby(hole_col):
         if len(group) != 1:
             continue
         original = group.iloc[0]
@@ -242,6 +252,156 @@ def fix_single_station_surveys(survey, collar=None, hole_col=HOLE_ID, depth_col=
 
     extended = pd.concat([survey, pd.DataFrame(new_rows)], ignore_index=True)
     return extended.sort_values([hole_col, depth_col]).reset_index(drop=True)
+
+
+def drop_unusable_survey_rows(survey, hole_col=HOLE_ID, depth_col=DEPTH, azimuth_col=AZIMUTH, dip_col=DIP):
+    """Drop survey rows whose depth, azimuth or dip is null or non-numeric.
+
+    The complement of the ``survey_null_orientation`` validation check.
+    Desurvey already ignores these rows, so removing them changes no trace;
+    it just makes the table honest about what it contains.  Holes left
+    with no rows at all are reported by ``survey_no_usable_stations`` and
+    can be rebuilt with :func:`synthesise_collar_station`.
+
+    Parameters
+    ----------
+    survey : pd.DataFrame
+        Survey table.
+    hole_col, depth_col, azimuth_col, dip_col : str
+        Column-name overrides (defaults from :mod:`baselode.datamodel`).
+
+    Returns
+    -------
+    pd.DataFrame
+        Filtered copy of *survey* with the index reset.
+    """
+    if survey.empty:
+        return survey.copy()
+    usable = _usable_station_mask(survey, depth_col, azimuth_col, dip_col)
+    return survey[usable].reset_index(drop=True)
+
+
+def _resolve_column(df, name):
+    """Return the column of *df* matching *name* exactly or case-insensitively, else ``None``."""
+    if name is None:
+        return None
+    if name in df.columns:
+        return name
+    wanted = str(name).strip().lower()
+    for col in df.columns:
+        if str(col).strip().lower() == wanted:
+            return col
+    return None
+
+
+def synthesise_collar_station(
+    survey,
+    collar,
+    hole_col=HOLE_ID,
+    depth_col=DEPTH,
+    azimuth_col=AZIMUTH,
+    dip_col=DIP,
+    collar_azimuth_col=AZIMUTH,
+    collar_dip_col=DIP,
+    return_diagnostics=False,
+):
+    """Build a survey station at the collar for every hole that has none.
+
+    Targets holes that would otherwise drop out of the desurvey: collar
+    holes with no survey rows, and holes whose every survey row lacks a
+    usable depth / azimuth / dip.  For each one a station at depth ``0``
+    is appended, oriented from the collar table's *collar_azimuth_col* /
+    *collar_dip_col* (matched case-insensitively) when both are numeric,
+    otherwise vertical (``azimuth 0``, ``dip -90``).  The hole's existing
+    unusable rows are dropped so the synthetic station is its only one.
+
+    Pair with :func:`fix_single_station_surveys` afterwards: the synthetic
+    station is a single-station survey, and that helper pads it to
+    ``collar.max_depth`` so the trace runs the full hole length.
+
+    Holes that already have at least one usable station are left alone.
+
+    Parameters
+    ----------
+    survey : pd.DataFrame
+        Survey table.
+    collar : pd.DataFrame
+        Collar table.  Provides the set of holes and, optionally, the
+        orientation columns.
+    hole_col, depth_col, azimuth_col, dip_col : str
+        Survey column-name overrides (defaults from :mod:`baselode.datamodel`).
+    collar_azimuth_col, collar_dip_col : str
+        Collar columns holding the planned hole orientation.  Default to
+        the canonical ``azimuth`` / ``dip`` names.  Dip follows the survey
+        convention (negative = down).
+    return_diagnostics : bool, optional
+        When ``True`` return ``(survey, report)`` where *report* is a dict
+        with ``holes_synthesised``, ``from_collar``, ``vertical_fallback``,
+        ``vertical_fallback_holes`` and ``rows_dropped``.
+
+    Returns
+    -------
+    pd.DataFrame, or tuple of (pd.DataFrame, dict)
+        Survey with synthetic stations appended, sorted by ``hole_col`` /
+        ``depth_col`` with the index reset.  See ``return_diagnostics``.
+    """
+    report = {
+        "holes_synthesised": 0,
+        "from_collar": 0,
+        "vertical_fallback": 0,
+        "vertical_fallback_holes": [],
+        "rows_dropped": 0,
+    }
+    if collar is None or collar.empty or hole_col not in collar.columns:
+        out = survey.copy()
+        return (out, report) if return_diagnostics else out
+
+    if survey.empty:
+        columns = list(survey.columns)
+        for col in (hole_col, depth_col, azimuth_col, dip_col):
+            if col not in columns:
+                columns.append(col)
+        work = pd.DataFrame(columns=columns)
+    else:
+        work = survey.copy()
+    for col in (depth_col, azimuth_col, dip_col):
+        if col not in work.columns:
+            work[col] = np.nan
+
+    usable = _usable_station_mask(work, depth_col, azimuth_col, dip_col)
+    holes_with_station = set(work.loc[usable, hole_col].dropna().tolist())
+
+    az_source = _resolve_column(collar, collar_azimuth_col)
+    dip_source = _resolve_column(collar, collar_dip_col)
+    collar_by_hole = collar.drop_duplicates(subset=[hole_col], keep="first").set_index(hole_col)
+
+    new_rows = []
+    for hole_id in collar_by_hole.index:
+        if hole_id is None or pd.isna(hole_id) or hole_id in holes_with_station:
+            continue
+        collar_row = collar_by_hole.loc[hole_id]
+        azimuth = _to_float(collar_row.get(az_source)) if az_source is not None else None
+        dip = _to_float(collar_row.get(dip_source)) if dip_source is not None else None
+        if azimuth is not None and dip is not None:
+            report["from_collar"] += 1
+        else:
+            azimuth, dip = 0.0, -90.0
+            report["vertical_fallback"] += 1
+            report["vertical_fallback_holes"].append(hole_id)
+        report["holes_synthesised"] += 1
+        new_rows.append({hole_col: hole_id, depth_col: 0.0, azimuth_col: azimuth, dip_col: dip})
+
+    if not new_rows:
+        out = work.reset_index(drop=True)
+        return (out, report) if return_diagnostics else out
+
+    synthesised_holes = {row[hole_col] for row in new_rows}
+    drop_mask = work[hole_col].isin(synthesised_holes) & ~usable
+    report["rows_dropped"] = int(drop_mask.sum())
+    kept = work[~drop_mask]
+    extended = pd.concat([kept, pd.DataFrame(new_rows, columns=kept.columns)], ignore_index=True)
+    out = extended.sort_values([hole_col, depth_col]).reset_index(drop=True)
+    return (out, report) if return_diagnostics else out
 
 
 def drop_orphan_intervals(table, collar, hole_col=HOLE_ID):
@@ -367,6 +527,8 @@ def fix_overlaps(
     touching_tol=0.01,
     merge_tol=0.05,
     coverage_min=0.95,
+    precedence_col=None,
+    precedence=None,
     return_diagnostics=False,
 ):
     """Resolve interval overlaps where it's safe, leave the rest flagged.
@@ -385,6 +547,14 @@ def fix_overlaps(
       longer's value within ``merge_tol`` (relative), and the shorter
       intervals cover at least ``coverage_min`` of the longer.  Drops
       the longer interval, keeps the higher-resolution rows.
+
+    * **Dataset precedence** (opt-in via ``precedence_col`` +
+      ``precedence``) — when two overlapping rows come from different
+      datasets / campaigns, drop the row from the lower-ranked dataset.
+      Resolves the common case of two sampling campaigns (say 0.5 m and
+      1 m intervals) interleaved over the same depths by rule instead of
+      by hand.  Rows whose dataset isn't listed in ``precedence`` are
+      never dropped this way.
 
     Anything else — same depth zone, materially different values, or
     partial overlaps — is left untouched and returned in the
@@ -410,6 +580,14 @@ def fix_overlaps(
         Minimum fraction of a candidate superset that must be covered by
         inner intervals before it qualifies as a "resampled superset".
         Default ``0.95``.
+    precedence_col : str, optional
+        Column identifying the dataset / campaign each row came from
+        (e.g. ``project_id``).  Enables the dataset-precedence pass when
+        given together with ``precedence``.
+    precedence : iterable of str, optional
+        Dataset values in priority order, highest first.  Where two rows
+        from different listed datasets overlap, the row from the dataset
+        that appears later in this list is dropped.
     return_diagnostics : bool, optional
         When ``True``, return ``(fixed, conflicts, report)``: the fixed
         table, the rows still in conflict, and an audit-log frame with
@@ -518,6 +696,41 @@ def fix_overlaps(
             _emit(hole_id, "superset", "dropped",
                   outer_from, outer_to,
                   f"covered by {len(inner_idxs)} finer rows ({covered / outer_length:.0%})")
+
+    # ---- Pass 3b: dataset precedence ----------------------------------------
+    if precedence_col is not None and precedence and precedence_col in work.columns:
+        rank = {str(value): position for position, value in enumerate(precedence)}
+
+        def _rank(idx):
+            value = work.at[idx, precedence_col]
+            if pd.isna(value):
+                return None
+            return rank.get(str(value))
+
+        for hole_id, group in work.loc[keep].groupby(hole_col, sort=False):
+            ordered_idxs = list(group.sort_values([from_col, to_col]).index)
+            for a_pos, a_idx in enumerate(ordered_idxs):
+                if not keep[a_idx]:
+                    continue
+                a_rank = _rank(a_idx)
+                if a_rank is None:
+                    continue
+                for b_idx in ordered_idxs[a_pos + 1:]:
+                    if not keep[a_idx]:
+                        break
+                    if not keep[b_idx]:
+                        continue
+                    if float(work.at[b_idx, from_col]) >= float(work.at[a_idx, to_col]):
+                        break
+                    b_rank = _rank(b_idx)
+                    if b_rank is None or b_rank == a_rank:
+                        continue
+                    loser_idx, winner_idx = (b_idx, a_idx) if b_rank > a_rank else (a_idx, b_idx)
+                    keep[loser_idx] = False
+                    _emit(hole_id, "precedence", "dropped",
+                          float(work.at[loser_idx, from_col]), float(work.at[loser_idx, to_col]),
+                          f"{precedence_col}={work.at[loser_idx, precedence_col]} yields to "
+                          f"{work.at[winner_idx, precedence_col]}")
 
     # ---- Pass 4: surface remaining real conflicts --------------------------
     conflict_idx_set = []
@@ -780,11 +993,107 @@ def _check_duplicate_hole_ids(collar, hole_col):
     ]
 
 
-def _check_single_station_surveys(survey, hole_col, depth_col):
+def _usable_station_mask(survey, depth_col, azimuth_col, dip_col):
+    """Boolean Series: True where depth, azimuth and dip are all finite numbers.
+
+    This is exactly the row filter :mod:`baselode.drill.desurvey` applies,
+    so "usable" here means "will contribute to a trace".
+    """
+    mask = pd.Series(True, index=survey.index)
+    for col in (depth_col, azimuth_col, dip_col):
+        if col not in survey.columns:
+            return pd.Series(False, index=survey.index)
+        numeric = pd.to_numeric(survey[col], errors="coerce")
+        mask &= numeric.notna() & np.isfinite(numeric.fillna(0.0))
+    return mask
+
+
+def _check_survey_null_orientation(survey, hole_col, depth_col, azimuth_col, dip_col):
+    """Error per survey row whose depth / azimuth / dip is null or non-numeric."""
     if survey.empty or hole_col not in survey.columns:
         return []
+    columns = [col for col in (depth_col, azimuth_col, dip_col) if col in survey.columns]
+    if not columns:
+        return []
     issues = []
-    for hole_id, group in survey.groupby(hole_col):
+    for idx, row in survey.iterrows():
+        missing = [col for col in columns if _to_float(row.get(col)) is None]
+        if not missing:
+            continue
+        hole_id = row.get(hole_col)
+        issues.append(_issue(
+            check="survey_null_orientation",
+            severity=SEVERITY_ERROR,
+            hole_id=str(hole_id) if hole_id is not None and not pd.isna(hole_id) else None,
+            table="survey",
+            row_index=int(idx) if isinstance(idx, (int, np.integer)) else None,
+            message=(
+                f"Survey row for hole '{hole_id}' has no usable {' / '.join(missing)}; "
+                "desurvey ignores this row"
+            ),
+            fix=(
+                "Fill the value from the source survey, or call "
+                "drop_unusable_survey_rows(survey); holes left without a station "
+                "can be rebuilt with synthesise_collar_station(survey, collar)"
+            ),
+        ))
+    return issues
+
+
+def _check_survey_no_usable_stations(collar, survey, hole_col, depth_col, azimuth_col, dip_col):
+    """Warning per hole that has no survey row desurvey can use.
+
+    Covers both holes whose every survey row is unusable and collar holes
+    with no survey rows at all — either way the hole silently drops out of
+    the desurvey.  Skipped when the survey table is empty (nothing to
+    compare against).
+    """
+    if survey.empty or hole_col not in survey.columns:
+        return []
+    usable = _usable_station_mask(survey, depth_col, azimuth_col, dip_col)
+    survey_rows = survey[hole_col].dropna().value_counts()
+    usable_rows = survey.loc[usable, hole_col].dropna().value_counts()
+
+    candidate_holes = list(survey_rows.index)
+    if collar is not None and not collar.empty and hole_col in collar.columns:
+        seen = set(candidate_holes)
+        for hole_id in collar[hole_col].dropna().unique():
+            if hole_id not in seen:
+                candidate_holes.append(hole_id)
+                seen.add(hole_id)
+
+    issues = []
+    for hole_id in candidate_holes:
+        if usable_rows.get(hole_id, 0) > 0:
+            continue
+        row_count = int(survey_rows.get(hole_id, 0))
+        if row_count:
+            message = (
+                f"Hole '{hole_id}' has {row_count} survey row(s) but none with usable "
+                "depth / azimuth / dip; it will be dropped by desurvey"
+            )
+        else:
+            message = f"Hole '{hole_id}' has no survey rows; it will be dropped by desurvey"
+        issues.append(_issue(
+            check="survey_no_usable_stations",
+            severity=SEVERITY_WARNING,
+            hole_id=str(hole_id),
+            table="survey",
+            message=message,
+            fix=(
+                "Call synthesise_collar_station(survey, collar) to build a station at "
+                "the collar from the collar azimuth/dip columns (vertical fallback)"
+            ),
+        ))
+    return issues
+
+
+def _check_single_station_surveys(survey, hole_col, depth_col, azimuth_col=AZIMUTH, dip_col=DIP):
+    if survey.empty or hole_col not in survey.columns:
+        return []
+    usable = _usable_station_mask(survey, depth_col, azimuth_col, dip_col)
+    issues = []
+    for hole_id, group in survey[usable].groupby(hole_col):
         if len(group) == 1:
             issues.append(_issue(
                 check="single_station_surveys",
@@ -792,7 +1101,7 @@ def _check_single_station_surveys(survey, hole_col, depth_col):
                 hole_id=str(hole_id),
                 table="survey",
                 row_index=int(group.index[0]) if isinstance(group.index[0], (int, np.integer)) else None,
-                message=f"Hole '{hole_id}' has only one survey station; desurvey will fail",
+                message=f"Hole '{hole_id}' has only one usable survey station; desurvey will fail",
                 fix="Call fix_single_station_surveys(survey, collar) to add a synthetic station",
             ))
     return issues

--- a/python/src/baselode/drill/validate.py
+++ b/python/src/baselode/drill/validate.py
@@ -203,7 +203,15 @@ def validate_drillhole_db(
     return {"summary": summary, "issues": issues}
 
 
-def fix_single_station_surveys(survey, collar=None, hole_col=HOLE_ID, depth_col=DEPTH, max_depth_col=MAX_DEPTH):
+def fix_single_station_surveys(
+    survey,
+    collar=None,
+    hole_col=HOLE_ID,
+    depth_col=DEPTH,
+    max_depth_col=MAX_DEPTH,
+    azimuth_col=AZIMUTH,
+    dip_col=DIP,
+):
     """Synthesize a second survey station for any hole with only one.
 
     Desurvey requires at least two stations per hole; a hole with exactly
@@ -222,7 +230,9 @@ def fix_single_station_surveys(survey, collar=None, hole_col=HOLE_ID, depth_col=
     collar : pd.DataFrame, optional
         Collar table; if provided and contains *max_depth_col*, that value
         is used as the synthetic station depth.
-    hole_col, depth_col, max_depth_col : str
+    hole_col, depth_col, max_depth_col, azimuth_col, dip_col : str
+        Column-name overrides.  Only rows with a finite *depth_col*,
+        *azimuth_col* and *dip_col* count as stations.
 
     Returns
     -------
@@ -234,7 +244,7 @@ def fix_single_station_surveys(survey, collar=None, hole_col=HOLE_ID, depth_col=
         return survey.copy()
 
     max_depth_lookup = _build_max_depth_lookup(collar, hole_col, max_depth_col) if collar is not None else {}
-    usable = _usable_station_mask(survey, depth_col, AZIMUTH, DIP)
+    usable = _usable_station_mask(survey, depth_col, azimuth_col, dip_col)
     new_rows = []
     for hole_id, group in survey[usable].groupby(hole_col):
         if len(group) != 1:
@@ -311,8 +321,8 @@ def synthesise_collar_station(
     holes with no survey rows, and holes whose every survey row lacks a
     usable depth / azimuth / dip.  For each one a station at depth ``0``
     is appended, oriented from the collar table's *collar_azimuth_col* /
-    *collar_dip_col* (matched case-insensitively) when both are numeric,
-    otherwise vertical (``azimuth 0``, ``dip -90``).  The hole's existing
+    *collar_dip_col* (matched case-insensitively) when both are finite
+    numbers, otherwise vertical (``azimuth 0``, ``dip -90``).  The hole's existing
     unusable rows are dropped so the synthetic station is its only one.
 
     Pair with :func:`fix_single_station_surveys` afterwards: the synthetic
@@ -380,8 +390,8 @@ def synthesise_collar_station(
         if hole_id is None or pd.isna(hole_id) or hole_id in holes_with_station:
             continue
         collar_row = collar_by_hole.loc[hole_id]
-        azimuth = _to_float(collar_row.get(az_source)) if az_source is not None else None
-        dip = _to_float(collar_row.get(dip_source)) if dip_source is not None else None
+        azimuth = _finite_float(collar_row.get(az_source)) if az_source is not None else None
+        dip = _finite_float(collar_row.get(dip_source)) if dip_source is not None else None
         if azimuth is not None and dip is not None:
             report["from_collar"] += 1
         else:
@@ -634,10 +644,50 @@ def fix_overlaps(
             "note": note,
         })
 
+    # ---- Pass 0: dataset precedence -----------------------------------------
+    # Runs first so the duplicate / superset passes below can never discard
+    # a preferred-dataset row in favour of a lower-ranked one.
+    if precedence_col is not None and precedence and precedence_col in work.columns:
+        rank = {str(value): position for position, value in enumerate(precedence)}
+
+        def _rank(idx):
+            value = work.at[idx, precedence_col]
+            if pd.isna(value):
+                return None
+            return rank.get(str(value))
+
+        for hole_id, group in work.loc[keep].groupby(hole_col, sort=False):
+            ordered_idxs = list(group.sort_values([from_col, to_col]).index)
+            for a_pos, a_idx in enumerate(ordered_idxs):
+                if not keep[a_idx]:
+                    continue
+                a_rank = _rank(a_idx)
+                if a_rank is None:
+                    continue
+                for b_idx in ordered_idxs[a_pos + 1:]:
+                    if not keep[a_idx]:
+                        break
+                    if not keep[b_idx]:
+                        continue
+                    if float(work.at[b_idx, from_col]) >= float(work.at[a_idx, to_col]):
+                        break
+                    b_rank = _rank(b_idx)
+                    if b_rank is None or b_rank == a_rank:
+                        continue
+                    loser_idx, winner_idx = (b_idx, a_idx) if b_rank > a_rank else (a_idx, b_idx)
+                    keep[loser_idx] = False
+                    _emit(hole_id, "precedence", "dropped",
+                          float(work.at[loser_idx, from_col]), float(work.at[loser_idx, to_col]),
+                          f"{precedence_col}={work.at[loser_idx, precedence_col]} yields to "
+                          f"{work.at[winner_idx, precedence_col]}")
+
     # ---- Pass 1: drop exact duplicates -------------------------------------
     dup_keys = [hole_col, from_col, to_col] + value_cols
     dup_keys = [k for k in dup_keys if k in work.columns]
-    duplicated_mask = work.duplicated(subset=dup_keys, keep="first")
+    # Only rows still kept take part, so a row already dropped by the
+    # precedence pass can't shadow the preferred duplicate.
+    duplicated_mask = pd.Series(False, index=work.index)
+    duplicated_mask.loc[keep] = work.loc[keep].duplicated(subset=dup_keys, keep="first")
     for idx in work.index[duplicated_mask]:
         row = work.loc[idx]
         _emit(row[hole_col], "duplicate", "dropped", row[from_col], row[to_col])
@@ -696,41 +746,6 @@ def fix_overlaps(
             _emit(hole_id, "superset", "dropped",
                   outer_from, outer_to,
                   f"covered by {len(inner_idxs)} finer rows ({covered / outer_length:.0%})")
-
-    # ---- Pass 3b: dataset precedence ----------------------------------------
-    if precedence_col is not None and precedence and precedence_col in work.columns:
-        rank = {str(value): position for position, value in enumerate(precedence)}
-
-        def _rank(idx):
-            value = work.at[idx, precedence_col]
-            if pd.isna(value):
-                return None
-            return rank.get(str(value))
-
-        for hole_id, group in work.loc[keep].groupby(hole_col, sort=False):
-            ordered_idxs = list(group.sort_values([from_col, to_col]).index)
-            for a_pos, a_idx in enumerate(ordered_idxs):
-                if not keep[a_idx]:
-                    continue
-                a_rank = _rank(a_idx)
-                if a_rank is None:
-                    continue
-                for b_idx in ordered_idxs[a_pos + 1:]:
-                    if not keep[a_idx]:
-                        break
-                    if not keep[b_idx]:
-                        continue
-                    if float(work.at[b_idx, from_col]) >= float(work.at[a_idx, to_col]):
-                        break
-                    b_rank = _rank(b_idx)
-                    if b_rank is None or b_rank == a_rank:
-                        continue
-                    loser_idx, winner_idx = (b_idx, a_idx) if b_rank > a_rank else (a_idx, b_idx)
-                    keep[loser_idx] = False
-                    _emit(hole_id, "precedence", "dropped",
-                          float(work.at[loser_idx, from_col]), float(work.at[loser_idx, to_col]),
-                          f"{precedence_col}={work.at[loser_idx, precedence_col]} yields to "
-                          f"{work.at[winner_idx, precedence_col]}")
 
     # ---- Pass 4: surface remaining real conflicts --------------------------
     conflict_idx_set = []
@@ -939,6 +954,18 @@ def _to_float(value):
     return result
 
 
+def _finite_float(value):
+    """Like :func:`_to_float` but also rejects ``inf`` / ``-inf``.
+
+    Desurvey treats infinities as missing, so anything that decides whether
+    a station is usable must do the same.
+    """
+    result = _to_float(value)
+    if result is None or not np.isfinite(result):
+        return None
+    return result
+
+
 def _numeric_view(table, *columns):
     """Return a copy of *table* with *columns* coerced to numeric (NaN on failure)."""
     out = table.copy()
@@ -1017,7 +1044,7 @@ def _check_survey_null_orientation(survey, hole_col, depth_col, azimuth_col, dip
         return []
     issues = []
     for idx, row in survey.iterrows():
-        missing = [col for col in columns if _to_float(row.get(col)) is None]
+        missing = [col for col in columns if _finite_float(row.get(col)) is None]
         if not missing:
             continue
         hole_id = row.get(hole_col)

--- a/test/data/parity_contract.json
+++ b/test/data/parity_contract.json
@@ -156,6 +156,7 @@
         "minimumCurvatureDesurvey",
         "tangentialDesurvey",
         "balancedTangentialDesurvey",
+        "midpointTangentialDesurvey",
         "attachAssayPositions",
         "buildTraces",
         "interpolateTrajectory"
@@ -164,6 +165,7 @@
         ["baselode.drill.desurvey", "minimum_curvature_desurvey"],
         ["baselode.drill.desurvey", "tangential_desurvey"],
         ["baselode.drill.desurvey", "balanced_tangential_desurvey"],
+        ["baselode.drill.desurvey", "midpoint_tangential_desurvey"],
         ["baselode.drill.desurvey", "attach_assay_positions"],
         ["baselode.drill.desurvey", "build_traces"],
         ["baselode.drill.desurvey", "interpolate_trajectory"]
@@ -328,10 +330,12 @@
     },
     {
       "name": "validate_drillhole_db",
-      "description": "Comprehensive drillhole-database validator: returns a structured {summary, issues} report covering duplicate collar IDs, single-station surveys, az/dip range, orphans, gaps, overlaps, beyond-max-depth, and below-detection sentinels. Ships fix_single_station_surveys + replace_below_detection_limit helpers.",
+      "description": "Comprehensive drillhole-database validator: returns a structured {summary, issues} report covering duplicate collar IDs, survey rows with null orientation, holes with no usable survey station, single-station surveys, az/dip range, orphans, gaps, overlaps, beyond-max-depth, and below-detection sentinels. Ships fix_single_station_surveys, drop_unusable_survey_rows, synthesise_collar_station + replace_below_detection_limit helpers. fix_overlaps (with dataset precedence) is Python-only.",
       "jsExports": [
         "validateDrillholeDb",
         "fixSingleStationSurveys",
+        "dropUnusableSurveyRows",
+        "synthesiseCollarStation",
         "normalizeAzimuth",
         "dropOrphanIntervals",
         "swapInvertedIntervals",
@@ -343,6 +347,8 @@
       "pythonSymbols": [
         ["baselode.drill.validate", "validate_drillhole_db"],
         ["baselode.drill.validate", "fix_single_station_surveys"],
+        ["baselode.drill.validate", "drop_unusable_survey_rows"],
+        ["baselode.drill.validate", "synthesise_collar_station"],
         ["baselode.drill.validate", "normalize_azimuth"],
         ["baselode.drill.validate", "drop_orphan_intervals"],
         ["baselode.drill.validate", "swap_inverted_intervals"],

--- a/test/test_desurvey_collar_and_midpoint.py
+++ b/test/test_desurvey_collar_and_midpoint.py
@@ -1,0 +1,137 @@
+# Copyright (C) 2026 Darkmine Pty Ltd
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Collar extrapolation and the Vulcan-style midpoint-tangent method.
+
+Covers GitHub issue #96 items 5 and 6: every trace starts at md 0 using
+the first station's orientation, and ``midpoint_tangential`` treats each
+station as the midpoint of its straight segment.
+"""
+
+import math
+
+import pandas as pd
+import pytest
+
+import baselode.drill.desurvey as desurvey
+import baselode.drill.drillhole_set
+
+
+ALL_METHODS = [
+    desurvey.minimum_curvature_desurvey,
+    desurvey.tangential_desurvey,
+    desurvey.balanced_tangential_desurvey,
+    desurvey.midpoint_tangential_desurvey,
+]
+
+
+def _collar(hole_id="A", easting=1000.0, northing=2000.0, elevation=300.0):
+    return pd.DataFrame([{
+        "hole_id": hole_id, "easting": easting, "northing": northing, "elevation": elevation,
+    }])
+
+
+def _survey(rows, hole_id="A"):
+    return pd.DataFrame(
+        [{"hole_id": hole_id, "depth": d, "azimuth": a, "dip": p} for d, a, p in rows]
+    )
+
+
+@pytest.mark.parametrize("method_fn", ALL_METHODS)
+def test_single_deep_station_extends_to_collar(method_fn):
+    """TRBC041-style hole: one station at 135 m used to give a zero-length trace."""
+    traces = method_fn(_collar(), _survey([(135.0, 90.0, -60.0)]), step=5.0)
+
+    assert traces["md"].iloc[0] == 0.0
+    assert traces["md"].iloc[-1] == pytest.approx(135.0)
+    if method_fn is not desurvey.midpoint_tangential_desurvey:
+        assert len(traces) == 28  # md 0 plus 27 x 5 m steps
+    first = traces.iloc[0]
+    assert (first["easting"], first["northing"], first["elevation"]) == (1000.0, 2000.0, 300.0)
+    toe = traces.iloc[-1]
+    horizontal = 135.0 * math.cos(math.radians(60.0))
+    assert toe["easting"] == pytest.approx(1000.0 + horizontal)
+    assert toe["northing"] == pytest.approx(2000.0)
+    assert toe["elevation"] == pytest.approx(300.0 - 135.0 * math.sin(math.radians(60.0)))
+    assert (traces["azimuth"] == 90.0).all()
+    assert (traces["dip"] == -60.0).all()
+
+
+@pytest.mark.parametrize("method_fn", ALL_METHODS)
+def test_first_station_below_collar_is_extrapolated_straight(method_fn):
+    """The first station's orientation holds from md 0 down to that station."""
+    traces = method_fn(
+        _collar(), _survey([(10.0, 0.0, -90.0), (20.0, 90.0, -45.0)]), step=1.0,
+    )
+    assert traces["md"].iloc[0] == 0.0
+    at_10 = traces[(traces["md"] - 10.0).abs() < 1e-9].iloc[0]
+    assert at_10["easting"] == pytest.approx(1000.0)
+    assert at_10["northing"] == pytest.approx(2000.0)
+    assert at_10["elevation"] == pytest.approx(290.0)
+
+
+@pytest.mark.parametrize("method_fn", ALL_METHODS)
+def test_first_station_at_collar_is_unchanged(method_fn):
+    traces = method_fn(_collar(), _survey([(0.0, 0.0, -90.0), (10.0, 0.0, -90.0)]), step=1.0)
+    assert traces["md"].iloc[0] == 0.0
+    assert len(traces) == 11
+    assert (traces["md"] >= 0).all()
+
+
+def test_midpoint_tangential_switches_orientation_halfway_between_stations():
+    """Station 1 (vertical) applies to 0-25 m, station 2 (horizontal east) to 25-50 m."""
+    survey = _survey([(0.0, 0.0, -90.0), (50.0, 90.0, 0.0)])
+    traces = desurvey.midpoint_tangential_desurvey(_collar(), survey, step=5.0)
+
+    at_25 = traces[(traces["md"] - 25.0).abs() < 1e-9].iloc[0]
+    assert at_25["elevation"] == pytest.approx(275.0)
+    assert at_25["easting"] == pytest.approx(1000.0)
+    toe = traces.iloc[-1]
+    assert toe["md"] == pytest.approx(50.0)
+    assert toe["elevation"] == pytest.approx(275.0)
+    assert toe["easting"] == pytest.approx(1025.0)
+    # Recorded orientation is the segment's orientation, not an interpolation.
+    assert (traces.loc[traces["md"] <= 25.0 + 1e-9, "dip"] == -90.0).all()
+    assert (traces.loc[traces["md"] > 25.0 + 1e-9, "dip"] == 0.0).all()
+
+
+def test_midpoint_tangential_differs_from_top_of_segment_tangential():
+    survey = _survey([(0.0, 0.0, -90.0), (50.0, 90.0, 0.0)])
+    top = desurvey.tangential_desurvey(_collar(), survey, step=5.0)
+    mid = desurvey.midpoint_tangential_desurvey(_collar(), survey, step=5.0)
+    # Top-of-segment tangential runs the whole 50 m vertically.
+    assert top.iloc[-1]["elevation"] == pytest.approx(250.0)
+    assert mid.iloc[-1]["elevation"] == pytest.approx(275.0)
+
+
+def test_midpoint_tangential_three_stations_last_orientation_runs_to_end():
+    survey = _survey([(0.0, 0.0, -90.0), (20.0, 0.0, -90.0), (40.0, 0.0, 0.0)])
+    traces = desurvey.midpoint_tangential_desurvey(_collar(), survey, step=10.0)
+    # Vertical from 0 to 30 (midpoint of 20/40), then horizontal north to 40.
+    at_30 = traces[(traces["md"] - 30.0).abs() < 1e-9].iloc[0]
+    assert at_30["elevation"] == pytest.approx(270.0)
+    assert at_30["northing"] == pytest.approx(2000.0)
+    toe = traces.iloc[-1]
+    assert toe["elevation"] == pytest.approx(270.0)
+    assert toe["northing"] == pytest.approx(2010.0)
+
+
+def test_midpoint_tangential_matches_other_methods_on_straight_hole():
+    survey = _survey([(0.0, 45.0, -60.0), (50.0, 45.0, -60.0), (100.0, 45.0, -60.0)])
+    reference = desurvey.minimum_curvature_desurvey(_collar(), survey, step=10.0)
+    mid = desurvey.midpoint_tangential_desurvey(_collar(), survey, step=10.0)
+    # Stop short of the toe: md accumulates by repeated addition, so 100.0
+    # can land a hair outside the trace range and interpolate to NaN.
+    depths = [0.0, 25.0, 50.0, 75.0, 99.0]
+    reference_at = desurvey.interpolate_trajectory(reference, depths)
+    mid_at = desurvey.interpolate_trajectory(mid, depths)
+    for axis in ("easting", "northing", "elevation"):
+        assert reference_at[axis].to_numpy() == pytest.approx(mid_at[axis].to_numpy(), abs=1e-9)
+
+
+def test_drillhole_set_exposes_midpoint_tangential():
+    holes = baselode.drill.drillhole_set.DrillholeSet(
+        _collar(), _survey([(0.0, 0.0, -90.0), (50.0, 90.0, 0.0)]),
+    )
+    traces = holes.desurvey(method="midpoint_tangential", step=5.0)
+    assert traces.iloc[-1]["elevation"] == pytest.approx(275.0)

--- a/test/test_drill_validate_surveys.py
+++ b/test/test_drill_validate_surveys.py
@@ -244,3 +244,58 @@ def test_fix_overlaps_without_precedence_leaves_campaign_conflicts():
     fixed, conflicts, _ = validate.fix_overlaps(table, return_diagnostics=True)
     assert len(fixed) == 2
     assert len(conflicts) == 2
+
+
+# ------------------------------------------------- codex review follow-ups
+
+def test_infinite_survey_orientation_is_flagged_and_unusable():
+    collar = _collar([("A", 0.0, 0.0, 0.0, 100.0)])
+    survey = _survey([("A", 0.0, float("inf"), -90.0)])
+    report = validate.validate_drillhole_db(collar, survey)
+    assert len(_checks_with(report, "survey_null_orientation")) == 1
+    assert len(_checks_with(report, "survey_no_usable_stations")) == 1
+
+
+def test_synthesise_collar_station_treats_infinite_collar_orientation_as_missing():
+    collar = _collar(
+        [("B", 0.0, 0.0, 0.0, 80.0, float("inf"), -55.0)],
+        columns=("hole_id", "easting", "northing", "elevation", "max_depth", "azimuth", "dip"),
+    )
+    out, report = validate.synthesise_collar_station(_survey([]), collar, return_diagnostics=True)
+    assert report["vertical_fallback_holes"] == ["B"]
+    assert out.iloc[0][["azimuth", "dip"]].tolist() == [0.0, -90.0]
+    assert not desurvey.build_traces(collar, out).empty
+
+
+def test_fix_single_station_surveys_honours_custom_orientation_columns():
+    collar = _collar([("A", 0.0, 0.0, 0.0, 100.0)])
+    survey = pd.DataFrame(
+        [("A", 0.0, 10.0, -60.0)], columns=["hole_id", "depth", "bearing", "inclination"],
+    )
+    out = validate.fix_single_station_surveys(
+        survey, collar, azimuth_col="bearing", dip_col="inclination",
+    )
+    assert out["depth"].tolist() == [0.0, 100.0]
+    assert out["bearing"].tolist() == [10.0, 10.0]
+
+
+def test_fix_overlaps_precedence_beats_duplicate_and_superset_passes():
+    # Identical rows from two datasets, lower-ranked first: the duplicate
+    # pass alone would keep the first (lower-ranked) row.
+    table = _assays([
+        ("A", 0.0, 1.0, 1.0, "low"),
+        ("A", 0.0, 1.0, 1.0, "high"),
+        # Preferred coarse row with lower-ranked finer rows that would
+        # otherwise qualify it as a resampled superset.
+        ("A", 2.0, 4.0, 2.0, "high"),
+        ("A", 2.0, 3.0, 2.0, "low"),
+        ("A", 3.0, 4.0, 2.0, "low"),
+    ])
+    fixed, conflicts, report = validate.fix_overlaps(
+        table, value_cols=["au_ppm"], precedence_col="project_id",
+        precedence=["high", "low"], return_diagnostics=True,
+    )
+    assert conflicts.empty
+    assert fixed["project_id"].tolist() == ["high", "high"]
+    assert fixed[["from", "to"]].values.tolist() == [[0.0, 1.0], [2.0, 4.0]]
+    assert report["kind"].tolist() == ["precedence"] * 3

--- a/test/test_drill_validate_surveys.py
+++ b/test/test_drill_validate_surveys.py
@@ -1,0 +1,246 @@
+# Copyright (C) 2026 Darkmine Pty Ltd
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Survey-usability checks and fixes (GitHub issue #96 items 3, 4 and 7).
+
+Desurvey silently ignores survey rows with a null depth / azimuth / dip and
+drops holes left without a usable station.  These tests pin the validator
+checks that surface that, the fix helpers that repair it, and the
+dataset-precedence rule on the overlap resolver.
+"""
+
+import pandas as pd
+
+import baselode.drill.desurvey as desurvey
+import baselode.drill.validate as validate
+
+
+def _collar(rows, columns=("hole_id", "easting", "northing", "elevation", "max_depth")):
+    return pd.DataFrame(rows, columns=list(columns))
+
+
+def _survey(rows):
+    return pd.DataFrame(rows, columns=["hole_id", "depth", "azimuth", "dip"])
+
+
+def _checks_with(report, name):
+    return [issue for issue in report["issues"] if issue["check"] == name]
+
+
+# --------------------------------------------------------------- validation
+
+def test_null_azimuth_or_dip_row_is_an_error_with_fix_recipe():
+    collar = _collar([("A", 0.0, 0.0, 0.0, 100.0)])
+    survey = _survey([
+        ("A", 0.0, 0.0, -90.0),
+        ("A", 50.0, None, -90.0),
+        ("A", 100.0, 0.0, None),
+    ])
+    report = validate.validate_drillhole_db(collar, survey)
+    issues = _checks_with(report, "survey_null_orientation")
+    assert [issue["row_index"] for issue in issues] == [1, 2]
+    assert {issue["severity"] for issue in issues} == {"error"}
+    assert "azimuth" in issues[0]["message"]
+    assert "dip" in issues[1]["message"]
+    assert "drop_unusable_survey_rows" in issues[0]["fix"]
+    assert "synthesise_collar_station" in issues[0]["fix"]
+    # The hole still has a usable station, so it is not reported as unusable.
+    assert _checks_with(report, "survey_no_usable_stations") == []
+
+
+def test_non_numeric_depth_is_flagged_too():
+    collar = _collar([("A", 0.0, 0.0, 0.0, 100.0)])
+    survey = _survey([("A", "n/a", 0.0, -90.0), ("A", 10.0, 0.0, -90.0)])
+    report = validate.validate_drillhole_db(collar, survey)
+    issues = _checks_with(report, "survey_null_orientation")
+    assert len(issues) == 1
+    assert "depth" in issues[0]["message"]
+
+
+def test_hole_whose_only_rows_are_unusable_gets_a_warning():
+    collar = _collar([("A", 0.0, 0.0, 0.0, 100.0), ("B", 0.0, 0.0, 0.0, 100.0)])
+    survey = _survey([
+        ("A", 0.0, 0.0, -90.0), ("A", 50.0, 0.0, -90.0),
+        ("B", 0.0, None, None),
+    ])
+    report = validate.validate_drillhole_db(collar, survey)
+    warnings = _checks_with(report, "survey_no_usable_stations")
+    assert len(warnings) == 1
+    assert warnings[0]["hole_id"] == "B"
+    assert warnings[0]["severity"] == "warning"
+    assert "1 survey row(s)" in warnings[0]["message"]
+    assert "synthesise_collar_station" in warnings[0]["fix"]
+    # Matches what desurvey actually does with this input.
+    assert set(desurvey.build_traces(collar, survey)["hole_id"]) == {"A"}
+
+
+def test_collar_hole_with_no_survey_rows_gets_a_warning():
+    collar = _collar([("A", 0.0, 0.0, 0.0, 100.0), ("C", 0.0, 0.0, 0.0, 100.0)])
+    survey = _survey([("A", 0.0, 0.0, -90.0), ("A", 50.0, 0.0, -90.0)])
+    report = validate.validate_drillhole_db(collar, survey)
+    warnings = _checks_with(report, "survey_no_usable_stations")
+    assert [w["hole_id"] for w in warnings] == ["C"]
+    assert "no survey rows" in warnings[0]["message"]
+
+
+def test_no_usable_station_check_skipped_when_survey_table_is_empty():
+    collar = _collar([("A", 0.0, 0.0, 0.0, 100.0)])
+    survey = _survey([])
+    report = validate.validate_drillhole_db(collar, survey)
+    assert _checks_with(report, "survey_no_usable_stations") == []
+
+
+def test_single_station_check_counts_only_usable_rows():
+    collar = _collar([("A", 0.0, 0.0, 0.0, 100.0)])
+    survey = _survey([("A", 0.0, 0.0, -90.0), ("A", 50.0, None, -90.0)])
+    report = validate.validate_drillhole_db(collar, survey)
+    single = _checks_with(report, "single_station_surveys")
+    assert len(single) == 1
+    assert single[0]["row_index"] == 0
+
+
+# ------------------------------------------------------------- fix helpers
+
+def test_drop_unusable_survey_rows_removes_null_and_non_numeric():
+    survey = _survey([
+        ("A", 0.0, 0.0, -90.0),
+        ("A", 50.0, None, -90.0),
+        ("A", "bad", 0.0, -90.0),
+        ("B", 0.0, 10.0, "x"),
+    ])
+    out = validate.drop_unusable_survey_rows(survey)
+    assert len(out) == 1
+    assert out.iloc[0]["hole_id"] == "A"
+    assert list(out.index) == [0]
+    assert len(survey) == 4  # input untouched
+
+
+def test_synthesise_collar_station_uses_collar_orientation():
+    collar = _collar(
+        [("A", 0.0, 0.0, 0.0, 100.0, 45.0, -60.0), ("B", 0.0, 0.0, 0.0, 80.0, 90.0, -70.0)],
+        columns=("hole_id", "easting", "northing", "elevation", "max_depth", "azimuth", "dip"),
+    )
+    survey = _survey([
+        ("A", 0.0, 0.0, -90.0), ("A", 50.0, 0.0, -90.0),
+        ("B", 30.0, None, None),
+    ])
+    out, report = validate.synthesise_collar_station(survey, collar, return_diagnostics=True)
+
+    assert report == {
+        "holes_synthesised": 1,
+        "from_collar": 1,
+        "vertical_fallback": 0,
+        "vertical_fallback_holes": [],
+        "rows_dropped": 1,
+    }
+    b_rows = out[out["hole_id"] == "B"]
+    assert len(b_rows) == 1
+    assert b_rows.iloc[0][["depth", "azimuth", "dip"]].tolist() == [0.0, 90.0, -70.0]
+    # Hole A untouched.
+    assert len(out[out["hole_id"] == "A"]) == 2
+    assert list(out.columns) == ["hole_id", "depth", "azimuth", "dip"]
+
+
+def test_synthesise_collar_station_falls_back_to_vertical_and_reports_it():
+    collar = _collar([("A", 0.0, 0.0, 0.0, 100.0), ("B", 0.0, 0.0, 0.0, 80.0)])
+    survey = _survey([("A", 0.0, 0.0, -90.0), ("A", 50.0, 0.0, -90.0)])
+    out, report = validate.synthesise_collar_station(survey, collar, return_diagnostics=True)
+    assert report["holes_synthesised"] == 1
+    assert report["vertical_fallback"] == 1
+    assert report["vertical_fallback_holes"] == ["B"]
+    b_row = out[out["hole_id"] == "B"].iloc[0]
+    assert (b_row["depth"], b_row["azimuth"], b_row["dip"]) == (0.0, 0.0, -90.0)
+
+
+def test_synthesise_collar_station_matches_collar_columns_case_insensitively():
+    collar = _collar(
+        [("B", 0.0, 0.0, 0.0, 80.0, 120.0, -55.0)],
+        columns=("hole_id", "easting", "northing", "elevation", "max_depth", "Azimuth", "DIP"),
+    )
+    survey = _survey([])
+    out = validate.synthesise_collar_station(survey, collar)
+    assert out.iloc[0][["azimuth", "dip"]].tolist() == [120.0, -55.0]
+
+
+def test_synthesise_collar_station_returns_plain_frame_by_default():
+    collar = _collar([("A", 0.0, 0.0, 0.0, 100.0)])
+    out = validate.synthesise_collar_station(_survey([]), collar)
+    assert isinstance(out, pd.DataFrame)
+    assert len(out) == 1
+
+
+def test_synthesise_then_pad_produces_full_length_trace():
+    """The end-to-end recipe the fix skill applies for a hole with no usable survey."""
+    collar = _collar(
+        [("B", 100.0, 200.0, 50.0, 80.0, 90.0, -60.0)],
+        columns=("hole_id", "easting", "northing", "elevation", "max_depth", "azimuth", "dip"),
+    )
+    survey = _survey([("B", 40.0, None, None)])
+    assert desurvey.build_traces(collar, survey).empty
+
+    fixed = validate.synthesise_collar_station(survey, collar)
+    fixed = validate.fix_single_station_surveys(fixed, collar)
+    assert fixed["depth"].tolist() == [0.0, 80.0]
+    traces = desurvey.build_traces(collar, fixed)
+    assert traces["md"].iloc[-1] == 80.0
+    assert validate.validate_drillhole_db(collar, fixed)["summary"] == {"error": 0, "warning": 0, "info": 0}
+
+
+def test_fix_single_station_surveys_ignores_unusable_rows_when_counting():
+    collar = _collar([("A", 0.0, 0.0, 0.0, 100.0)])
+    survey = _survey([("A", 0.0, 0.0, -90.0), ("A", 50.0, None, -90.0)])
+    out = validate.fix_single_station_surveys(survey, collar)
+    assert out["depth"].tolist() == [0.0, 50.0, 100.0]
+
+
+# ------------------------------------------------------- overlap precedence
+
+def _assays(rows):
+    return pd.DataFrame(rows, columns=["hole_id", "from", "to", "au_ppm", "project_id"])
+
+
+def test_fix_overlaps_precedence_drops_lower_ranked_dataset_where_it_overlaps():
+    table = _assays([
+        ("A", 0.0, 1.0, 1.0, "campaign_1m"),
+        ("A", 1.0, 2.0, 2.0, "campaign_1m"),
+        ("A", 2.0, 3.0, 3.0, "campaign_1m"),      # no 0.5 m coverage: kept
+        ("A", 0.0, 0.5, 0.9, "campaign_0.5m"),
+        ("A", 0.5, 1.0, 5.0, "campaign_0.5m"),    # mean 2.95 vs 1.0: not a superset match
+        ("A", 1.0, 1.5, 2.1, "campaign_0.5m"),
+        ("A", 1.5, 2.0, 7.0, "campaign_0.5m"),
+    ])
+    fixed, conflicts, report = validate.fix_overlaps(
+        table,
+        precedence_col="project_id",
+        precedence=["campaign_0.5m", "campaign_1m"],
+        return_diagnostics=True,
+    )
+    assert conflicts.empty
+    assert fixed["project_id"].tolist() == ["campaign_1m"] + ["campaign_0.5m"] * 4
+    assert fixed[fixed["project_id"] == "campaign_1m"]["from"].tolist() == [2.0]
+    dropped = report[report["kind"] == "precedence"]
+    assert len(dropped) == 2
+    assert dropped["action"].eq("dropped").all()
+    assert "project_id=campaign_1m yields to campaign_0.5m" in dropped["note"].iloc[0]
+
+
+def test_fix_overlaps_precedence_ignores_unlisted_datasets():
+    table = _assays([
+        ("A", 0.0, 1.0, 1.0, "campaign_1m"),
+        ("A", 0.0, 0.5, 9.0, "other"),
+    ])
+    fixed, conflicts, _ = validate.fix_overlaps(
+        table, precedence_col="project_id", precedence=["campaign_1m"], return_diagnostics=True,
+    )
+    assert len(fixed) == 2
+    assert len(conflicts) == 2
+
+
+def test_fix_overlaps_without_precedence_leaves_campaign_conflicts():
+    table = _assays([
+        ("A", 0.0, 1.0, 1.0, "campaign_1m"),
+        ("A", 0.0, 0.5, 9.0, "campaign_0.5m"),
+    ])
+    fixed, conflicts, _ = validate.fix_overlaps(table, return_diagnostics=True)
+    assert len(fixed) == 2
+    assert len(conflicts) == 2


### PR DESCRIPTION
Closes #96 (baselode half; the skills half is in darkmine-oss/darkmine-data-skills).

## Desurvey
- **Traces start at the collar.** When a hole's first survey station is below md 0, its orientation is extended straight up to the collar (Vulcan / Surpac convention). A single station at 135 m now yields a full 135 m trace instead of a single point. Mirrored in JS.
- **New `midpoint_tangential` method** (Vulcan's default "Tangent": each station is the midpoint of its straight segment). Python `midpoint_tangential_desurvey`, JS `midpointTangentialDesurvey`, registered on `DrillholeSet` in both, added to the parity contract.

## Validation
- **`survey_null_orientation`** (error, per row): depth / azimuth / dip is null or non-numeric, so desurvey silently ignores the row.
- **`survey_no_usable_stations`** (warning, per hole): the hole will drop out of the desurvey entirely; also covers collar holes with no survey rows. Skipped when the survey table is empty.
- `single_station_surveys` and `fix_single_station_surveys` now count usable rows only.
- **New helpers** `drop_unusable_survey_rows` and `synthesise_collar_station` (collar azimuth/dip matched case-insensitively, vertical fallback with a reported count and hole list). Mirrored in JS.
- **`fix_overlaps` dataset precedence** via `precedence_col` / `precedence`: rows from a lower-ranked dataset are dropped wherever they overlap a higher-ranked one; unlisted datasets stay as conflicts. Audit rows carry `kind="precedence"`.

## Python support
- `requires-python` widened to `>=3.10`; the suite passes on 3.10 and 3.13 locally. CI now runs the Python suite on 3.10 and 3.12. Note: baselode *is* on PyPI (0.1.51); the "no matching distribution" in the issue came from a 3.11 interpreter against the old `>=3.12` pin.
- `load_geophysics` no longer turns a blank `hole_id` into the string `"nan"` on pandas 2.x (pre-existing; surfaced by the new 3.10 job).

## Tests
- `test/test_desurvey_collar_and_midpoint.py`, `test/test_drill_validate_surveys.py`, and new cases in the JS `desurveyMethods` / `validateDrillholeDb` suites.
- 534 Python tests pass on 3.10 and 3.13; 716 JS tests pass; package builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WqXVK4gBuLZS3VV46NNykj
