### PR TITLE
Publish to npm with trusted publishing instead of NPM_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,6 +159,12 @@ jobs:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"
 
+      # Trusted publishing (OIDC) needs npm 11.5.1+, newer than the npm
+      # bundled with Node 20.  The registry trusts this repo + workflow +
+      # environment directly, so no NPM_TOKEN secret is involved.
+      - name: Update npm for trusted publishing
+        run: npm install -g npm@latest
+
       - name: Install dependencies
         working-directory: javascript/packages/baselode
         run: npm ci
@@ -174,5 +180,3 @@ jobs:
       - name: Publish to npm
         working-directory: javascript/packages/baselode
         run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -13,8 +13,9 @@ Merging to `main` triggers the `.github/workflows/release.yml` workflow, which:
 3. Runs the JavaScript test suite (`npm test`).
 4. Builds the Python package and publishes it to PyPI using trusted publishing
    (OIDC — no long-lived token required).
-5. Builds the JavaScript package and publishes it to npm using the `NPM_TOKEN`
-   repository secret.
+5. Builds the JavaScript package and publishes it to npm, also via trusted
+   publishing (OIDC).  The job upgrades npm first because OIDC publishing
+   needs npm 11.5.1+, newer than the npm bundled with Node 20.
 
 Both publish jobs run against a GitHub Actions environment named **`release`**.
 Configure that environment in *Settings → Environments → release* to add any
@@ -24,8 +25,13 @@ Required secrets / configurations:
 
 | Secret / setting | Where | Purpose |
 |---|---|---|
-| `NPM_TOKEN` | Repository secret | Authenticate `npm publish` |
+| npm trusted publisher | npmjs.com → `baselode` → Settings → Trusted Publisher | OIDC publish from Actions.  GitHub Actions publisher with organization `darkmine-oss`, repository `baselode`, workflow `release.yml`, environment `release` |
 | PyPI trusted publisher | PyPI project settings | OIDC publish from Actions |
+
+No npm token is stored anywhere.  If the npm publish job fails with
+`404 Not Found - PUT https://registry.npmjs.org/baselode`, the registry did
+not accept the workflow's identity: check the trusted-publisher entry matches
+the four values above exactly (the environment name is easy to miss).
 
 ### Recommended branch protection
 


### PR DESCRIPTION
The last two releases (0.1.52, 0.1.53) published to PyPI and tagged fine but failed the npm step with `404 Not Found - PUT https://registry.npmjs.org/baselode`, which is npm's response to an invalid or revoked token. The workflow was unchanged since the last successful publish on 16 August.

This switches the npm job to trusted publishing (OIDC), matching how the PyPI job already works:
- upgrade npm in the job (OIDC publishing needs npm 11.5.1+, newer than Node 20's bundled npm);
- drop the `NODE_AUTH_TOKEN` / `NPM_TOKEN` line from `npm publish`;
- document the npmjs.com trusted-publisher settings in `RELEASING.md`.

**Merge only after the trusted publisher is registered on npmjs.com** for package `baselode`: GitHub Actions, organization `darkmine-oss`, repository `baselode`, workflow `release.yml`, environment `release`. Until then the publish step fails the same way it does today.

After merging, the release run for this merge publishes the next patch version to both registries; npm 0.1.52 and 0.1.53 can be back-filled by re-running the failed jobs of those two runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WqXVK4gBuLZS3VV46NNykj
