### PR TITLE
Pin npm 11 for trusted publishing on Node 20

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,10 +160,11 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       # Trusted publishing (OIDC) needs npm 11.5.1+, newer than the npm
-      # bundled with Node 20.  The registry trusts this repo + workflow +
-      # environment directly, so no NPM_TOKEN secret is involved.
+      # bundled with Node 20.  Pin the 11.x line: npm 12 requires Node 22+.
+      # The registry trusts this repo + workflow + environment directly, so
+      # no NPM_TOKEN secret is involved.
       - name: Update npm for trusted publishing
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
 
       - name: Install dependencies
         working-directory: javascript/packages/baselode

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -14,8 +14,9 @@ Merging to `main` triggers the `.github/workflows/release.yml` workflow, which:
 4. Builds the Python package and publishes it to PyPI using trusted publishing
    (OIDC — no long-lived token required).
 5. Builds the JavaScript package and publishes it to npm, also via trusted
-   publishing (OIDC).  The job upgrades npm first because OIDC publishing
-   needs npm 11.5.1+, newer than the npm bundled with Node 20.
+   publishing (OIDC).  The job upgrades to npm 11 first because OIDC
+   publishing needs npm 11.5.1+, newer than the npm bundled with Node 20
+   (npm 12 needs Node 22+, so the 11.x line is pinned).
 
 Both publish jobs run against a GitHub Actions environment named **`release`**.
 Configure that environment in *Settings → Environments → release* to add any


### PR DESCRIPTION
Follow-up to #98: `npm@latest` is npm 12, which requires Node 22+ and failed with EBADENGINE on the Node 20 publish job, so the OIDC publish never ran. Pin `npm@11`, which supports Node 20 and trusted publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WqXVK4gBuLZS3VV46NNykj